### PR TITLE
Make DiagrammeR a suggested dependency.

### DIFF
--- a/r-package/grf/DESCRIPTION
+++ b/r-package/grf/DESCRIPTION
@@ -20,7 +20,6 @@ Depends:
 License: GPL-3
 LinkingTo: Rcpp, RcppEigen
 Imports:
-    DiagrammeR,
     DiceKriging,
     lmtest,
     Matrix,
@@ -29,6 +28,7 @@ Imports:
     sandwich (>= 2.4-0)
 RoxygenNote: 6.1.1
 Suggests:
+    DiagrammeR,
     testthat
 SystemRequirements: GNU make
 URL: https://github.com/grf-labs/grf

--- a/r-package/grf/R/plot.R
+++ b/r-package/grf/R/plot.R
@@ -79,7 +79,11 @@ export_graphviz <- function(tree){
 #'
 #' @method plot grf_tree
 #' @export
-plot.grf_tree <- function(x, ...){
+plot.grf_tree <- function(x, ...) {
+  if (!requireNamespace("DiagrammeR", quietly = TRUE)) {
+    stop("Package \"DiagrammeR\" must be installed to plot trees.")
+  }
+
   dot_file <- export_graphviz(x)
   DiagrammeR::grViz(dot_file)
 }


### PR DESCRIPTION
The DiagrammeR package is quite large and can be expensive to install from
source. Since it is only used when plotting trees, it can be demoted to
'Suggests' as opposed to 'Imports'.