### PR TITLE
Fix the package build.

### DIFF
--- a/core/src/prediction/Prediction.h
+++ b/core/src/prediction/Prediction.h
@@ -35,7 +35,6 @@ public:
   const std::vector<double>& get_error_estimates() const;
   const std::vector<double>& get_excess_error_estimates() const;
   const bool contains_variance_estimates() const;
-  const bool contains_excess_error_estimates() const;
   const bool contains_error_estimates() const;
   const size_t size() const;
 

--- a/r-package/grf/bindings/RcppUtilities.cpp
+++ b/r-package/grf/bindings/RcppUtilities.cpp
@@ -134,7 +134,7 @@ Rcpp::NumericMatrix RcppUtilities::create_excess_error_matrix(const std::vector<
   }
 
   Prediction first_prediction = predictions.at(0);
-  if (!first_prediction.contains_excess_error_estimates()) {
+  if (!first_prediction.contains_error_estimates()) {
     return Rcpp::NumericMatrix(0);
   }
 


### PR DESCRIPTION
This commit removes references to `Prediction#contains_excess_error_estimates`,
which were accidentally committed in #327 even though the method was refactored
away.