### PR TITLE
Fix quantile forest bindings

### DIFF
--- a/r-package/grf/R/RcppExports.R
+++ b/r-package/grf/R/RcppExports.R
@@ -53,8 +53,8 @@ quantile_predict <- function(forest_object, quantiles, train_matrix, sparse_trai
     .Call('_grf_quantile_predict', PACKAGE = 'grf', forest_object, quantiles, train_matrix, sparse_train_matrix, outcome_index, test_matrix, sparse_test_matrix, num_threads)
 }
 
-quantile_predict_oob <- function(forest_object, quantiles, outcome_index, train_matrix, sparse_train_matrix, num_threads) {
-    .Call('_grf_quantile_predict_oob', PACKAGE = 'grf', forest_object, quantiles, outcome_index, train_matrix, sparse_train_matrix, num_threads)
+quantile_predict_oob <- function(forest_object, quantiles, train_matrix, sparse_train_matrix, outcome_index, num_threads) {
+    .Call('_grf_quantile_predict_oob', PACKAGE = 'grf', forest_object, quantiles, train_matrix, sparse_train_matrix, outcome_index, num_threads)
 }
 
 regression_train <- function(train_matrix, sparse_train_matrix, outcome_index, mtry, num_trees, num_threads, min_node_size, sample_fraction, seed, honesty, honesty_fraction, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster) {

--- a/r-package/grf/R/quantile_forest.R
+++ b/r-package/grf/R/quantile_forest.R
@@ -99,6 +99,7 @@ quantile_forest <- function(X, Y, quantiles = c(0.1, 0.5, 0.9), regression.split
         ci.group.size, alpha, imbalance.penalty, clusters, samples_per_cluster)
     
     forest[["X.orig"]] <- X
+    forest[["Y.orig"]] <- Y
     forest[["clusters"]] <- clusters
     
     class(forest) <- c("quantile_forest", "grf")

--- a/r-package/grf/bindings/QuantileForestBindings.cpp
+++ b/r-package/grf/bindings/QuantileForestBindings.cpp
@@ -56,7 +56,7 @@ Rcpp::NumericMatrix quantile_predict(Rcpp::List forest_object,
                                      Eigen::SparseMatrix<double> sparse_test_matrix,
                                      unsigned int num_threads) {
   Data* train_data = RcppUtilities::convert_data(train_matrix, sparse_train_matrix);
-  train_data->set_outcome_index(outcome_index);
+  train_data->set_outcome_index(outcome_index - 1);
   Data* data = RcppUtilities::convert_data(test_matrix, sparse_test_matrix);
 
   Forest forest = RcppUtilities::deserialize_forest(

--- a/r-package/grf/bindings/QuantileForestBindings.cpp
+++ b/r-package/grf/bindings/QuantileForestBindings.cpp
@@ -56,8 +56,8 @@ Rcpp::NumericMatrix quantile_predict(Rcpp::List forest_object,
                                      Eigen::SparseMatrix<double> sparse_test_matrix,
                                      unsigned int num_threads) {
   Data* train_data = RcppUtilities::convert_data(train_matrix, sparse_train_matrix);
-  train_data->set_outcome_index(outcome_index - 1);
   Data* data = RcppUtilities::convert_data(test_matrix, sparse_test_matrix);
+  train_data->set_outcome_index(outcome_index - 1);
 
   Forest forest = RcppUtilities::deserialize_forest(
       forest_object[RcppUtilities::SERIALIZED_FOREST_KEY]);
@@ -74,12 +74,13 @@ Rcpp::NumericMatrix quantile_predict(Rcpp::List forest_object,
 // [[Rcpp::export]]
 Rcpp::NumericMatrix quantile_predict_oob(Rcpp::List forest_object,
                                          std::vector<double> quantiles,
-                                         size_t outcome_index,
                                          Rcpp::NumericMatrix train_matrix,
                                          Eigen::SparseMatrix<double> sparse_train_matrix,
+                                         size_t outcome_index,
                                          unsigned int num_threads) {
   Data* data = RcppUtilities::convert_data(train_matrix, sparse_train_matrix);
-  data->set_outcome_index(outcome_index);
+  data->set_outcome_index(outcome_index - 1);
+
   Forest forest = RcppUtilities::deserialize_forest(
       forest_object[RcppUtilities::SERIALIZED_FOREST_KEY]);
 

--- a/r-package/grf/tests/testthat/test_quantile_forest.R
+++ b/r-package/grf/tests/testthat/test_quantile_forest.R
@@ -54,6 +54,6 @@ test_that("quantile forest predictions for 90th percentile are strongly positive
     Y = runif(n) + 100 * (X[,i] > 0)
 
     qrf = quantile_forest(X, Y, quantiles = c(0.1, 0.5, 0.9), mtry = p, min.node.size = 10, sample.fraction = 0.632)
-  expect_true(cor(predict(qrf, quantiles=.9), X[,i]) > .5)
+    expect_true(cor(predict(qrf, quantiles=.9), X[,i]) > .5)
     expect_true(cor(predict(qrf, X.new, quantiles=.9), X.new[,i])  > .5)
 })

--- a/r-package/grf/tests/testthat/test_quantile_forest.R
+++ b/r-package/grf/tests/testthat/test_quantile_forest.R
@@ -30,3 +30,30 @@ test_that("quantile forests with regression splitting are identical to regressio
 	rrf.split.frequencies = split_frequencies(rrf, 4)
 	expect_equal(qrf.split.frequencies, rrf.split.frequencies)
 })
+
+test_that("quantile forest predictions are positive given positive outcomes", {
+	p = 10
+	n = 500
+	i = 5
+	X = matrix(2 * runif(n * p) - 1, n, p)
+	X.new = matrix(2 * runif(n * p) - 1, n, p)
+	Y = runif(n) + 100 * (X[,i] > 0)
+
+	qrf = quantile_forest(X, Y, quantiles = c(0.1, 0.5, 0.9), mtry = p, min.node.size = 10, sample.fraction = 0.632)
+	expect_true(all(predict(qrf) > 0))
+	expect_true(all(predict(qrf, X.new) > 0))
+})
+
+test_that("quantile forest predictions for 90th percentile are strongly positively correlated
+					 with covariate strongly positively correlated with Y", {
+	p = 10
+	n = 500
+	i = 5
+	X = matrix(2 * runif(n * p) - 1, n, p)
+	X.new = matrix(2 * runif(n * p) - 1, n, p)
+	Y = runif(n) + 100 * (X[,i] > 0)
+
+	qrf = quantile_forest(X, Y, quantiles = c(0.1, 0.5, 0.9), mtry = p, min.node.size = 10, sample.fraction = 0.632)
+  expect_true(cor(predict(qrf, quantiles=.9), X[,i]) > .5)
+	expect_true(cor(predict(qrf, X.new, quantiles=.9), X.new[,i])  > .5)
+})

--- a/r-package/grf/tests/testthat/test_quantile_forest.R
+++ b/r-package/grf/tests/testthat/test_quantile_forest.R
@@ -1,59 +1,59 @@
 library(grf)
 
 test_that("quantile forests have reasonable split frequencies", {
-	p = 10
-	n = 500
-	i = 5
-	X = matrix(2 * runif(n * p) - 1, n, p)
-	Y = rnorm(n) * (1 + 100 * (X[,i] > 0))
+    p = 10
+    n = 500
+    i = 5
+    X = matrix(2 * runif(n * p) - 1, n, p)
+    Y = rnorm(n) * (1 + 100 * (X[,i] > 0))
 
-	qrf = quantile_forest(X, Y, quantiles = c(0.1, 0.5, 0.9), mtry = p, min.node.size = 10, sample.fraction = 0.632)
-	split.frequencies = split_frequencies(qrf, 4)
-	expect_true(split.frequencies[1,i]/sum(split.frequencies[1,]) > 1/2)
+    qrf = quantile_forest(X, Y, quantiles = c(0.1, 0.5, 0.9), mtry = p, min.node.size = 10, sample.fraction = 0.632)
+    split.frequencies = split_frequencies(qrf, 4)
+    expect_true(split.frequencies[1,i]/sum(split.frequencies[1,]) > 1/2)
 })
 
 test_that("quantile forests with regression splitting are identical to regression forests", {
-	p = 10
-	n = 500
-	i = 5
-	X = matrix(2 * runif(n * p) - 1, n, p)
-	Y = rnorm(n) * (1 + 100 * (X[,i] > 0))
+    p = 10
+    n = 500
+    i = 5
+    X = matrix(2 * runif(n * p) - 1, n, p)
+    Y = rnorm(n) * (1 + 100 * (X[,i] > 0))
 
-	set.seed(1234)
-	qrf = quantile_forest(X, Y, quantiles = c(0.1, 0.5, 0.9), regression.splitting = TRUE,
-						  mtry = p, min.node.size = 10, sample.fraction = 0.632)
+    set.seed(1234)
+    qrf = quantile_forest(X, Y, quantiles = c(0.1, 0.5, 0.9), regression.splitting = TRUE,
+                          mtry = p, min.node.size = 10, sample.fraction = 0.632)
 
-	set.seed(1234)
-	rrf = regression_forest(X, Y, mtry = p, min.node.size = 10, sample.fraction = 0.632, ci.group.size = 1)
+    set.seed(1234)
+    rrf = regression_forest(X, Y, mtry = p, min.node.size = 10, sample.fraction = 0.632, ci.group.size = 1)
 
-	qrf.split.frequencies = split_frequencies(qrf, 4)
-	rrf.split.frequencies = split_frequencies(rrf, 4)
-	expect_equal(qrf.split.frequencies, rrf.split.frequencies)
+    qrf.split.frequencies = split_frequencies(qrf, 4)
+    rrf.split.frequencies = split_frequencies(rrf, 4)
+    expect_equal(qrf.split.frequencies, rrf.split.frequencies)
 })
 
 test_that("quantile forest predictions are positive given positive outcomes", {
-	p = 10
-	n = 500
-	i = 5
-	X = matrix(2 * runif(n * p) - 1, n, p)
-	X.new = matrix(2 * runif(n * p) - 1, n, p)
-	Y = runif(n) + 100 * (X[,i] > 0)
+    p = 10
+    n = 500
+    i = 5
+    X = matrix(2 * runif(n * p) - 1, n, p)
+    X.new = matrix(2 * runif(n * p) - 1, n, p)
+    Y = runif(n) + 100 * (X[,i] > 0)
 
-	qrf = quantile_forest(X, Y, quantiles = c(0.1, 0.5, 0.9), mtry = p, min.node.size = 10, sample.fraction = 0.632)
-	expect_true(all(predict(qrf) > 0))
-	expect_true(all(predict(qrf, X.new) > 0))
+    qrf = quantile_forest(X, Y, quantiles = c(0.1, 0.5, 0.9), mtry = p, min.node.size = 10, sample.fraction = 0.632)
+    expect_true(all(predict(qrf) > 0))
+    expect_true(all(predict(qrf, X.new) > 0))
 })
 
 test_that("quantile forest predictions for 90th percentile are strongly positively correlated
-					 with covariate strongly positively correlated with Y", {
-	p = 10
-	n = 500
-	i = 5
-	X = matrix(2 * runif(n * p) - 1, n, p)
-	X.new = matrix(2 * runif(n * p) - 1, n, p)
-	Y = runif(n) + 100 * (X[,i] > 0)
+                     with covariate strongly positively correlated with Y", {
+    p = 10
+    n = 500
+    i = 5
+    X = matrix(2 * runif(n * p) - 1, n, p)
+    X.new = matrix(2 * runif(n * p) - 1, n, p)
+    Y = runif(n) + 100 * (X[,i] > 0)
 
-	qrf = quantile_forest(X, Y, quantiles = c(0.1, 0.5, 0.9), mtry = p, min.node.size = 10, sample.fraction = 0.632)
+    qrf = quantile_forest(X, Y, quantiles = c(0.1, 0.5, 0.9), mtry = p, min.node.size = 10, sample.fraction = 0.632)
   expect_true(cor(predict(qrf, quantiles=.9), X[,i]) > .5)
-	expect_true(cor(predict(qrf, X.new, quantiles=.9), X.new[,i])  > .5)
+    expect_true(cor(predict(qrf, X.new, quantiles=.9), X.new[,i])  > .5)
 })


### PR DESCRIPTION
Fixes two issues with quantile forest introduced with the Data/Observations rewrite in commit 996f3b3fd4d89761b7b9ed6b0da31dbbba6895ac.
1. Nondeterministic junk output from predict caused by
    a. bindings failing to subtract 1 from outcome_index to go from R to C indexing conventions
    b. R code passing [X, null] = X rather than [X, Y] to the C code 
2. predict(forest) giving an error, caused by disagreement between R and C code on argument order.

Closes #387.