### PR TITLE
In tree plotting, include the name of the column when describing a variable split.

### DIFF
--- a/r-package/grf/R/plot.R
+++ b/r-package/grf/R/plot.R
@@ -1,9 +1,9 @@
 #' Writes each node information 
 #' If it is a leaf node: show it in different color, show number of samples, show leaf id
 #' If it is a non-leaf node: show its splitting variable and splitting value
-create_dot_body <- function(nodes, index=1) {
+create_dot_body <- function(tree, index=1) {
   
-  node <- nodes[[index]]
+  node <- tree$nodes[[index]]
   
   # Leaf case: print label only
   if (node$is_leaf) {
@@ -13,26 +13,27 @@ create_dot_body <- function(nodes, index=1) {
   }
   
   # Non-leaf case: print label, child edges
-  if(!is.null(node$left_child)){
+  if (!is.null(node$left_child)) {
     edge = paste(index-1, "->", node$left_child-1)
-    if(index ==1 ){
+    if (index == 1){
       edge_info_left <- paste(edge, '[labeldistance=2.5, labelangle=45, headlabel="True"];')
     }
-    else{
+    else {
       edge_info_left <- paste(edge, " ;")
     }
   } 
   else{edge_info_right<-NULL}
   
-  if(!is.null(node$right_child)){
+  if (!is.null(node$right_child)) {
     edge = paste(index-1, "->", node$right_child-1)
-    if(index==1){
+    if (index==1) {
       edge_info_right <- paste(edge, '[labeldistance=2.5, labelangle=-45, headlabel="False"]')
-    }
-    else{
+    } else {
       edge_info_right <- paste(edge, " ;")
     }
-  }else{edge_info_right<-NULL}
+  } else {
+    edge_info_right<-NULL
+  }
   
   node_info <- paste(index-1, '[label="split_variable', node$split_variable, '<=', round(node$split_value,2), '"] ;')
   
@@ -41,11 +42,11 @@ create_dot_body <- function(nodes, index=1) {
                       edge_info_right, sep="\n")
   
   left_child_lines <- ifelse(!is.null(node$left_child),
-                             create_dot_body(nodes, index=node$left_child),
+                             create_dot_body(tree, index=node$left_child),
                              NULL)
   
   right_child_lines <- ifelse(!is.null(node$right_child),
-                              create_dot_body(nodes, index=node$right_child),
+                              create_dot_body(tree, index=node$right_child),
                               NULL)
   
   lines <- paste(this_lines, left_child_lines, right_child_lines, sep="\n")
@@ -56,10 +57,10 @@ create_dot_body <- function(nodes, index=1) {
 #' Export a tree in DOT format.
 #' This function generates a GraphViz representation of the tree,
 #' which is then written into `dot_string`. 
-export_graphviz <- function(nodes){
+export_graphviz <- function(tree){
   header <- "digraph nodes { \n node [shape=box] ;"
   footer <- "}"
-  body <- create_dot_body(nodes)
+  body <- create_dot_body(tree)
   
   dot_string <- paste(header, body, footer, sep="\n")
   
@@ -71,7 +72,7 @@ export_graphviz <- function(nodes){
 #' @param ... Additional arguments (currently ignored).
 #' @export
 plot.grf_tree <- function(x){
-  dot_file <- export_graphviz(nodes=x$nodes)
+  dot_file <- export_graphviz(x)
   DiagrammeR::grViz(dot_file)
 }
 

--- a/r-package/grf/R/plot.R
+++ b/r-package/grf/R/plot.R
@@ -8,7 +8,7 @@ create_dot_body <- function(tree, index=1) {
   # Leaf case: print label only
   if (node$is_leaf) {
     num_samples = length(node$samples)
-    line_label <- paste(index-1, ' [shape=box,style=filled,color=".7 .3 1.0" , label="leaf' , index,' \nsamples = ',num_samples,'"];')
+    line_label <- paste(index-1, ' [shape=box,style=filled,color=".7 .3 1.0" , label="leaf node', ' \nsize = ',num_samples,'"];')
     return(line_label)
   }
   

--- a/r-package/grf/R/plot.R
+++ b/r-package/grf/R/plot.R
@@ -35,7 +35,8 @@ create_dot_body <- function(tree, index=1) {
     edge_info_right<-NULL
   }
   
-  node_info <- paste(index-1, '[label="split_variable', node$split_variable, '<=', round(node$split_value,2), '"] ;')
+  variable_name = tree$columns[node$split_variable]
+  node_info <- paste(index-1, '[label="', variable_name, '<=', round(node$split_value,2), '"] ;')
   
   this_lines <- paste(node_info,
                       edge_info_left,

--- a/r-package/grf/tests/testthat/test_plot.R
+++ b/r-package/grf/tests/testthat/test_plot.R
@@ -5,7 +5,6 @@ test_that("basic quantile forest plotting is successful", {
   X = matrix(2 * runif(n * p) - 1, n, p)
   Y = rnorm(n) * (1 + (X[,i] > 0))
   D = data.frame(X=X, Y=Y)
-  names(D) = c("age", "income", "weight", "height")
   q.forest = quantile_forest(X, Y, quantiles = c(0.1, 0.5, 0.9), num.trees = 50)
   q.tree = get_tree(q.forest, 1)
   capture_output(plot(q.tree))
@@ -17,6 +16,7 @@ test_that("basic regression forest plotting is successful", {
   n = 50
   i = 2
   X = matrix(2 * runif(n * p) - 1, n, p)
+  colnames(X) = c("age", "income", "weight", "height")
   Y = rnorm(n) * (1 + (X[,i] > 0))
   r.forest = regression_forest(X, Y)
   r.tree = get_tree(r.forest, 1)

--- a/r-package/grf/tests/testthat/test_plot.R
+++ b/r-package/grf/tests/testthat/test_plot.R
@@ -5,6 +5,7 @@ test_that("basic quantile forest plotting is successful", {
   X = matrix(2 * runif(n * p) - 1, n, p)
   Y = rnorm(n) * (1 + (X[,i] > 0))
   D = data.frame(X=X, Y=Y)
+  names(D) = c("age", "income", "weight", "height")
   q.forest = quantile_forest(X, Y, quantiles = c(0.1, 0.5, 0.9), num.trees = 50)
   q.tree = get_tree(q.forest, 1)
   capture_output(plot(q.tree))


### PR DESCRIPTION
Addresses part of https://github.com/grf-labs/grf/issues/298.

When the data matrix includes column names, this is how the plot now looks:

<img width="578" alt="screen shot 2018-09-23 at 3 05 21 pm" src="https://user-images.githubusercontent.com/7461306/45933466-428bb900-bf42-11e8-83d5-d9531c30040b.png">
