### PR TITLE
Allow samples per cluster to be larger than smallest cluster size.

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -206,9 +206,9 @@ When clustering is enabled during training, all subsampling procedures operate o
 - For each 'CI group' used in estimating variance, sample half of the clusters. Each CI group is then associated with a list of cluster IDs.
 - Within this half-sample of cluster IDs, sample `sample.fraction` of the clusters. Each tree is now associated with a list of cluster IDs.
 - If honesty is enabled, split these cluster IDs in half, so that one half can be used for growing the tree, and the other half is used in repopulating the leaves.
-- To grow the tree, draw `samples_per_cluster` examples from each of the cluster IDs, and do the same when repopulating the leaves for honesty.
+- To grow the tree, draw `samples_per_cluster` examples from each of the cluster IDs, and do the same when repopulating the leaves for honesty. In the event where `samples_per_cluster` is larger than the size of the cluster, we just select the whole cluster.
 
-Note that when clusters are provided, standard errors from `average_treatment_effect` and `average_partial_effect` estimation are also cluster-robust.
+Note that when clusters are provided, standard errors from `average_treatment_effect` and `average_partial_effect` estimation are also cluster-robust. Moreover, if clusters are specified, then each cluster gets equal weight. For example, if there are 10 clusters with 1 unit each and per-cluster ATE = 1, and there are 10 clusters with 19 units each and per-cluster ATE = 0, then the overall ATE is 0.5 (not 0.05).
 
 ## Troubleshooting
 

--- a/core/src/sampling/RandomSampler.cpp
+++ b/core/src/sampling/RandomSampler.cpp
@@ -101,9 +101,15 @@ void RandomSampler::sample_from_clusters(const std::vector<size_t>& clusters,
     for (size_t cluster : clusters) {
       const std::vector<size_t>& cluster_samples = samples_by_cluster.at(cluster);
 
-      std::vector<size_t> subsamples;
-      subsample_with_size(cluster_samples, options.get_samples_per_cluster(), subsamples);
-      samples.insert(samples.end(), subsamples.begin(), subsamples.end());
+      // Draw samples_per_cluster observations from each cluster. If the cluster is
+      // smaller than the samples_per_cluster parameter, just use the whole cluster.
+      if (cluster_samples.size() <= options.get_samples_per_cluster()) {
+        samples.insert(samples.end(), cluster_samples.begin(), cluster_samples.end());
+      } else {
+        std::vector<size_t> subsamples;
+        subsample_with_size(cluster_samples, options.get_samples_per_cluster(), subsamples);
+        samples.insert(samples.end(), subsamples.begin(), subsamples.end());
+      }
     }
   }
 }

--- a/r-package/grf/R/causal_forest.R
+++ b/r-package/grf/R/causal_forest.R
@@ -44,8 +44,13 @@
 #' @param seed The seed of the C++ random number generator.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
 #' @param samples_per_cluster If sampling by cluster, the number of observations to be sampled from
-#'                            each cluster. Must be less than the size of the smallest cluster. If set to NULL
-#'                            software will set this value to the size of the smallest cluster.#'
+#'                            each cluster when training a tree. If NULL, we set samples_per_cluster to the size
+#'                            of the smallest cluster. If some clusters are smaller than samples_per_cluster,
+#'                            the whole cluster is used every time the cluster is drawn. Note that
+#'                            clusters with less than samples_per_cluster observations get relatively
+#'                            smaller weight than others in training the forest, i.e., the contribution
+#'                            of a given cluster to the final forest scales with the minimum of
+#'                            the number of observations in the cluster and samples_per_cluster.
 #' @param tune.parameters If true, NULL parameters are tuned by cross-validation; if false
 #'                        NULL parameters are set to defaults.
 #' @param num.fit.trees The number of trees in each 'mini forest' used to fit the tuning model.

--- a/r-package/grf/R/custom_forest.R
+++ b/r-package/grf/R/custom_forest.R
@@ -24,8 +24,13 @@
 #' @param seed The seed for the C++ random number generator.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
 #' @param samples_per_cluster If sampling by cluster, the number of observations to be sampled from
-#'                            each cluster. Must be less than the size of the smallest cluster. If set to NULL
-#'                            software will set this value to the size of the smallest cluster.
+#'                            each cluster when training a tree. If NULL, we set samples_per_cluster to the size
+#'                            of the smallest cluster. If some clusters are smaller than samples_per_cluster,
+#'                            the whole cluster is used every time the cluster is drawn. Note that
+#'                            clusters with less than samples_per_cluster observations get relatively
+#'                            smaller weight than others in training the forest, i.e., the contribution
+#'                            of a given cluster to the final forest scales with the minimum of
+#'                            the number of observations in the cluster and samples_per_cluster.
 #'
 #' @return A trained regression forest object.
 #'

--- a/r-package/grf/R/input_utilities.R
+++ b/r-package/grf/R/input_utilities.R
@@ -98,12 +98,10 @@ validate_samples_per_cluster <- function(samples_per_cluster, clusters) {
   }
   cluster_size_counts <- table(clusters)
   min_size <- unname(cluster_size_counts[order(cluster_size_counts)][1])
-  # Check for whether this number is too small?
   if (is.null(samples_per_cluster)) {
     samples_per_cluster <- min_size
-  } else if (samples_per_cluster > min_size) {
-    stop(paste("Smallest cluster has", min_size, "observations",
-         "samples_per_cluster of", samples_per_cluster, "is too large."))
+  } else if (samples_per_cluster <= 0) {
+    stop("samples_per_cluster must be positive")
   }
   samples_per_cluster
 }

--- a/r-package/grf/R/instrumental_forest.R
+++ b/r-package/grf/R/instrumental_forest.R
@@ -47,8 +47,13 @@
 #' @param seed The seed for the C++ random number generator.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
 #' @param samples_per_cluster If sampling by cluster, the number of observations to be sampled from
-#'                            each cluster. Must be less than the size of the smallest cluster. If set to NULL
-#'                            software will set this value to the size of the smallest cluster.
+#'                            each cluster when training a tree. If NULL, we set samples_per_cluster to the size
+#'                            of the smallest cluster. If some clusters are smaller than samples_per_cluster,
+#'                            the whole cluster is used every time the cluster is drawn. Note that
+#'                            clusters with less than samples_per_cluster observations get relatively
+#'                            smaller weight than others in training the forest, i.e., the contribution
+#'                            of a given cluster to the final forest scales with the minimum of
+#'                            the number of observations in the cluster and samples_per_cluster.
 #'
 #' @return A trained instrumental forest object.
 #' @export

--- a/r-package/grf/R/local_linear_forest.R
+++ b/r-package/grf/R/local_linear_forest.R
@@ -26,8 +26,13 @@
 #' @param seed The seed for the C++ random number generator.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
 #' @param samples_per_cluster If sampling by cluster, the number of observations to be sampled from
-#'                            each cluster. Must be less than the size of the smallest cluster. If set to NULL
-#'                            software will set this value to the size of the smallest cluster.
+#'                            each cluster when training a tree. If NULL, we set samples_per_cluster to the size
+#'                            of the smallest cluster. If some clusters are smaller than samples_per_cluster,
+#'                            the whole cluster is used every time the cluster is drawn. Note that
+#'                            clusters with less than samples_per_cluster observations get relatively
+#'                            smaller weight than others in training the forest, i.e., the contribution
+#'                            of a given cluster to the final forest scales with the minimum of
+#'                            the number of observations in the cluster and samples_per_cluster.
 #' @param tune.parameters If true, NULL parameters are tuned by cross-validation; if false
 #'                        NULL parameters are set to defaults.
 #' @param num.fit.trees The number of trees in each 'mini forest' used to fit the tuning model.

--- a/r-package/grf/R/quantile_forest.R
+++ b/r-package/grf/R/quantile_forest.R
@@ -30,8 +30,13 @@
 #' @param seed The seed for the C++ random number generator.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
 #' @param samples_per_cluster If sampling by cluster, the number of observations to be sampled from
-#'                            each cluster. Must be less than the size of the smallest cluster. If set to NULL
-#'                            software will set this value to the size of the smallest cluster.
+#'                            each cluster when training a tree. If NULL, we set samples_per_cluster to the size
+#'                            of the smallest cluster. If some clusters are smaller than samples_per_cluster,
+#'                            the whole cluster is used every time the cluster is drawn. Note that
+#'                            clusters with less than samples_per_cluster observations get relatively
+#'                            smaller weight than others in training the forest, i.e., the contribution
+#'                            of a given cluster to the final forest scales with the minimum of
+#'                            the number of observations in the cluster and samples_per_cluster.
 #'
 #' @return A trained quantile forest object.
 #'

--- a/r-package/grf/R/regression_forest.R
+++ b/r-package/grf/R/regression_forest.R
@@ -29,8 +29,13 @@
 #' @param seed The seed for the C++ random number generator.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
 #' @param samples_per_cluster If sampling by cluster, the number of observations to be sampled from
-#'                            each cluster. Must be less than the size of the smallest cluster. If set to NULL
-#'                            software will set this value to the size of the smallest cluster.
+#'                            each cluster when training a tree. If NULL, we set samples_per_cluster to the size
+#'                            of the smallest cluster. If some clusters are smaller than samples_per_cluster,
+#'                            the whole cluster is used every time the cluster is drawn. Note that
+#'                            clusters with less than samples_per_cluster observations get relatively
+#'                            smaller weight than others in training the forest, i.e., the contribution
+#'                            of a given cluster to the final forest scales with the minimum of
+#'                            the number of observations in the cluster and samples_per_cluster.
 #' @param tune.parameters If true, NULL parameters are tuned by cross-validation; if false
 #'                        NULL parameters are set to defaults.
 #' @param num.fit.trees The number of trees in each 'mini forest' used to fit the tuning model.

--- a/r-package/grf/tests/testthat/test_average_effect.R
+++ b/r-package/grf/tests/testthat/test_average_effect.R
@@ -222,7 +222,9 @@ test_that("cluster robust average effects are consistent", {
   clust = c(1:n, 1:n, 1:n, 1:n)
 
   forest.causal = causal_forest(X, Y, W, num.trees = 1000, ci.group.size = 4)
-  forest.causal.clust = causal_forest(Xc, Yc, Wc, num.trees = 1000, ci.group.size = 4, clusters = clust)
+  forest.causal.clust = causal_forest(Xc, Yc, Wc, num.trees = 1000,
+                                      ci.group.size = 4, clusters = clust,
+                                      samples_per_cluster = 7)
 
   cate.aipw = average_treatment_effect(forest.causal, target.sample = "all", method = "AIPW")
   cate.clust.aipw = average_treatment_effect(forest.causal.clust, target.sample = "all", method = "AIPW")


### PR DESCRIPTION
If some clusters are smaller than `samples_per_cluster`, the whole cluster is used every time the cluster is drawn. Note that clusters with less than `samples_per_cluster` observations get relatively smaller weight than others in training the forest, i.e., the contribution of a given cluster to the final forest scales with the minimum of the number of observations in the cluster and `samples_per_cluster`.