### PR TITLE
Fix train/test data assignment in custom_forest

### DIFF
--- a/r-package/grf/bindings/CustomForestBindings.cpp
+++ b/r-package/grf/bindings/CustomForestBindings.cpp
@@ -66,9 +66,9 @@ Rcpp::NumericMatrix custom_predict(Rcpp::List forest_object,
                                    Rcpp::NumericMatrix test_matrix,
                                    Eigen::SparseMatrix<double> sparse_test_matrix,
                                    unsigned int num_threads) {
-  Data* train_data = RcppUtilities::convert_data(test_matrix, sparse_test_matrix);
+  Data* train_data = RcppUtilities::convert_data(train_matrix, sparse_train_matrix);
   train_data->set_outcome_index(outcome_index - 1);
-  Data* data = RcppUtilities::convert_data(train_matrix, sparse_train_matrix);
+  Data* data = RcppUtilities::convert_data(test_matrix, sparse_test_matrix);
 
   Forest forest = RcppUtilities::deserialize_forest(
       forest_object[RcppUtilities::SERIALIZED_FOREST_KEY]);

--- a/r-package/grf/tests/testthat/test_custom_forest.R
+++ b/r-package/grf/tests/testthat/test_custom_forest.R
@@ -12,3 +12,17 @@ test_that("custom forests behave as expected", {
 	predictions = predict(forest, X)
 	expect_equal(0.0, sum(predictions))
 })
+
+test_that("custom forest prediction is of correct size", {
+  p = 40
+  n = 500
+  X = matrix(2 * runif(n * p) - 1, n, p)
+  Y = rnorm(n) * (1 + (X[,1] > 0))
+  
+  n_test = 50
+  X_test = matrix(2 * runif(n_test * p) - 1, n_test, p)
+  
+  forest = custom_forest(X, Y)
+  predictions = predict(forest, X_test)
+  expect_length(predictions, n_test)
+})


### PR DESCRIPTION
The training data was used as test data in prediction with a custom forest