### PR TITLE
Continuous Integration with CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,41 @@
+version: 2
+
+# `templates` is not a CircleCI key. I'm just defining shared YAML keys here,
+#  which I will reuse later using YAML references.
+templates:
+  job_defaults: &job_defaults
+    docker:
+      - image: yatharthagarwal/grf:3
+    steps:
+      - checkout
+      - run:
+          name: "Build and test C++ core"
+          command: |
+            mkdir ~/project/core/build && cd ~/project/core/build
+            cmake -DCMAKE_CXX_COMPILER=$COMPILER ..
+            make
+            cd ~/project/core
+            ./build/grf exclude:[characterization]
+            valgrind --leak-check=full --error-exitcode=1 ./build/grf exclude:[characterization]
+      - run:
+          name: "Build and test R package"
+          command: |
+            cd ~/project/r-package
+            cat build_package.R | R --vanilla  # Rscript does not work.
+
+jobs:
+  clang:
+    <<: *job_defaults  # YAML reference to the shared key defined above.
+    environment:
+      COMPILER: clang++-3.7
+  gpp:
+    <<: *job_defaults
+    environment:
+      COMPILER: g++-4.9
+
+workflows:
+  version: 2
+  all:
+    jobs:
+      - clang
+      - gpp


### PR DESCRIPTION
From #283:

> Currently, we use Travis CI for continuous integration, but the free tier only supports one language at a time, so only the C++ tests run, not the R ones.
> 
> As discussed with @jtibshirani, we could move to CircleCI and include both C++ and R tests.

 Confirmed to work on my fork.

Installing dependencies took forever (= 20–30min), so I created a [Docker image](http://hub.docker.com/r/yatharthagarwal/grf) for GRF. Most of the work is actually in [this repo](https://github.com/yatharth/grf-dockerfile), where I build and deploy the Docker image.

@jtibshirani I didn’t delete the `.travis.yml` file yet—feel free to do so after you’ve set up the CircleCI integration!