### PR TITLE
Disable roxygen comments processing for unavailable methods

### DIFF
--- a/r-package/grf/R/plot.R
+++ b/r-package/grf/R/plot.R
@@ -1,8 +1,9 @@
-# Writes each node information 
-# If it is a leaf node: show it in different color, show number of samples, show leaf id
-# If it is a non-leaf node: show its splitting variable and splitting value
-# @param tree the tree to convert
-# @param index the index of the current node
+#' Writes each node information 
+#' If it is a leaf node: show it in different color, show number of samples, show leaf id
+#' If it is a non-leaf node: show its splitting variable and splitting value
+#' @param tree the tree to convert
+#' @param index the index of the current node
+#' @keyword internal
 create_dot_body <- function(tree, index=1) {
   
   node <- tree$nodes[[index]]
@@ -57,10 +58,11 @@ create_dot_body <- function(tree, index=1) {
   return(lines)
 }
 
-# Export a tree in DOT format.
-# This function generates a GraphViz representation of the tree,
-# which is then written into `dot_string`. 
-# @param tree the tree to convert
+#' Export a tree in DOT format.
+#' This function generates a GraphViz representation of the tree,
+#' which is then written into `dot_string`. 
+#' @param tree the tree to convert
+#' @keyword internal
 export_graphviz <- function(tree){
   header <- "digraph nodes { \n node [shape=box] ;"
   footer <- "}"

--- a/r-package/grf/R/plot.R
+++ b/r-package/grf/R/plot.R
@@ -1,8 +1,8 @@
-#' Writes each node information 
-#' If it is a leaf node: show it in different color, show number of samples, show leaf id
-#' If it is a non-leaf node: show its splitting variable and splitting value
-#' @param tree the tree to convert
-#' @param index the index of the current node
+# Writes each node information 
+# If it is a leaf node: show it in different color, show number of samples, show leaf id
+# If it is a non-leaf node: show its splitting variable and splitting value
+# @param tree the tree to convert
+# @param index the index of the current node
 create_dot_body <- function(tree, index=1) {
   
   node <- tree$nodes[[index]]
@@ -57,10 +57,10 @@ create_dot_body <- function(tree, index=1) {
   return(lines)
 }
 
-#' Export a tree in DOT format.
-#' This function generates a GraphViz representation of the tree,
-#' which is then written into `dot_string`. 
-#' @param tree the tree to convert
+# Export a tree in DOT format.
+# This function generates a GraphViz representation of the tree,
+# which is then written into `dot_string`. 
+# @param tree the tree to convert
 export_graphviz <- function(tree){
   header <- "digraph nodes { \n node [shape=box] ;"
   footer <- "}"


### PR DESCRIPTION
I had been, unfortunately, looking at outdated sample code for grf which included a use of "create_dot_body" which has been moved into a sub-method for plot.grf_tree since. As "create_dot_body" was listed in the 00index.html, I was under the assumption it should be available as a method even though it was not. Maybe this commit will help prevent confusion of that kind while still maintaining the commentary for development purposed. Would this comply with the GRF coding/documentation practices?