### PR TITLE
Clean up the confidence interval framework.

### DIFF
--- a/core/src/forest/Forest.h
+++ b/core/src/forest/Forest.h
@@ -20,25 +20,31 @@
 
 #include <memory>
 
-#include "tree/TreeTrainer.h"
-#include "commons/globals.h"
-#include "tree/Tree.h"
 #include "commons/DefaultData.h"
+#include "commons/globals.h"
 #include "commons/Observations.h"
+#include "forest/ForestOptions.h"
+#include "tree/TreeTrainer.h"
+#include "tree/Tree.h"
+
 
 class Forest {
 public:
   static Forest create(std::vector<std::shared_ptr<Tree>> trees,
+                       const ForestOptions& forest_options,
                        Data* data,
                        std::unordered_map<size_t, size_t> observables);
 
   Forest(const std::vector<std::shared_ptr<Tree>>& trees,
          const Observations& observations,
-         size_t num_variables);
+         size_t num_variables,
+         size_t ci_group_size);
 
   const Observations& get_observations() const;
   const std::vector<std::shared_ptr<Tree>>& get_trees() const;
+
   const size_t get_num_variables() const;
+  const size_t get_ci_group_size() const;
 
   static Forest merge(const std::vector<std::shared_ptr<Forest>>& forests);
   
@@ -46,6 +52,7 @@ private:
   std::vector<std::shared_ptr<Tree>> trees;
   Observations observations;
   size_t num_variables;
+  size_t ci_group_size;
 };
 
 #endif /* GRF_FOREST_H_ */

--- a/core/src/forest/ForestOptions.cpp
+++ b/core/src/forest/ForestOptions.cpp
@@ -20,7 +20,7 @@
 #include "tree/TreeOptions.h"
 
 ForestOptions::ForestOptions(uint num_trees,
-                             uint ci_group_size,
+                             size_t ci_group_size,
                              double sample_fraction,
                              uint mtry,
                              uint min_node_size,
@@ -60,7 +60,7 @@ uint ForestOptions::get_num_trees() const {
   return num_trees;
 }
 
-uint ForestOptions::get_ci_group_size() const {
+size_t ForestOptions::get_ci_group_size() const {
   return ci_group_size;
 }
 

--- a/core/src/forest/ForestOptions.h
+++ b/core/src/forest/ForestOptions.h
@@ -27,7 +27,7 @@
 class ForestOptions {
 public:
   ForestOptions(uint num_trees,
-                uint ci_group_size,
+                size_t ci_group_size,
                 double sample_fraction,
                 uint mtry,
                 uint min_node_size,
@@ -43,7 +43,7 @@ public:
   static uint validate_num_threads(uint num_threads);
 
   uint get_num_trees() const;
-  uint get_ci_group_size() const;
+  size_t get_ci_group_size() const;
   double get_sample_fraction() const;
 
   const TreeOptions& get_tree_options() const;
@@ -54,7 +54,7 @@ public:
 
 private:
   uint num_trees;
-  uint ci_group_size;
+  size_t ci_group_size;
   double sample_fraction;
 
   TreeOptions tree_options;

--- a/core/src/forest/ForestPredictor.cpp
+++ b/core/src/forest/ForestPredictor.cpp
@@ -21,35 +21,44 @@
 #include "commons/utility.h"
 
 ForestPredictor::ForestPredictor(uint num_threads,
-                                 uint ci_group_size,
                                  std::shared_ptr<DefaultPredictionStrategy> strategy) :
     tree_traverser(num_threads) {
   this->prediction_collector = std::shared_ptr<PredictionCollector>(
-        new DefaultPredictionCollector(strategy, ci_group_size));
+        new DefaultPredictionCollector(strategy));
 }
 
 ForestPredictor::ForestPredictor(uint num_threads,
-                                 uint ci_group_size,
                                  std::shared_ptr<OptimizedPredictionStrategy> strategy) :
     tree_traverser(num_threads) {
   this->prediction_collector = std::shared_ptr<PredictionCollector>(
-      new OptimizedPredictionCollector(strategy, ci_group_size));
-}
-
-std::vector<Prediction> ForestPredictor::predict(const Forest& forest, Data* data) const {
-  return predict(forest, data, false);
-}
-
-std::vector<Prediction> ForestPredictor::predict_oob(const Forest& forest, Data* data) const {
-  return predict(forest, data, true);
+      new OptimizedPredictionCollector(strategy));
 }
 
 std::vector<Prediction> ForestPredictor::predict(const Forest& forest,
                                                  Data* data,
+                                                 bool estimate_variance) const {
+  return predict(forest, data, estimate_variance, false);
+}
+
+std::vector<Prediction> ForestPredictor::predict_oob(const Forest& forest,
+                                                     Data* data,
+                                                     bool estimate_variance) const {
+  return predict(forest, data, estimate_variance, true);
+}
+
+std::vector<Prediction> ForestPredictor::predict(const Forest& forest,
+                                                 Data* data,
+                                                 bool estimate_variance,
                                                  bool oob_prediction) const {
+  if (estimate_variance && forest.get_ci_group_size() <= 1) {
+    throw std::runtime_error("To estimate variance during prediction, the forest must"
+       " be trained with ci_group_size greater than 1.");
+  }
+
   std::vector<std::vector<size_t>> leaf_nodes_by_tree = tree_traverser.get_leaf_nodes(forest, data, oob_prediction);
   std::vector<std::vector<bool>> trees_by_sample = tree_traverser.get_valid_trees_by_sample(forest, data, oob_prediction);
 
-  return prediction_collector->collect_predictions(
-      forest, data, leaf_nodes_by_tree, trees_by_sample, oob_prediction);
+  return prediction_collector->collect_predictions(forest, data,
+      leaf_nodes_by_tree, trees_by_sample,
+      estimate_variance, oob_prediction);
 }

--- a/core/src/forest/ForestPredictor.h
+++ b/core/src/forest/ForestPredictor.h
@@ -38,19 +38,22 @@
 class ForestPredictor {
 public:
   ForestPredictor(uint num_threads,
-                  uint ci_group_size,
                   std::shared_ptr<DefaultPredictionStrategy> strategy);
 
   ForestPredictor(uint num_threads,
-                  uint ci_group_size,
                   std::shared_ptr<OptimizedPredictionStrategy> strategy);
 
-  std::vector<Prediction> predict(const Forest& forest, Data* prediction_data) const;
-  std::vector<Prediction> predict_oob(const Forest& forest, Data* original_data) const;
+  std::vector<Prediction> predict(const Forest& forest,
+                                  Data* prediction_data,
+                                  bool estimate_variance) const;
+  std::vector<Prediction> predict_oob(const Forest& forest,
+                                      Data* original_data,
+                                      bool estimate_variance) const;
 
 private:
   std::vector<Prediction> predict(const Forest& forest,
                                   Data* data,
+                                  bool estimate_variance,
                                   bool oob_prediction) const;
 
 private:

--- a/core/src/forest/ForestPredictors.cpp
+++ b/core/src/forest/ForestPredictors.cpp
@@ -26,32 +26,29 @@
 ForestPredictor ForestPredictors::custom_predictor(uint num_threads) {
   num_threads = ForestOptions::validate_num_threads(num_threads);
   std::shared_ptr<DefaultPredictionStrategy> prediction_strategy(new CustomPredictionStrategy());
-  return ForestPredictor(num_threads, 1.0, prediction_strategy);
+  return ForestPredictor(num_threads, prediction_strategy);
 }
 
-ForestPredictor ForestPredictors::instrumental_predictor(uint num_threads,
-                                                         uint ci_group_size) {
+ForestPredictor ForestPredictors::instrumental_predictor(uint num_threads) {
   num_threads = ForestOptions::validate_num_threads(num_threads);
   std::shared_ptr<OptimizedPredictionStrategy> prediction_strategy(new InstrumentalPredictionStrategy());
-  return ForestPredictor(num_threads, ci_group_size, prediction_strategy);
+  return ForestPredictor(num_threads, prediction_strategy);
 }
 
 ForestPredictor ForestPredictors::quantile_predictor(uint num_threads,
                                                      const std::vector<double>& quantiles) {
   num_threads = ForestOptions::validate_num_threads(num_threads);
   std::shared_ptr<DefaultPredictionStrategy> prediction_strategy(new QuantilePredictionStrategy(quantiles));
-  return ForestPredictor(num_threads, 1.0, prediction_strategy);
+  return ForestPredictor(num_threads, prediction_strategy);
 }
 
-ForestPredictor ForestPredictors::regression_predictor(uint num_threads,
-                                                       uint ci_group_size) {
+ForestPredictor ForestPredictors::regression_predictor(uint num_threads) {
   num_threads = ForestOptions::validate_num_threads(num_threads);
   std::shared_ptr<OptimizedPredictionStrategy> prediction_strategy(new RegressionPredictionStrategy());
-  return ForestPredictor(num_threads, ci_group_size, prediction_strategy);
+  return ForestPredictor(num_threads, prediction_strategy);
 }
 
 ForestPredictor ForestPredictors::local_linear_predictor(uint num_threads,
-                                                         uint ci_group_size,
                                                          const Data* original_data,
                                                          const Data* test_data,
                                                          std::vector<double> lambdas,
@@ -63,5 +60,5 @@ ForestPredictor ForestPredictors::local_linear_predictor(uint num_threads,
                                                                                                    lambdas,
                                                                                                    weighted_penalty,
                                                                                                    linear_correction_variables));
-  return ForestPredictor(num_threads, ci_group_size, prediction_strategy);
+  return ForestPredictor(num_threads, prediction_strategy);
 }

--- a/core/src/forest/ForestPredictors.h
+++ b/core/src/forest/ForestPredictors.h
@@ -24,17 +24,14 @@ class ForestPredictors {
 public:
   static ForestPredictor custom_predictor(uint num_threads);
 
-  static ForestPredictor instrumental_predictor(uint num_threads,
-                                                uint ci_group_size);
+  static ForestPredictor instrumental_predictor(uint num_threads);
 
   static ForestPredictor quantile_predictor(uint num_threads,
                                             const std::vector<double>& quantiles);
 
-  static ForestPredictor regression_predictor(uint num_threads,
-                                              uint ci_group_size);
+  static ForestPredictor regression_predictor(uint num_threads);
 
   static ForestPredictor local_linear_predictor(uint num_threads,
-                                                uint ci_group_size,
                                                 const Data* original_data,
                                                 const Data* test_data,
                                                 std::vector<double> lambdas,

--- a/core/src/forest/ForestTrainer.cpp
+++ b/core/src/forest/ForestTrainer.cpp
@@ -50,8 +50,6 @@ const Forest ForestTrainer::train(Data* data,
     throw std::runtime_error("The honesty fraction is too close to 1 or 0, as no observations will be sampled.");
   }
 
-
-
   size_t num_types = observables.size();
   std::vector<std::vector<double>> observations_by_type(num_types);
   for (auto it : observables) {
@@ -95,7 +93,7 @@ const Forest ForestTrainer::train(Data* data,
     trees.insert(trees.end(), thread_trees.begin(), thread_trees.end());
   }
 
-  return Forest::create(trees, data, observables);
+  return Forest::create(trees, options, data, observables);
 }
 
 std::vector<std::shared_ptr<Tree>> ForestTrainer::train_batch(
@@ -104,7 +102,7 @@ std::vector<std::shared_ptr<Tree>> ForestTrainer::train_batch(
     Data* data,
     const Observations& observations,
     const ForestOptions& options) const {
-  uint ci_group_size = options.get_ci_group_size();
+  size_t ci_group_size = options.get_ci_group_size();
 
   std::mt19937_64 random_number_generator(options.get_random_seed() + start);
   std::uniform_int_distribution<uint> udist;

--- a/core/src/prediction/CustomPredictionStrategy.cpp
+++ b/core/src/prediction/CustomPredictionStrategy.cpp
@@ -34,6 +34,6 @@ std::vector<double> CustomPredictionStrategy::compute_variance(
     std::vector<std::vector<size_t>> samples_by_tree,
     std::unordered_map<size_t, double> weights_by_sampleID,
     const Observations& observations,
-    uint ci_group_size){
+    size_t ci_group_size){
   return { 0.0 };
 }

--- a/core/src/prediction/CustomPredictionStrategy.h
+++ b/core/src/prediction/CustomPredictionStrategy.h
@@ -37,7 +37,7 @@ public:
       std::vector<std::vector<size_t>> samples_by_tree,
       std::unordered_map<size_t, double> weights_by_sampleID,
       const Observations& observations,
-      uint ci_group_size);
+      size_t ci_group_size);
 };
 
 

--- a/core/src/prediction/DefaultPredictionStrategy.h
+++ b/core/src/prediction/DefaultPredictionStrategy.h
@@ -73,7 +73,7 @@ public:
       std::vector<std::vector<size_t>> samples_by_tree,
       std::unordered_map<size_t, double> weights_by_sampleID,
       const Observations& observations,
-      uint ci_group_size) = 0;
+      size_t ci_group_size) = 0;
 };
 
 #endif //GRF_PREDICTIONSTRATEGY_H

--- a/core/src/prediction/InstrumentalPredictionStrategy.cpp
+++ b/core/src/prediction/InstrumentalPredictionStrategy.cpp
@@ -46,7 +46,7 @@ std::vector<double> InstrumentalPredictionStrategy::predict(const std::vector<do
 std::vector<double> InstrumentalPredictionStrategy::compute_variance(
     const std::vector<double>& average,
     const PredictionValues& leaf_values,
-    uint ci_group_size) {
+    size_t ci_group_size) {
 
   double instrument_effect_numerator = average.at(OUTCOME_INSTRUMENT)
      - average.at(OUTCOME) * average.at(INSTRUMENT);

--- a/core/src/prediction/InstrumentalPredictionStrategy.h
+++ b/core/src/prediction/InstrumentalPredictionStrategy.h
@@ -45,7 +45,7 @@ public:
 
   std::vector<double> compute_variance(const std::vector<double>& average,
                           const PredictionValues& leaf_values,
-                          uint ci_group_size);
+                          size_t ci_group_size);
 
   std::vector<double> compute_debiased_error(
       size_t sample,

--- a/core/src/prediction/LocalLinearPredictionStrategy.cpp
+++ b/core/src/prediction/LocalLinearPredictionStrategy.cpp
@@ -112,7 +112,7 @@ std::vector<double> LocalLinearPredictionStrategy::compute_variance(
     std::vector<std::vector<size_t>> samples_by_tree,
     std::unordered_map<size_t, double> weights_by_sampleID,
     const Observations& observations,
-    uint ci_group_size) {
+    size_t ci_group_size) {
 
   double lambda = lambdas[0];
 

--- a/core/src/prediction/LocalLinearPredictionStrategy.h
+++ b/core/src/prediction/LocalLinearPredictionStrategy.h
@@ -54,7 +54,7 @@ public:
         std::vector<std::vector<size_t>> samples_by_tree,
         std::unordered_map<size_t, double> weights_by_sampleID,
         const Observations& observations,
-        uint ci_group_size);
+        size_t ci_group_size);
 
 private:
 

--- a/core/src/prediction/OptimizedPredictionStrategy.h
+++ b/core/src/prediction/OptimizedPredictionStrategy.h
@@ -66,7 +66,7 @@ public:
   virtual std::vector<double> compute_variance(
       const std::vector<double>& average_prediction_values,
       const PredictionValues& leaf_prediction_values,
-      uint ci_group_size) = 0;
+      size_t ci_group_size) = 0;
 
  /**
   * The number of types of precomputed prediction values. For regression

--- a/core/src/prediction/QuantilePredictionStrategy.cpp
+++ b/core/src/prediction/QuantilePredictionStrategy.cpp
@@ -81,6 +81,6 @@ std::vector<double> QuantilePredictionStrategy::compute_variance(
     std::vector<std::vector<size_t>> samples_by_tree,
     std::unordered_map<size_t, double> weights_by_sampleID,
     const Observations& observations,
-    uint ci_group_size){
+    size_t ci_group_size){
   return { 0.0 };
 }

--- a/core/src/prediction/QuantilePredictionStrategy.h
+++ b/core/src/prediction/QuantilePredictionStrategy.h
@@ -41,7 +41,7 @@ public:
       std::vector<std::vector<size_t>> samples_by_tree,
       std::unordered_map<size_t, double> weights_by_sampleID,
       const Observations& observations,
-      uint ci_group_size);
+      size_t ci_group_size);
 
 private:
   std::vector<double> compute_quantile_cutoffs(const std::unordered_map<size_t, double>& weights_by_sample,

--- a/core/src/prediction/RegressionPredictionStrategy.cpp
+++ b/core/src/prediction/RegressionPredictionStrategy.cpp
@@ -32,7 +32,7 @@ std::vector<double> RegressionPredictionStrategy::predict(const std::vector<doub
 std::vector<double> RegressionPredictionStrategy::compute_variance(
     const std::vector<double>& average,
     const PredictionValues& leaf_values,
-    uint ci_group_size) {
+    size_t ci_group_size) {
 
   double average_outcome = average.at(OUTCOME);
 

--- a/core/src/prediction/RegressionPredictionStrategy.h
+++ b/core/src/prediction/RegressionPredictionStrategy.h
@@ -38,7 +38,7 @@ public:
   std::vector<double> compute_variance(
       const std::vector<double>& average,
       const PredictionValues& leaf_values,
-      uint ci_group_size);
+      size_t ci_group_size);
 
   std::vector<double> compute_debiased_error(
       size_t sample,

--- a/core/src/prediction/collector/DefaultPredictionCollector.h
+++ b/core/src/prediction/collector/DefaultPredictionCollector.h
@@ -26,13 +26,13 @@
 
 class DefaultPredictionCollector: public PredictionCollector {
 public:
-  DefaultPredictionCollector(std::shared_ptr<DefaultPredictionStrategy> strategy,
-                              uint ci_group_size);
+  DefaultPredictionCollector(std::shared_ptr<DefaultPredictionStrategy> strategy);
 
   std::vector<Prediction> collect_predictions(const Forest& forest,
                                               Data* prediction_data,
                                               const std::vector<std::vector<size_t>>& leaf_nodes_by_tree,
                                               const std::vector<std::vector<bool>>& valid_trees_by_sample,
+                                              bool estimate_variance,
                                               bool estimate_error);
 
 private:
@@ -40,7 +40,6 @@ private:
 
   std::shared_ptr<DefaultPredictionStrategy> strategy;
   SampleWeightComputer weight_computer;
-  uint ci_group_size;
 };
 
 

--- a/core/src/prediction/collector/OptimizedPredictionCollector.cpp
+++ b/core/src/prediction/collector/OptimizedPredictionCollector.cpp
@@ -17,19 +17,18 @@
 
 #include "prediction/collector/OptimizedPredictionCollector.h"
 
-OptimizedPredictionCollector::OptimizedPredictionCollector(std::shared_ptr<OptimizedPredictionStrategy> strategy,
-                                                           uint ci_group_size):
-    strategy(strategy),
-    ci_group_size(ci_group_size) {}
+OptimizedPredictionCollector::OptimizedPredictionCollector(std::shared_ptr<OptimizedPredictionStrategy> strategy):
+    strategy(strategy) {}
 
 std::vector<Prediction> OptimizedPredictionCollector::collect_predictions(const Forest& forest,
                                                                           Data* prediction_data,
                                                                           const std::vector<std::vector<size_t>>& leaf_nodes_by_tree,
                                                                           const std::vector<std::vector<bool>>& valid_trees_by_sample,
+                                                                          bool estimate_variance,
                                                                           bool estimate_error) {
   size_t num_trees = forest.get_trees().size();
   size_t num_samples = prediction_data->get_num_rows();
-  bool record_leaf_values = ci_group_size > 1 || estimate_error;
+  bool record_leaf_values = estimate_variance || estimate_error;
 
   std::vector<Prediction> predictions;
   predictions.reserve(num_samples);
@@ -75,8 +74,8 @@ std::vector<Prediction> OptimizedPredictionCollector::collect_predictions(const 
     std::vector<double> point_prediction = strategy->predict(average_value);
 
     PredictionValues prediction_values(leaf_values, num_trees, strategy->prediction_value_length());
-    std::vector<double> variance = ci_group_size > 1
-        ? strategy->compute_variance(average_value, prediction_values, ci_group_size)
+    std::vector<double> variance = estimate_variance
+        ? strategy->compute_variance(average_value, prediction_values, forest.get_ci_group_size())
         : std::vector<double>();
 
     std::vector<double> mse = estimate_error

--- a/core/src/prediction/collector/OptimizedPredictionCollector.h
+++ b/core/src/prediction/collector/OptimizedPredictionCollector.h
@@ -24,13 +24,13 @@
 
 class OptimizedPredictionCollector: public PredictionCollector {
 public:
-  OptimizedPredictionCollector(std::shared_ptr<OptimizedPredictionStrategy> strategy,
-                               uint ci_group_size);
+  OptimizedPredictionCollector(std::shared_ptr<OptimizedPredictionStrategy> strategy);
 
   std::vector<Prediction> collect_predictions(const Forest& forest,
                                               Data* prediction_data,
                                               const std::vector<std::vector<size_t>>& leaf_nodes_by_tree,
                                               const std::vector<std::vector<bool>>& valid_trees_by_sample,
+                                              bool estimate_variance,
                                               bool estimate_error);
 
 private:
@@ -44,7 +44,6 @@ private:
   void validate_prediction(size_t sample, Prediction prediction);
 
   std::shared_ptr<OptimizedPredictionStrategy> strategy;
-  uint ci_group_size;
 };
 
 

--- a/core/src/prediction/collector/PredictionCollector.h
+++ b/core/src/prediction/collector/PredictionCollector.h
@@ -26,6 +26,7 @@ public:
                                                       Data* prediction_data,
                                                       const std::vector<std::vector<size_t>>& leaf_nodes_by_tree,
                                                       const std::vector<std::vector<bool>>& valid_trees_by_sample,
+                                                      bool estimate_variance,
                                                       bool estimate_error) = 0;
 };
 

--- a/core/src/serialization/ForestSerializer.cpp
+++ b/core/src/serialization/ForestSerializer.cpp
@@ -31,6 +31,9 @@ void ForestSerializer::serialize(std::ostream& stream, const Forest& forest) {
 
   size_t num_variables = forest.get_num_variables();
   stream.write((char*) &num_variables, sizeof(num_variables));
+
+  size_t ci_group_size = forest.get_ci_group_size();
+  stream.write((char*) &ci_group_size, sizeof(ci_group_size));
 }
 
 Forest ForestSerializer::deserialize(std::istream& stream) {
@@ -47,6 +50,9 @@ Forest ForestSerializer::deserialize(std::istream& stream) {
   size_t num_variables;
   stream.read((char*) &num_variables, sizeof(num_variables));
 
-  return Forest(trees, observations, num_variables);
+  size_t ci_group_size;
+  stream.read((char*) &ci_group_size, sizeof(ci_group_size));
+
+  return Forest(trees, observations, num_variables, ci_group_size);
 }
 

--- a/core/test/analysis/SplitFrequencyUnitTest.cpp
+++ b/core/test/analysis/SplitFrequencyUnitTest.cpp
@@ -60,7 +60,8 @@ TEST_CASE("split frequency computation works as expected", "[analysis, unit]") {
       {{1}}, second_split_vars, {1}, {1}, PredictionValues())));
 
   size_t num_variables = 5;
-  Forest forest(trees, Observations(), num_variables);
+  size_t ci_group_size = 2;
+  Forest forest(trees, Observations(), num_variables, ci_group_size);
 
   SplitFrequencyComputer computer;
   size_t max_depth = 3;
@@ -94,7 +95,8 @@ TEST_CASE("split frequency computation respects max depth", "[analysis, unit]") 
       {{0}}, split_vars, {0}, {0}, PredictionValues())));
 
   size_t num_variables = 5;
-  Forest forest(trees, Observations(), num_variables);
+  size_t ci_group_size = 2;
+  Forest forest(trees, Observations(), num_variables, ci_group_size);
 
   SplitFrequencyComputer computer;
   size_t max_depth = 2;

--- a/core/test/commons/SparseDataTest.cpp
+++ b/core/test/commons/SparseDataTest.cpp
@@ -30,16 +30,16 @@ TEST_CASE("using a sparse data representation produces the same predictions", "[
   uint outcome_index = 10;
 
   ForestTrainer trainer = ForestTrainers::regression_trainer(outcome_index);
-  ForestPredictor predictor = ForestPredictors::regression_predictor(4, 1);
+  ForestPredictor predictor = ForestPredictors::regression_predictor(4);
   ForestOptions options = ForestTestUtilities::default_options();
 
   // Train and predict using the default data format.
   Forest forest = trainer.train(data, options);
-  std::vector<Prediction> predictions = predictor.predict_oob(forest, data);
+  std::vector<Prediction> predictions = predictor.predict_oob(forest, data, false);
 
   // Train and predict using the sparse data format.
   Forest sparse_forest = trainer.train(sparse_data, options);
-  std::vector<Prediction> sparse_predictions = predictor.predict_oob(sparse_forest, sparse_data);
+  std::vector<Prediction> sparse_predictions = predictor.predict_oob(sparse_forest, sparse_data, false);
 
   // Check that the predictions are the same.
   REQUIRE(predictions.size() == sparse_predictions.size());

--- a/core/test/forest/CustomForestTest.cpp
+++ b/core/test/forest/CustomForestTest.cpp
@@ -36,7 +36,7 @@ TEST_CASE("custom forests predict 0 by default", "[custom, forest]") {
 
   // Predict on the same data.
   ForestPredictor predictor = ForestPredictors::custom_predictor(4);
-  std::vector<Prediction> predictions = predictor.predict_oob(forest, data);
+  std::vector<Prediction> predictions = predictor.predict_oob(forest, data, false);
 
   // Check the dummy predictions look as expected.
   REQUIRE(predictions.size() == data->get_num_rows());

--- a/core/test/forest/ForestCharacterizationTest.cpp
+++ b/core/test/forest/ForestCharacterizationTest.cpp
@@ -70,8 +70,8 @@ TEST_CASE("quantile forest predictions have not changed", "[quantile], [characte
   Forest forest = trainer.train(data, options);
 
   ForestPredictor predictor = ForestPredictors::quantile_predictor(4, quantiles);
-  std::vector<Prediction> oob_predictions = predictor.predict_oob(forest, data);
-  std::vector<Prediction> predictions = predictor.predict(forest, data);
+  std::vector<Prediction> oob_predictions = predictor.predict_oob(forest, data, false);
+  std::vector<Prediction> predictions = predictor.predict(forest, data, false);
 
 
 #ifdef UPDATE_PREDICTION_FILES
@@ -102,9 +102,9 @@ TEST_CASE("causal forest predictions have not changed", "[causal], [characteriza
 
   Forest forest = trainer.train(data, options);
 
-  ForestPredictor predictor = ForestPredictors::instrumental_predictor(4, 1);
-  std::vector<Prediction> oob_predictions = predictor.predict_oob(forest, data);
-  std::vector<Prediction> predictions = predictor.predict(forest, data);
+  ForestPredictor predictor = ForestPredictors::instrumental_predictor(4);
+  std::vector<Prediction> oob_predictions = predictor.predict_oob(forest, data, false);
+  std::vector<Prediction> predictions = predictor.predict(forest, data, false);
 
 #ifdef UPDATE_PREDICTION_FILES
   update_predictions_file("test/forest/resources/causal_oob_predictions.csv", oob_predictions);
@@ -134,9 +134,9 @@ TEST_CASE("causal forest predictions with stable splitting have not changed", "[
 
   Forest forest = trainer.train(data, options);
 
-  ForestPredictor predictor = ForestPredictors::instrumental_predictor(4, 1);
-  std::vector<Prediction> oob_predictions = predictor.predict_oob(forest, data);
-  std::vector<Prediction> predictions = predictor.predict(forest, data);
+  ForestPredictor predictor = ForestPredictors::instrumental_predictor(4);
+  std::vector<Prediction> oob_predictions = predictor.predict_oob(forest, data, false);
+  std::vector<Prediction> predictions = predictor.predict(forest, data, false);
 
 #ifdef UPDATE_PREDICTION_FILES
   update_predictions_file("test/forest/resources/stable_causal_oob_predictions.csv", oob_predictions);
@@ -161,9 +161,9 @@ TEST_CASE("regression forest predictions have not changed", "[regression], [char
   ForestOptions options = ForestTestUtilities::default_options();
   Forest forest = trainer.train(data, options);
 
-  ForestPredictor predictor = ForestPredictors::regression_predictor(4, 1);
-  std::vector<Prediction> oob_predictions = predictor.predict_oob(forest, data);
-  std::vector<Prediction> predictions = predictor.predict(forest, data);
+  ForestPredictor predictor = ForestPredictors::regression_predictor(4);
+  std::vector<Prediction> oob_predictions = predictor.predict_oob(forest, data, false);
+  std::vector<Prediction> predictions = predictor.predict(forest, data, false);
 
 #ifdef UPDATE_PREDICTION_FILES
   update_predictions_file("test/forest/resources/regression_oob_predictions.csv", oob_predictions);
@@ -192,11 +192,11 @@ TEST_CASE("local linear regression forest predictions have not changed",
   std::vector<double> lambdas = {0, 0.1, 1, 10, 100};
   bool weight_penalty = false;
   std::vector<size_t> linear_correction_variables = {1, 3, 5};
-  ForestPredictor predictor = ForestPredictors::local_linear_predictor(4, 1,
+  ForestPredictor predictor = ForestPredictors::local_linear_predictor(4,
       data, data, lambdas, weight_penalty, linear_correction_variables);
 
-  std::vector<Prediction> oob_predictions = predictor.predict_oob(forest, data);
-  std::vector<Prediction> predictions = predictor.predict(forest, data);
+  std::vector<Prediction> oob_predictions = predictor.predict_oob(forest, data, false);
+  std::vector<Prediction> predictions = predictor.predict(forest, data, false);
 
 #ifdef UPDATE_PREDICTION_FILES
   update_predictions_file("test/forest/resources/ll_regression_oob_predictions.csv", oob_predictions);

--- a/core/test/forest/ForestSmokeTest.cpp
+++ b/core/test/forest/ForestSmokeTest.cpp
@@ -20,6 +20,7 @@
 #include "forest/ForestPredictors.h"
 #include "forest/ForestTrainer.h"
 #include "forest/ForestTrainers.h"
+#include "utilities/ForestTestUtilities.h"
 
 #include "catch.hpp"
 
@@ -34,7 +35,7 @@ TEST_CASE("forests don't crash when there are fewer trees than threads", "[fores
   uint seed = 42;
   uint num_threads = 4;
   uint min_node_size = 1;
-  uint ci_group_size = 2;
+  size_t ci_group_size = 2;
   double sample_fraction = 0.35;
   bool honesty = true;
   double honesty_fraction = 0.5;
@@ -47,7 +48,66 @@ TEST_CASE("forests don't crash when there are fewer trees than threads", "[fores
           alpha, imbalance_penalty, num_threads, seed, empty_clusters, samples_per_cluster);
 
   Forest forest = trainer.train(data, options);
-  ForestPredictor predictor = ForestPredictors::regression_predictor(4, 2);
-  predictor.predict_oob(forest, data);
+  ForestPredictor predictor = ForestPredictors::regression_predictor(4);
+  predictor.predict_oob(forest, data, true);
+  delete data;
+}
+
+
+TEST_CASE("basic forest merges work", "[regression, forest]") {
+  Data* data = load_data("test/forest/resources/gaussian_data.csv");
+  uint outcome_index = 10;
+
+  ForestTrainer trainer = ForestTrainers::regression_trainer(outcome_index);
+  ForestOptions options = ForestTestUtilities::default_options(false, 2);
+
+  Forest forest1 = trainer.train(data, options);
+  Forest forest2 = trainer.train(data, options);
+  Forest forest3 = trainer.train(data, options);
+
+  std::shared_ptr<Forest> forest_ptr1 = std::make_shared<Forest>(forest1);
+  std::shared_ptr<Forest> forest_ptr2 = std::make_shared<Forest>(forest2);
+  std::shared_ptr<Forest> forest_ptr3 = std::make_shared<Forest>(forest3);
+
+  std::vector<std::shared_ptr<Forest>> forests{ forest_ptr1, forest_ptr2, forest_ptr3 };
+
+  Forest big_forest = Forest::merge(forests);
+
+  REQUIRE(forest1.get_trees().size() == 50);
+  REQUIRE(big_forest.get_trees().size() == 150);
+
+  REQUIRE(big_forest.get_num_variables() == forest1.get_num_variables());
+  REQUIRE(big_forest.get_ci_group_size() == forest1.get_ci_group_size());
+
+  ForestPredictor predictor = ForestPredictors::regression_predictor(4);
+  std::vector<Prediction> predictions = predictor.predict_oob(big_forest, data, false);
+
+  REQUIRE(predictions.size() == data->get_num_rows());
+
+  delete data;
+}
+
+TEST_CASE("forests with different ci_group_size cannot be merged", "[regression, forest]") {
+  Data* data = load_data("test/forest/resources/gaussian_data.csv");
+  uint outcome_index = 10;
+
+  ForestTrainer trainer = ForestTrainers::regression_trainer(outcome_index);
+
+  ForestOptions options = ForestTestUtilities::default_options(false, 1);
+  Forest forest = trainer.train(data, options);
+
+  ForestOptions options_with_ci = ForestTestUtilities::default_options(false, 2);
+  Forest forest_with_ci = trainer.train(data, options_with_ci);
+
+  std::vector<std::shared_ptr<Forest>> forests = { std::make_shared<Forest>(forest),
+                                                   std::make_shared<Forest>(forest_with_ci) };
+
+  try {
+    Forest big_forest = Forest::merge(forests);
+    FAIL();
+  } catch (const std::runtime_error& e) {
+    // Expected exception.
+  }
+
   delete data;
 }

--- a/core/test/forest/LocalLinearForestTest.cpp
+++ b/core/test/forest/LocalLinearForestTest.cpp
@@ -39,7 +39,7 @@ TEST_CASE("LLF gives reasonable prediction on friedman data", "[local linear], [
   std::vector<size_t> empty_clusters;
   uint samples_per_cluster = 0;
   uint num_threads = 1;
-  uint ci_group_size = 1;
+  size_t ci_group_size = 1;
   uint seed = 42;
   ForestOptions options (
       num_trees, ci_group_size, sample_fraction,
@@ -50,10 +50,10 @@ TEST_CASE("LLF gives reasonable prediction on friedman data", "[local linear], [
 
   Data* queries = data;
   ForestPredictor predictor = ForestPredictors::local_linear_predictor(
-      num_threads, ci_group_size, data, queries,
+      num_threads, data, queries,
       lambda, false,
       linear_correction_variables);
-  std::vector<Prediction> predictions = predictor.predict_oob(forest, data);
+  std::vector<Prediction> predictions = predictor.predict_oob(forest, data, false);
 
   const std::vector<double>& p = predictions[0].get_predictions();
 
@@ -74,12 +74,12 @@ TEST_CASE("LLF predictions vary linearly with Y", "[local linear], [forest]") {
   Forest forest = trainer.train(data, options);
 
   uint num_threads = 1;
-  uint ci_group_size = 1;
+  size_t ci_group_size = 1;
 
-  ForestPredictor predictor = ForestPredictors::local_linear_predictor(num_threads, ci_group_size,
-                                                                       data, data, lambda, false, linear_correction_variables);
+  ForestPredictor predictor = ForestPredictors::local_linear_predictor(num_threads,
+      data, data, lambda, false, linear_correction_variables);
 
-  std::vector<Prediction> predictions = predictor.predict_oob(forest, data);
+  std::vector<Prediction> predictions = predictor.predict_oob(forest, data, false);
 
   // Shift each outcome by 1, and re-run the forest.
   bool error;
@@ -89,10 +89,9 @@ TEST_CASE("LLF predictions vary linearly with Y", "[local linear], [forest]") {
   }
 
   Forest shifted_forest = trainer.train(data, options);
-  ForestPredictor shifted_predictor = ForestPredictors::local_linear_predictor(num_threads, ci_group_size,
-                                                                               data, data, lambda, false, linear_correction_variables);
-  std::vector<Prediction> shifted_predictions = shifted_predictor.predict_oob(shifted_forest, data);
-
+  ForestPredictor shifted_predictor = ForestPredictors::local_linear_predictor(num_threads,
+      data, data, lambda, false, linear_correction_variables);
+  std::vector<Prediction> shifted_predictions = shifted_predictor.predict_oob(shifted_forest, data, false);
 
   REQUIRE(predictions.size() == shifted_predictions.size());
   double delta = 0.0;
@@ -128,7 +127,7 @@ TEST_CASE("local linear forests give reasonable variance estimates", "[regressio
   std::vector<size_t> empty_clusters;
   uint samples_per_cluster = 0;
   uint num_threads = 1;
-  uint ci_group_size = 2;
+  size_t ci_group_size = 2;
   uint seed = 42;
   ForestOptions options (
       num_trees, ci_group_size, sample_fraction,
@@ -137,8 +136,8 @@ TEST_CASE("local linear forests give reasonable variance estimates", "[regressio
   ForestTrainer trainer = ForestTrainers::regression_trainer(outcome_index);
   Forest forest = trainer.train(data, options);
 
-  ForestPredictor predictor = ForestPredictors::local_linear_predictor(4, 2, data, data, lambda, false, linear_correction_variables);
-  std::vector<Prediction> predictions = predictor.predict_oob(forest, data);
+  ForestPredictor predictor = ForestPredictors::local_linear_predictor(4, data, data, lambda, false, linear_correction_variables);
+  std::vector<Prediction> predictions = predictor.predict_oob(forest, data, true);
 
   for (size_t i = 0; i < predictions.size(); i++) {
     Prediction prediction = predictions[i];

--- a/core/test/forest/RegressionForestTest.cpp
+++ b/core/test/forest/RegressionForestTest.cpp
@@ -34,8 +34,8 @@ TEST_CASE("honest regression forests are shift invariant", "[regression, forest]
   ForestOptions options = ForestTestUtilities::default_honest_options();
 
   Forest forest = trainer.train(data, options);
-  ForestPredictor predictor = ForestPredictors::regression_predictor(4, 1);
-  std::vector<Prediction> predictions = predictor.predict_oob(forest, data);
+  ForestPredictor predictor = ForestPredictors::regression_predictor(4);
+  std::vector<Prediction> predictions = predictor.predict_oob(forest, data, false);
 
   // Shift each outcome by 1, and re-run the forest.
   bool error;
@@ -45,8 +45,8 @@ TEST_CASE("honest regression forests are shift invariant", "[regression, forest]
   }
 
   Forest shifted_forest = trainer.train(data, options);
-  ForestPredictor shifted_predictor = ForestPredictors::regression_predictor(4, 1);
-  std::vector<Prediction> shifted_predictions = shifted_predictor.predict_oob(shifted_forest, data);
+  ForestPredictor shifted_predictor = ForestPredictors::regression_predictor(4);
+  std::vector<Prediction> shifted_predictions = shifted_predictor.predict_oob(shifted_forest, data, false);
 
   REQUIRE(predictions.size() == shifted_predictions.size());
   double delta = 0.0;
@@ -74,8 +74,8 @@ TEST_CASE("regression forests give reasonable variance estimates", "[regression,
   ForestOptions options = ForestTestUtilities::default_options(false, 2);
 
   Forest forest = trainer.train(data, options);
-  ForestPredictor predictor = ForestPredictors::regression_predictor(4, 2);
-  std::vector<Prediction> predictions = predictor.predict_oob(forest, data);
+  ForestPredictor predictor = ForestPredictors::regression_predictor(4);
+  std::vector<Prediction> predictions = predictor.predict_oob(forest, data, true);
 
   for (size_t i = 0; i < predictions.size(); i++) {
     Prediction prediction = predictions[i];
@@ -88,38 +88,6 @@ TEST_CASE("regression forests give reasonable variance estimates", "[regression,
   delete data;
 }
 
-
-TEST_CASE("regression forests are joinable", "[regression, forest]") {
-  Data* data = load_data("test/forest/resources/gaussian_data.csv");
-  uint outcome_index = 10;
-
-  ForestTrainer trainer = ForestTrainers::regression_trainer(outcome_index);
-  ForestOptions options = ForestTestUtilities::default_options(false, 2);
-
-  Forest forest1 = trainer.train(data, options);
-  Forest forest2 = trainer.train(data, options);
-  Forest forest3 = trainer.train(data, options);
-
-  std::shared_ptr<Forest> forest_ptr1 = std::make_shared<Forest>(forest1);
-  std::shared_ptr<Forest> forest_ptr2 = std::make_shared<Forest>(forest2);
-  std::shared_ptr<Forest> forest_ptr3 = std::make_shared<Forest>(forest3);
-
-  std::vector<std::shared_ptr<Forest>> forests{ forest_ptr1, forest_ptr2, forest_ptr3 };
-
-  Forest big_forest = Forest::merge(forests);
-
-  REQUIRE(forest1.get_trees().size() == 50);
-  REQUIRE(big_forest.get_trees().size() == 150);
-
-  ForestPredictor predictor = ForestPredictors::regression_predictor(4, 1);
-  std::vector<Prediction> predictions = predictor.predict_oob(big_forest, data);
-
-  REQUIRE(predictions.size() == data->get_num_rows());
-
-  delete data;
-}
-
-
 TEST_CASE("regression error estimates are shift invariant", "[regression, forest]") {
   // Run the original forest.
   Data* data = load_data("test/forest/resources/gaussian_data.csv");
@@ -129,8 +97,8 @@ TEST_CASE("regression error estimates are shift invariant", "[regression, forest
   ForestOptions options = ForestTestUtilities::default_honest_options();
 
   Forest forest = trainer.train(data, options);
-  ForestPredictor predictor = ForestPredictors::regression_predictor(4, 1);
-  std::vector<Prediction> predictions = predictor.predict_oob(forest, data);
+  ForestPredictor predictor = ForestPredictors::regression_predictor(4);
+  std::vector<Prediction> predictions = predictor.predict_oob(forest, data, false);
 
   // Shift each outcome by 1, and re-run the forest.
   bool data_error;
@@ -140,8 +108,8 @@ TEST_CASE("regression error estimates are shift invariant", "[regression, forest
   }
 
   Forest shifted_forest = trainer.train(data, options);
-  ForestPredictor shifted_predictor = ForestPredictors::regression_predictor(4, 1);
-  std::vector<Prediction> shifted_predictions = shifted_predictor.predict_oob(shifted_forest, data);
+  ForestPredictor shifted_predictor = ForestPredictors::regression_predictor(4);
+  std::vector<Prediction> shifted_predictions = shifted_predictor.predict_oob(shifted_forest, data, false);
 
   REQUIRE(predictions.size() == shifted_predictions.size());
   double delta = 0.0;

--- a/core/test/serialization/SerializationTest.cpp
+++ b/core/test/serialization/SerializationTest.cpp
@@ -80,11 +80,13 @@ TEST_CASE("forests serialize and deserialize correctly", "[forestSerialization]"
 
   ForestSerializer forest_serializer;
   std::stringstream stream;
-  Forest original_forest(trees, observations, 3);
+  Forest original_forest(trees, observations, 3, 5);
 
   forest_serializer.serialize(stream, original_forest);
   Forest forest = forest_serializer.deserialize(stream);
 
   REQUIRE(forest.get_trees().size() == original_forest.get_trees().size());
   REQUIRE(forest.get_observations().get_num_samples() == original_forest.get_observations().get_num_samples());
+  REQUIRE(forest.get_num_variables() == original_forest.get_num_variables());
+  REQUIRE(forest.get_ci_group_size() == original_forest.get_ci_group_size());
 }

--- a/core/test/utilities/ForestTestUtilities.cpp
+++ b/core/test/utilities/ForestTestUtilities.cpp
@@ -27,7 +27,7 @@ ForestOptions ForestTestUtilities::default_honest_options() {
 }
 
 ForestOptions ForestTestUtilities::default_options(bool honesty,
-                                                   uint ci_group_size) {
+                                                   size_t ci_group_size) {
   double honesty_fraction = 0.5;
   uint num_trees = 50;
   double sample_fraction = ci_group_size > 1 ? 0.35 : 0.7;

--- a/core/test/utilities/ForestTestUtilities.h
+++ b/core/test/utilities/ForestTestUtilities.h
@@ -26,7 +26,7 @@ public:
   static ForestOptions default_options();
   static ForestOptions default_honest_options();
 
-  static ForestOptions default_options(bool honesty, uint ci_group_size);
+  static ForestOptions default_options(bool honesty, size_t ci_group_size);
 };
 
 #endif //GRF_FORESTTESTUTILITIES_H

--- a/r-package/grf/R/RcppExports.R
+++ b/r-package/grf/R/RcppExports.R
@@ -37,12 +37,12 @@ instrumental_train <- function(input_data, sparse_input_data, outcome_index, tre
     .Call('_grf_instrumental_train', PACKAGE = 'grf', input_data, sparse_input_data, outcome_index, treatment_index, instrument_index, mtry, num_trees, num_threads, min_node_size, sample_fraction, seed, honesty, honesty_fraction, ci_group_size, reduced_form_weight, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster)
 }
 
-instrumental_predict <- function(forest_object, input_data, sparse_input_data, num_threads, ci_group_size) {
-    .Call('_grf_instrumental_predict', PACKAGE = 'grf', forest_object, input_data, sparse_input_data, num_threads, ci_group_size)
+instrumental_predict <- function(forest_object, input_data, sparse_input_data, num_threads, estimate_variance) {
+    .Call('_grf_instrumental_predict', PACKAGE = 'grf', forest_object, input_data, sparse_input_data, num_threads, estimate_variance)
 }
 
-instrumental_predict_oob <- function(forest_object, input_data, sparse_input_data, num_threads, ci_group_size) {
-    .Call('_grf_instrumental_predict_oob', PACKAGE = 'grf', forest_object, input_data, sparse_input_data, num_threads, ci_group_size)
+instrumental_predict_oob <- function(forest_object, input_data, sparse_input_data, num_threads, estimate_variance) {
+    .Call('_grf_instrumental_predict_oob', PACKAGE = 'grf', forest_object, input_data, sparse_input_data, num_threads, estimate_variance)
 }
 
 quantile_train <- function(quantiles, regression_splits, input_data, sparse_input_data, outcome_index, mtry, num_trees, num_threads, min_node_size, sample_fraction, seed, honesty, honesty_fraction, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster) {
@@ -61,19 +61,19 @@ regression_train <- function(input_data, sparse_input_data, outcome_index, mtry,
     .Call('_grf_regression_train', PACKAGE = 'grf', input_data, sparse_input_data, outcome_index, mtry, num_trees, num_threads, min_node_size, sample_fraction, seed, honesty, honesty_fraction, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster)
 }
 
-regression_predict <- function(forest_object, input_data, sparse_input_data, num_threads, ci_group_size) {
-    .Call('_grf_regression_predict', PACKAGE = 'grf', forest_object, input_data, sparse_input_data, num_threads, ci_group_size)
+regression_predict <- function(forest_object, input_data, sparse_input_data, num_threads, estimate_variance) {
+    .Call('_grf_regression_predict', PACKAGE = 'grf', forest_object, input_data, sparse_input_data, num_threads, estimate_variance)
 }
 
-regression_predict_oob <- function(forest_object, input_data, sparse_input_data, num_threads, ci_group_size) {
-    .Call('_grf_regression_predict_oob', PACKAGE = 'grf', forest_object, input_data, sparse_input_data, num_threads, ci_group_size)
+regression_predict_oob <- function(forest_object, input_data, sparse_input_data, num_threads, estimate_variance) {
+    .Call('_grf_regression_predict_oob', PACKAGE = 'grf', forest_object, input_data, sparse_input_data, num_threads, estimate_variance)
 }
 
-local_linear_predict <- function(forest, input_data, training_data, sparse_input_data, sparse_training_data, lambdas, weight_penalty, linear_correction_variables, num_threads, ci_group_size) {
-    .Call('_grf_local_linear_predict', PACKAGE = 'grf', forest, input_data, training_data, sparse_input_data, sparse_training_data, lambdas, weight_penalty, linear_correction_variables, num_threads, ci_group_size)
+local_linear_predict <- function(forest, input_data, training_data, sparse_input_data, sparse_training_data, lambdas, weight_penalty, linear_correction_variables, num_threads, estimate_variance) {
+    .Call('_grf_local_linear_predict', PACKAGE = 'grf', forest, input_data, training_data, sparse_input_data, sparse_training_data, lambdas, weight_penalty, linear_correction_variables, num_threads, estimate_variance)
 }
 
-local_linear_predict_oob <- function(forest, input_data, sparse_input_data, lambdas, weight_penalty, linear_correction_variables, num_threads, ci_group_size) {
-    .Call('_grf_local_linear_predict_oob', PACKAGE = 'grf', forest, input_data, sparse_input_data, lambdas, weight_penalty, linear_correction_variables, num_threads, ci_group_size)
+local_linear_predict_oob <- function(forest, input_data, sparse_input_data, lambdas, weight_penalty, linear_correction_variables, num_threads, estimate_variance) {
+    .Call('_grf_local_linear_predict_oob', PACKAGE = 'grf', forest, input_data, sparse_input_data, lambdas, weight_penalty, linear_correction_variables, num_threads, estimate_variance)
 }
 

--- a/r-package/grf/R/causal_forest.R
+++ b/r-package/grf/R/causal_forest.R
@@ -292,22 +292,16 @@ predict.causal_forest <- function(object, newdata = NULL, num.threads = NULL, es
 
     num.threads <- validate_num_threads(num.threads)
 
-    if (estimate.variance) {
-        ci.group.size = object$ci.group.size
-    } else {
-        ci.group.size = 1
-    }
-
     forest.short <- object[-which(names(object) == "X.orig")]
     if (!is.null(newdata)) {
         validate_newdata(newdata, object$X.orig)
         data <- create_data_matrices(newdata)
         ret <- instrumental_predict(forest.short, data$default, data$sparse,
-                                    num.threads, ci.group.size)
+                                    num.threads, estimate.variance)
     } else {
         data <- create_data_matrices(object[["X.orig"]])
         ret <- instrumental_predict_oob(forest.short, data$default, data$sparse,
-                                        num.threads, ci.group.size)
+                                        num.threads, estimate.variance)
     }
 
     # Convert list to data frame.

--- a/r-package/grf/R/causal_tuning.R
+++ b/r-package/grf/R/causal_tuning.R
@@ -135,7 +135,7 @@ tune_causal_forest <- function(X, Y, W, Y.hat, W.hat,
                                        clusters,
                                        samples_per_cluster)
     prediction = instrumental_predict_oob(small.forest, data$default, data$sparse,
-                                          num.threads, ci.group.size)
+                                          num.threads, FALSE)
     mean(prediction$debiased.error, na.rm = TRUE)
   })
   

--- a/r-package/grf/R/instrumental_forest.R
+++ b/r-package/grf/R/instrumental_forest.R
@@ -196,24 +196,17 @@ predict.instrumental_forest <- function(object, newdata = NULL,
     }
 
     num.threads <- validate_num_threads(num.threads)
-
-    if (estimate.variance) {
-        ci.group.size <- object$ci.group.size
-    } else {
-        ci.group.size <- 1
-    }
-
     forest.short <- object[-which(names(object) == "X.orig")]
 
     if (!is.null(newdata)) {
         validate_newdata(newdata, object$X.orig)
         data <- create_data_matrices(newdata)
         ret <- instrumental_predict(forest.short, data$default, data$sparse,
-                                    num.threads, ci.group.size)
+                                    num.threads, estimate.variance)
     } else {
         data <- create_data_matrices(object[["X.orig"]])
         ret <- instrumental_predict_oob(forest.short, data$default, data$sparse,
-                                        num.threads, ci.group.size)
+                                        num.threads, estimate.variance)
     }
 
     # Convert list to data frame.

--- a/r-package/grf/R/local_linear_forest.R
+++ b/r-package/grf/R/local_linear_forest.R
@@ -211,12 +211,6 @@ predict.local_linear_forest <- function(object, newdata = NULL,
     ll.lambda = validate_ll_lambda(ll.lambda)
   }
 
-  if (estimate.variance) {
-    ci.group.size = object$ci.group.size
-  } else {
-    ci.group.size = 1
-  }
-
   num.threads = validate_num_threads(num.threads)
 
   # Subtract 1 to account for C++ indexing
@@ -228,11 +222,11 @@ predict.local_linear_forest <- function(object, newdata = NULL,
     training.data = create_data_matrices(X.orig)
     ret = local_linear_predict(forest.short, data$default, training.data$default, data$sparse,
                   training.data$sparse, ll.lambda, ll.weight.penalty, linear.correction.variables,
-                  num.threads, ci.group.size)
+                  num.threads, estimate.variance)
   } else {
      data = create_data_matrices(X.orig)
      ret = local_linear_predict_oob(forest.short, data$default, data$sparse, ll.lambda, ll.weight.penalty,
-                  linear.correction.variables, num.threads, ci.group.size)
+                  linear.correction.variables, num.threads, estimate.variance)
   }
 
   ret[["ll.lambda"]] = ll.lambda

--- a/r-package/grf/R/local_linear_tuning.R
+++ b/r-package/grf/R/local_linear_tuning.R
@@ -44,9 +44,9 @@ tune_local_linear_forest <- function(forest,
   linear.correction.variables = linear.correction.variables - 1
 
   # Enforce no variance estimates in tuning
-  ci.group.size = 1
+  estimate.variance = FALSE
   prediction.object = local_linear_predict_oob(forest.short, data$default, data$sparse, lambda.path, ll.weight.penalty,
-                                 linear.correction.variables, num.threads, ci.group.size)
+                                 linear.correction.variables, num.threads, estimate.variance)
 
   prediction.object = prediction.object$predictions
   errors = apply(prediction.object, MARGIN = 2, FUN = function(row){

--- a/r-package/grf/R/merge_forests.R
+++ b/r-package/grf/R/merge_forests.R
@@ -70,14 +70,6 @@ validate_forest_list <- function(forest_list) {
     stop(paste("All forests in 'forest_list' must be of the same type, but we found:", 
                paste(classes, collapse=", ")))
   }
-  
-  first.ci.group.size <- first_forest$ci.group.size
-  compatible.ci.group.sizes <- sapply(
-    forest_list, function(frst) frst$ci.group.size == first.ci.group.size)
-  if (!all(compatible.ci.group.sizes)) {
-    stop("All forests in 'forest_list' must have the same ci.group.size.")
-  }
-  
 }
 
 

--- a/r-package/grf/R/regression_forest.R
+++ b/r-package/grf/R/regression_forest.R
@@ -221,12 +221,6 @@ predict.regression_forest <- function(object, newdata = NULL,
 
     num.threads = validate_num_threads(num.threads)
 
-    if (estimate.variance) {
-        ci.group.size = object$ci.group.size
-    } else {
-        ci.group.size = 1
-    }
-
     forest.short = object[-which(names(object) == "X.orig")]
     X.orig = object[["X.orig"]]
 
@@ -249,20 +243,20 @@ predict.regression_forest <- function(object, newdata = NULL,
         validate_newdata(newdata, object$X.orig)
         if (!local.linear) {
             ret = regression_predict(forest.short, data$default, data$sparse,
-                num.threads, ci.group.size)
+                num.threads, estimate.variance)
         } else {
             training.data = create_data_matrices(X.orig)
             ret = local_linear_predict(forest.short, data$default, training.data$default, data$sparse,
                 training.data$sparse, ll.lambda, ll.weight.penalty, linear.correction.variables, num.threads,
-                ci.group.size)
+                estimate.variance)
         }
     } else {
         data = create_data_matrices(X.orig)
         if (!local.linear) {
-            ret = regression_predict_oob(forest.short, data$default, data$sparse, num.threads, ci.group.size)
+            ret = regression_predict_oob(forest.short, data$default, data$sparse, num.threads, estimate.variance)
         } else {
             ret = local_linear_predict_oob(forest.short, data$default, data$sparse, ll.lambda, ll.weight.penalty,
-                linear.correction.variables, num.threads, ci.group.size)
+                linear.correction.variables, num.threads, estimate.variance)
         }
     }
 

--- a/r-package/grf/R/regression_tuning.R
+++ b/r-package/grf/R/regression_tuning.R
@@ -116,7 +116,7 @@ tune_regression_forest <- function(X, Y,
                                      samples_per_cluster)
 
     prediction = regression_predict_oob(small.forest, data$default, data$sparse,
-                                            num.threads, ci.group.size)
+                                        num.threads, FALSE)
     error = prediction$debiased.error
     mean(error, na.rm = TRUE)
   })

--- a/r-package/grf/bindings/CustomForestBindings.cpp
+++ b/r-package/grf/bindings/CustomForestBindings.cpp
@@ -37,7 +37,7 @@ Rcpp::List custom_train(Rcpp::NumericMatrix input_data,
                         unsigned int seed,
                         bool honesty,
                         double honesty_fraction,
-                        unsigned int ci_group_size,
+                        size_t ci_group_size,
                         double alpha,
                         double imbalance_penalty,
                         std::vector<size_t> clusters,
@@ -64,7 +64,7 @@ Rcpp::NumericMatrix custom_predict(Rcpp::List forest_object,
       forest_object[RcppUtilities::SERIALIZED_FOREST_KEY]);
 
   ForestPredictor predictor = ForestPredictors::custom_predictor(num_threads);
-  std::vector<Prediction> predictions = predictor.predict(forest, data);
+  std::vector<Prediction> predictions = predictor.predict(forest, data, false);
   Rcpp::NumericMatrix result = RcppUtilities::create_prediction_matrix(predictions);
 
   delete data;
@@ -81,7 +81,7 @@ Rcpp::NumericMatrix custom_predict_oob(Rcpp::List forest_object,
       forest_object[RcppUtilities::SERIALIZED_FOREST_KEY]);
 
   ForestPredictor predictor = ForestPredictors::custom_predictor(num_threads);
-  std::vector<Prediction> predictions = predictor.predict_oob(forest, data);
+  std::vector<Prediction> predictions = predictor.predict_oob(forest, data, false);
   Rcpp::NumericMatrix result = RcppUtilities::create_prediction_matrix(predictions);
 
   delete data;

--- a/r-package/grf/bindings/InstrumentalForestBindings.cpp
+++ b/r-package/grf/bindings/InstrumentalForestBindings.cpp
@@ -23,7 +23,7 @@ Rcpp::List instrumental_train(Rcpp::NumericMatrix input_data,
                               unsigned int seed,
                               bool honesty,
                               double honesty_fraction,
-                              unsigned int ci_group_size,
+                              size_t ci_group_size,
                               double reduced_form_weight,
                               double alpha,
                               double imbalance_penalty,
@@ -53,13 +53,13 @@ Rcpp::List instrumental_predict(Rcpp::List forest_object,
                                 Rcpp::NumericMatrix input_data,
                                 Eigen::SparseMatrix<double> sparse_input_data,
                                 unsigned int num_threads,
-                                unsigned int ci_group_size) {
-  Data* data = RcppUtilities::convert_data(input_data, sparse_input_data);
+                                bool estimate_variance) {
   Forest forest = RcppUtilities::deserialize_forest(
       forest_object[RcppUtilities::SERIALIZED_FOREST_KEY]);
+  Data* data = RcppUtilities::convert_data(input_data, sparse_input_data);
 
-  ForestPredictor predictor = ForestPredictors::instrumental_predictor(num_threads, ci_group_size);
-  std::vector<Prediction> predictions = predictor.predict(forest, data);
+  ForestPredictor predictor = ForestPredictors::instrumental_predictor(num_threads);
+  std::vector<Prediction> predictions = predictor.predict(forest, data, estimate_variance);
 
   Rcpp::List result = RcppUtilities::create_prediction_object(predictions);
   delete data;
@@ -71,13 +71,13 @@ Rcpp::List instrumental_predict_oob(Rcpp::List forest_object,
                                     Rcpp::NumericMatrix input_data,
                                     Eigen::SparseMatrix<double> sparse_input_data,
                                     unsigned int num_threads,
-                                    unsigned int ci_group_size) {
-  Data* data = RcppUtilities::convert_data(input_data, sparse_input_data);
+                                    bool estimate_variance) {
   Forest forest = RcppUtilities::deserialize_forest(
       forest_object[RcppUtilities::SERIALIZED_FOREST_KEY]);
+  Data* data = RcppUtilities::convert_data(input_data, sparse_input_data);
 
-  ForestPredictor predictor = ForestPredictors::instrumental_predictor(num_threads, ci_group_size);
-  std::vector<Prediction> predictions = predictor.predict_oob(forest, data);
+  ForestPredictor predictor = ForestPredictors::instrumental_predictor(num_threads);
+  std::vector<Prediction> predictions = predictor.predict_oob(forest, data, estimate_variance);
 
   Rcpp::List result = RcppUtilities::create_prediction_object(predictions);
   delete data;

--- a/r-package/grf/bindings/QuantileForestBindings.cpp
+++ b/r-package/grf/bindings/QuantileForestBindings.cpp
@@ -23,7 +23,7 @@ Rcpp::List quantile_train(std::vector<double> quantiles,
                           unsigned int seed,
                           bool honesty,
                           double honesty_fraction,
-                          unsigned int ci_group_size,
+                          size_t ci_group_size,
                           double alpha,
                           double imbalance_penalty,
                           std::vector<size_t> clusters,
@@ -54,7 +54,7 @@ Rcpp::NumericMatrix quantile_predict(Rcpp::List forest_object,
       forest_object[RcppUtilities::SERIALIZED_FOREST_KEY]);
 
   ForestPredictor predictor = ForestPredictors::quantile_predictor(num_threads, quantiles);
-  std::vector<Prediction> predictions = predictor.predict(forest, data);
+  std::vector<Prediction> predictions = predictor.predict(forest, data, false);
   Rcpp::NumericMatrix result = RcppUtilities::create_prediction_matrix(predictions);
 
   delete data;
@@ -72,7 +72,7 @@ Rcpp::NumericMatrix quantile_predict_oob(Rcpp::List forest_object,
       forest_object[RcppUtilities::SERIALIZED_FOREST_KEY]);
 
   ForestPredictor predictor = ForestPredictors::quantile_predictor(num_threads, quantiles);
-  std::vector<Prediction> predictions = predictor.predict_oob(forest, data);
+  std::vector<Prediction> predictions = predictor.predict_oob(forest, data, false);
   Rcpp::NumericMatrix result = RcppUtilities::create_prediction_matrix(predictions);
 
   delete data;

--- a/r-package/grf/bindings/RegressionForestBindings.cpp
+++ b/r-package/grf/bindings/RegressionForestBindings.cpp
@@ -38,7 +38,7 @@ Rcpp::List regression_train(Rcpp::NumericMatrix input_data,
                             unsigned int seed,
                             bool honesty,
                             double honesty_fraction,
-                            unsigned int ci_group_size,
+                            size_t ci_group_size,
                             double alpha,
                             double imbalance_penalty,
                             std::vector<size_t> clusters,
@@ -63,13 +63,13 @@ Rcpp::List regression_predict(Rcpp::List forest_object,
                               Rcpp::NumericMatrix input_data,
                               Eigen::SparseMatrix<double> sparse_input_data,
                               unsigned int num_threads,
-                              unsigned int ci_group_size) {
+                              bool estimate_variance) {
   Data* data = RcppUtilities::convert_data(input_data, sparse_input_data);
   Forest forest = RcppUtilities::deserialize_forest(
           forest_object[RcppUtilities::SERIALIZED_FOREST_KEY]);
 
-  ForestPredictor predictor = ForestPredictors::regression_predictor(num_threads, ci_group_size);
-  std::vector<Prediction> predictions = predictor.predict(forest, data);
+  ForestPredictor predictor = ForestPredictors::regression_predictor(num_threads);
+  std::vector<Prediction> predictions = predictor.predict(forest, data, estimate_variance);
 
   Rcpp::List result = RcppUtilities::create_prediction_object(predictions);
   delete data;
@@ -81,13 +81,13 @@ Rcpp::List regression_predict_oob(Rcpp::List forest_object,
                                   Rcpp::NumericMatrix input_data,
                                   Eigen::SparseMatrix<double> sparse_input_data,
                                   unsigned int num_threads,
-                                  unsigned int ci_group_size) {
+                                  bool estimate_variance) {
   Data* data = RcppUtilities::convert_data(input_data, sparse_input_data);
   Forest forest = RcppUtilities::deserialize_forest(
           forest_object[RcppUtilities::SERIALIZED_FOREST_KEY]);
 
-  ForestPredictor predictor = ForestPredictors::regression_predictor(num_threads, ci_group_size);
-  std::vector<Prediction> predictions = predictor.predict_oob(forest, data);
+  ForestPredictor predictor = ForestPredictors::regression_predictor(num_threads);
+  std::vector<Prediction> predictions = predictor.predict_oob(forest, data, estimate_variance);
 
   Rcpp::List result = RcppUtilities::create_prediction_object(predictions);
   delete data;
@@ -104,16 +104,16 @@ Rcpp::List local_linear_predict(Rcpp::List forest,
                                 bool weight_penalty,
                                 std::vector<size_t> linear_correction_variables,
                                 unsigned int num_threads,
-                                unsigned int ci_group_size) {
+                                bool estimate_variance) {
   Data *test_data = RcppUtilities::convert_data(input_data, sparse_input_data);
   Data *original_data = RcppUtilities::convert_data(training_data, sparse_training_data);
 
   Forest deserialized_forest = RcppUtilities::deserialize_forest(forest[RcppUtilities::SERIALIZED_FOREST_KEY]);
 
-  ForestPredictor predictor = ForestPredictors::local_linear_predictor(num_threads, ci_group_size, original_data, test_data,
+  ForestPredictor predictor = ForestPredictors::local_linear_predictor(num_threads, original_data, test_data,
                                                                        lambdas, weight_penalty,
                                                                        linear_correction_variables);
-  std::vector<Prediction> predictions = predictor.predict(deserialized_forest, test_data);
+  std::vector<Prediction> predictions = predictor.predict(deserialized_forest, test_data, estimate_variance);
   Rcpp::List result = RcppUtilities::create_prediction_object(predictions);
 
   delete original_data;
@@ -129,15 +129,15 @@ Rcpp::List local_linear_predict_oob(Rcpp::List forest,
                                     bool weight_penalty,
                                     std::vector<size_t> linear_correction_variables,
                                     unsigned int num_threads,
-                                    unsigned int ci_group_size) {
+                                    bool estimate_variance) {
   Data* data = RcppUtilities::convert_data(input_data, sparse_input_data);
 
   Forest deserialized_forest = RcppUtilities::deserialize_forest(forest[RcppUtilities::SERIALIZED_FOREST_KEY]);
 
-  ForestPredictor predictor = ForestPredictors::local_linear_predictor(num_threads, ci_group_size, data, data,
+  ForestPredictor predictor = ForestPredictors::local_linear_predictor(num_threads, data, data,
                                                                        lambdas, weight_penalty,
                                                                        linear_correction_variables);
-  std::vector<Prediction> predictions = predictor.predict_oob(deserialized_forest, data);
+  std::vector<Prediction> predictions = predictor.predict_oob(deserialized_forest, data, estimate_variance);
   Rcpp::List result = RcppUtilities::create_prediction_object(predictions);
 
   delete data;


### PR DESCRIPTION
* Store ci_group_size as part of the forest to avoid a mismatch between training and prediction.
* Add an estimate_variance option to prediction, to replace the fragile check ci_group_size > 1.
* Move the check for consistent ci_group_size during merges into C++.
* Use size_t instead of uint for ci_group_size.

Addresses #232.