### PR TITLE
Avoid extra round-trip when precomputing OOB predictions.

### DIFF
--- a/r-package/grf/R/RcppExports.R
+++ b/r-package/grf/R/RcppExports.R
@@ -37,8 +37,8 @@ ll_causal_predict_oob <- function(forest, input_data, sparse_input_data, outcome
     .Call('_grf_ll_causal_predict_oob', PACKAGE = 'grf', forest, input_data, sparse_input_data, outcome_index, treatment_index, instrument_index, lambdas, use_unweighted_penalty, linear_correction_variables, num_threads)
 }
 
-custom_train <- function(train_matrix, sparse_train_matrix, outcome_index, mtry, num_trees, num_threads, min_node_size, sample_fraction, seed, honesty, honesty_fraction, ci_group_size, alpha, imbalance_penalty, compute_oob_predictions, clusters, samples_per_cluster) {
-    .Call('_grf_custom_train', PACKAGE = 'grf', train_matrix, sparse_train_matrix, outcome_index, mtry, num_trees, num_threads, min_node_size, sample_fraction, seed, honesty, honesty_fraction, ci_group_size, alpha, imbalance_penalty, compute_oob_predictions, clusters, samples_per_cluster)
+custom_train <- function(train_matrix, sparse_train_matrix, outcome_index, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed) {
+    .Call('_grf_custom_train', PACKAGE = 'grf', train_matrix, sparse_train_matrix, outcome_index, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed)
 }
 
 custom_predict <- function(forest_object, train_matrix, sparse_train_matrix, outcome_index, test_matrix, sparse_test_matrix, num_threads) {
@@ -49,8 +49,8 @@ custom_predict_oob <- function(forest_object, train_matrix, sparse_train_matrix,
     .Call('_grf_custom_predict_oob', PACKAGE = 'grf', forest_object, train_matrix, sparse_train_matrix, outcome_index, num_threads)
 }
 
-instrumental_train <- function(train_matrix, sparse_train_matrix, outcome_index, treatment_index, instrument_index, mtry, num_trees, num_threads, min_node_size, sample_fraction, seed, honesty, honesty_fraction, ci_group_size, reduced_form_weight, alpha, imbalance_penalty, stabilize_splits, compute_oob_predictions, clusters, samples_per_cluster) {
-    .Call('_grf_instrumental_train', PACKAGE = 'grf', train_matrix, sparse_train_matrix, outcome_index, treatment_index, instrument_index, mtry, num_trees, num_threads, min_node_size, sample_fraction, seed, honesty, honesty_fraction, ci_group_size, reduced_form_weight, alpha, imbalance_penalty, stabilize_splits, compute_oob_predictions, clusters, samples_per_cluster)
+instrumental_train <- function(train_matrix, sparse_train_matrix, outcome_index, treatment_index, instrument_index, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, ci_group_size, reduced_form_weight, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed) {
+    .Call('_grf_instrumental_train', PACKAGE = 'grf', train_matrix, sparse_train_matrix, outcome_index, treatment_index, instrument_index, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, ci_group_size, reduced_form_weight, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed)
 }
 
 instrumental_predict <- function(forest_object, train_matrix, sparse_train_matrix, outcome_index, treatment_index, instrument_index, test_matrix, sparse_test_matrix, num_threads, estimate_variance) {
@@ -61,8 +61,8 @@ instrumental_predict_oob <- function(forest_object, train_matrix, sparse_train_m
     .Call('_grf_instrumental_predict_oob', PACKAGE = 'grf', forest_object, train_matrix, sparse_train_matrix, outcome_index, treatment_index, instrument_index, num_threads, estimate_variance)
 }
 
-quantile_train <- function(quantiles, regression_splits, train_matrix, sparse_train_matrix, outcome_index, mtry, num_trees, num_threads, min_node_size, sample_fraction, seed, honesty, honesty_fraction, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster) {
-    .Call('_grf_quantile_train', PACKAGE = 'grf', quantiles, regression_splits, train_matrix, sparse_train_matrix, outcome_index, mtry, num_trees, num_threads, min_node_size, sample_fraction, seed, honesty, honesty_fraction, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster)
+quantile_train <- function(quantiles, regression_splits, train_matrix, sparse_train_matrix, outcome_index, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, num_threads, seed) {
+    .Call('_grf_quantile_train', PACKAGE = 'grf', quantiles, regression_splits, train_matrix, sparse_train_matrix, outcome_index, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, num_threads, seed)
 }
 
 quantile_predict <- function(forest_object, quantiles, train_matrix, sparse_train_matrix, outcome_index, test_matrix, sparse_test_matrix, num_threads) {
@@ -73,8 +73,8 @@ quantile_predict_oob <- function(forest_object, quantiles, train_matrix, sparse_
     .Call('_grf_quantile_predict_oob', PACKAGE = 'grf', forest_object, quantiles, train_matrix, sparse_train_matrix, outcome_index, num_threads)
 }
 
-regression_train <- function(train_matrix, sparse_train_matrix, outcome_index, sample_weight_index, use_sample_weights, mtry, num_trees, num_threads, min_node_size, sample_fraction, seed, honesty, honesty_fraction, ci_group_size, alpha, imbalance_penalty, compute_oob_predictions, clusters, samples_per_cluster) {
-    .Call('_grf_regression_train', PACKAGE = 'grf', train_matrix, sparse_train_matrix, outcome_index, sample_weight_index, use_sample_weights, mtry, num_trees, num_threads, min_node_size, sample_fraction, seed, honesty, honesty_fraction, ci_group_size, alpha, imbalance_penalty, compute_oob_predictions, clusters, samples_per_cluster)
+regression_train <- function(train_matrix, sparse_train_matrix, outcome_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed) {
+    .Call('_grf_regression_train', PACKAGE = 'grf', train_matrix, sparse_train_matrix, outcome_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed)
 }
 
 regression_predict <- function(forest_object, train_matrix, sparse_train_matrix, outcome_index, test_matrix, sparse_test_matrix, num_threads, estimate_variance) {

--- a/r-package/grf/R/RcppExports.R
+++ b/r-package/grf/R/RcppExports.R
@@ -73,8 +73,8 @@ quantile_predict_oob <- function(forest_object, quantiles, train_matrix, sparse_
     .Call('_grf_quantile_predict_oob', PACKAGE = 'grf', forest_object, quantiles, train_matrix, sparse_train_matrix, outcome_index, num_threads)
 }
 
-regression_train <- function(train_matrix, sparse_train_matrix, outcome_index, sample_weight_index, use_sample_weights, mtry, num_trees, num_threads, min_node_size, sample_fraction, seed, honesty, honesty_fraction, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster) {
-    .Call('_grf_regression_train', PACKAGE = 'grf', train_matrix, sparse_train_matrix, outcome_index, sample_weight_index, use_sample_weights, mtry, num_trees, num_threads, min_node_size, sample_fraction, seed, honesty, honesty_fraction, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster)
+regression_train <- function(train_matrix, sparse_train_matrix, outcome_index, sample_weight_index, use_sample_weights, mtry, num_trees, num_threads, min_node_size, sample_fraction, seed, honesty, honesty_fraction, ci_group_size, alpha, imbalance_penalty, compute_oob_predictions, clusters, samples_per_cluster) {
+    .Call('_grf_regression_train', PACKAGE = 'grf', train_matrix, sparse_train_matrix, outcome_index, sample_weight_index, use_sample_weights, mtry, num_trees, num_threads, min_node_size, sample_fraction, seed, honesty, honesty_fraction, ci_group_size, alpha, imbalance_penalty, compute_oob_predictions, clusters, samples_per_cluster)
 }
 
 regression_predict <- function(forest_object, train_matrix, sparse_train_matrix, outcome_index, test_matrix, sparse_test_matrix, num_threads, estimate_variance) {

--- a/r-package/grf/R/RcppExports.R
+++ b/r-package/grf/R/RcppExports.R
@@ -49,8 +49,8 @@ custom_predict_oob <- function(forest_object, train_matrix, sparse_train_matrix,
     .Call('_grf_custom_predict_oob', PACKAGE = 'grf', forest_object, train_matrix, sparse_train_matrix, outcome_index, num_threads)
 }
 
-instrumental_train <- function(train_matrix, sparse_train_matrix, outcome_index, treatment_index, instrument_index, mtry, num_trees, num_threads, min_node_size, sample_fraction, seed, honesty, honesty_fraction, ci_group_size, reduced_form_weight, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster) {
-    .Call('_grf_instrumental_train', PACKAGE = 'grf', train_matrix, sparse_train_matrix, outcome_index, treatment_index, instrument_index, mtry, num_trees, num_threads, min_node_size, sample_fraction, seed, honesty, honesty_fraction, ci_group_size, reduced_form_weight, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster)
+instrumental_train <- function(train_matrix, sparse_train_matrix, outcome_index, treatment_index, instrument_index, mtry, num_trees, num_threads, min_node_size, sample_fraction, seed, honesty, honesty_fraction, ci_group_size, reduced_form_weight, alpha, imbalance_penalty, stabilize_splits, compute_oob_predictions, clusters, samples_per_cluster) {
+    .Call('_grf_instrumental_train', PACKAGE = 'grf', train_matrix, sparse_train_matrix, outcome_index, treatment_index, instrument_index, mtry, num_trees, num_threads, min_node_size, sample_fraction, seed, honesty, honesty_fraction, ci_group_size, reduced_form_weight, alpha, imbalance_penalty, stabilize_splits, compute_oob_predictions, clusters, samples_per_cluster)
 }
 
 instrumental_predict <- function(forest_object, train_matrix, sparse_train_matrix, outcome_index, treatment_index, instrument_index, test_matrix, sparse_test_matrix, num_threads, estimate_variance) {

--- a/r-package/grf/R/RcppExports.R
+++ b/r-package/grf/R/RcppExports.R
@@ -37,8 +37,8 @@ ll_causal_predict_oob <- function(forest, input_data, sparse_input_data, outcome
     .Call('_grf_ll_causal_predict_oob', PACKAGE = 'grf', forest, input_data, sparse_input_data, outcome_index, treatment_index, instrument_index, lambdas, use_unweighted_penalty, linear_correction_variables, num_threads)
 }
 
-custom_train <- function(train_matrix, sparse_train_matrix, outcome_index, mtry, num_trees, num_threads, min_node_size, sample_fraction, seed, honesty, honesty_fraction, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster) {
-    .Call('_grf_custom_train', PACKAGE = 'grf', train_matrix, sparse_train_matrix, outcome_index, mtry, num_trees, num_threads, min_node_size, sample_fraction, seed, honesty, honesty_fraction, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster)
+custom_train <- function(train_matrix, sparse_train_matrix, outcome_index, mtry, num_trees, num_threads, min_node_size, sample_fraction, seed, honesty, honesty_fraction, ci_group_size, alpha, imbalance_penalty, compute_oob_predictions, clusters, samples_per_cluster) {
+    .Call('_grf_custom_train', PACKAGE = 'grf', train_matrix, sparse_train_matrix, outcome_index, mtry, num_trees, num_threads, min_node_size, sample_fraction, seed, honesty, honesty_fraction, ci_group_size, alpha, imbalance_penalty, compute_oob_predictions, clusters, samples_per_cluster)
 }
 
 custom_predict <- function(forest_object, train_matrix, sparse_train_matrix, outcome_index, test_matrix, sparse_test_matrix, num_threads) {

--- a/r-package/grf/R/causal_forest.R
+++ b/r-package/grf/R/causal_forest.R
@@ -25,8 +25,6 @@
 #' @param num.trees Number of trees grown in the forest. Note: Getting accurate
 #'                  confidence intervals generally requires more trees than
 #'                  getting accurate predictions.
-#' @param num.threads Number of threads used in training. If set to NULL, the software
-#'                    automatically selects an appropriate amount.
 #' @param min.node.size A target for the minimum number of observations in each tree leaf. Note that nodes
 #'                      with size smaller than min.node.size can occur, as in the original randomForest package.
 #' @param honesty Whether to use honest splitting (i.e., sub-sample splitting).
@@ -40,8 +38,6 @@
 #' @param imbalance.penalty A tuning parameter that controls how harshly imbalanced splits are penalized.
 #' @param stabilize.splits Whether or not the treatment should be taken into account when
 #'                         determining the imbalance of a split (experimental).
-#' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed.
-#' @param seed The seed of the C++ random number generator.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
 #' @param samples_per_cluster If sampling by cluster, the number of observations to be sampled from
 #'                            each cluster when training a tree. If NULL, we set samples_per_cluster to the size
@@ -57,6 +53,10 @@
 #' @param num.fit.reps The number of forests used to fit the tuning model.
 #' @param num.optimize.reps The number of random parameter values considered when using the model
 #'                          to select the optimal parameters.
+#' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed.
+#' @param num.threads Number of threads used in training. By default, the number of threads is set
+#'                    to the maximum hardware concurrency.
+#' @param seed The seed of the C++ random number generator.
 #'
 #' @return A trained causal forest object.
 #'
@@ -116,7 +116,6 @@ causal_forest <- function(X, Y, W,
                           sample.fraction = 0.5,
                           mtry = NULL,
                           num.trees = 2000,
-                          num.threads = NULL,
                           min.node.size = NULL,
                           honesty = TRUE,
                           honesty.fraction = NULL,
@@ -124,14 +123,15 @@ causal_forest <- function(X, Y, W,
                           alpha = NULL,
                           imbalance.penalty = NULL,
                           stabilize.splits = TRUE,
-                          compute.oob.predictions = TRUE,
-                          seed = NULL,
                           clusters = NULL,
                           samples_per_cluster = NULL,
                           tune.parameters = FALSE,
                           num.fit.trees = 200,
                           num.fit.reps = 50,
-                          num.optimize.reps = 1000) {
+                          num.optimize.reps = 1000,
+                          compute.oob.predictions = TRUE,
+                          num.threads = NULL,
+                          seed = NULL) {
     validate_X(X)
 
     validate_observations(list(Y,W), X)
@@ -207,10 +207,8 @@ causal_forest <- function(X, Y, W,
                                  outcome.index, treatment.index, instrument.index,
                                  as.numeric(tunable.params["mtry"]),
                                  num.trees,
-                                 num.threads,
                                  as.numeric(tunable.params["min.node.size"]),
                                  as.numeric(tunable.params["sample.fraction"]),
-                                 seed,
                                  honesty,
                                  coerce_honesty_fraction(honesty.fraction),
                                  ci.group.size,
@@ -218,9 +216,11 @@ causal_forest <- function(X, Y, W,
                                  as.numeric(tunable.params["alpha"]),
                                  as.numeric(tunable.params["imbalance.penalty"]),
                                  stabilize.splits,
-                                 compute.oob.predictions,
                                  clusters,
-                                 samples_per_cluster)
+                                 samples_per_cluster,
+                                 compute.oob.predictions,
+                                 num.threads,
+                                 seed)
 
     class(forest) <- c("causal_forest", "grf")
     forest[["ci.group.size"]] <- ci.group.size

--- a/r-package/grf/R/causal_forest.R
+++ b/r-package/grf/R/causal_forest.R
@@ -218,9 +218,11 @@ causal_forest <- function(X, Y, W,
                                  as.numeric(tunable.params["alpha"]),
                                  as.numeric(tunable.params["imbalance.penalty"]),
                                  stabilize.splits,
+                                 compute.oob.predictions,
                                  clusters,
                                  samples_per_cluster)
 
+    class(forest) <- c("causal_forest", "grf")
     forest[["ci.group.size"]] <- ci.group.size
     forest[["X.orig"]] <- X
     forest[["Y.orig"]] <- Y
@@ -229,16 +231,6 @@ causal_forest <- function(X, Y, W,
     forest[["W.hat"]] <- W.hat
     forest[["clusters"]] <- clusters
     forest[["tunable.params"]] <- tunable.params
-
-    class(forest) <- c("causal_forest", "grf")
-
-    if (compute.oob.predictions) {
-        oob.pred <- predict(forest)
-        forest[["predictions"]] <- oob.pred$predictions
-        forest[["debiased.error"]] <- oob.pred$debiased.error
-        forest[["excess.error"]] <- oob.pred$excess.error
-    }
-
     forest
 }
 

--- a/r-package/grf/R/causal_tuning.R
+++ b/r-package/grf/R/causal_tuning.R
@@ -111,6 +111,7 @@ tune_causal_forest <- function(X, Y, W, Y.hat, W.hat,
   num.params = length(tuning.params)
   fit.draws = matrix(runif(num.fit.reps * num.params), num.fit.reps, num.params)
   colnames(fit.draws) = names(tuning.params)
+  compute.oob.predictions = TRUE
 
   debiased.errors = apply(fit.draws, 1, function(draw) {
     params = c(fixed.params, get_params_from_draw(X, draw))
@@ -129,6 +130,7 @@ tune_causal_forest <- function(X, Y, W, Y.hat, W.hat,
                                        as.numeric(params["alpha"]),
                                        as.numeric(params["imbalance.penalty"]),
                                        stabilize.splits,
+                                       compute.oob.predictions,
                                        clusters,
                                        samples_per_cluster)
     prediction = instrumental_predict_oob(small.forest, data$default, data$sparse,

--- a/r-package/grf/R/custom_forest.R
+++ b/r-package/grf/R/custom_forest.R
@@ -21,6 +21,7 @@
 #'                         honesty.fraction = NULL), half of the data will be used for determining splits
 #' @param alpha A tuning parameter that controls the maximum imbalance of a split.
 #' @param imbalance.penalty A tuning parameter that controls how harshly imbalanced splits are penalized.
+#' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed. Defaults to FALSE.
 #' @param seed The seed for the C++ random number generator.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
 #' @param samples_per_cluster If sampling by cluster, the number of observations to be sampled from
@@ -48,10 +49,20 @@
 #' }
 #'
 #' @export
-custom_forest <- function(X, Y, sample.fraction = 0.5, mtry = NULL, 
-    num.trees = 2000, num.threads = NULL, min.node.size = NULL, honesty = TRUE,
-    honesty.fraction = NULL, alpha = 0.05, imbalance.penalty = 0.0, seed = NULL,
-    clusters = NULL, samples_per_cluster = NULL) {
+custom_forest <- function(X, Y,
+                          sample.fraction = 0.5,
+                          mtry = NULL, 
+                          num.trees = 2000,
+                          num.threads = NULL,
+                          min.node.size = NULL,
+                          honesty = TRUE,
+                          honesty.fraction = NULL,
+                          alpha = 0.05,
+                          imbalance.penalty = 0.0,
+                          compute.oob.predictions = FALSE,
+                          seed = NULL,
+                          clusters = NULL,
+                          samples_per_cluster = NULL) {
 
     validate_X(X)
     validate_observations(Y, X)
@@ -73,12 +84,11 @@ custom_forest <- function(X, Y, sample.fraction = 0.5, mtry = NULL,
 
     forest <- custom_train(data$default, data$sparse, outcome.index, mtry,num.trees, num.threads,
         min.node.size, sample.fraction, seed, honesty, coerce_honesty_fraction(honesty.fraction),
-        ci.group.size, alpha, imbalance.penalty, clusters, samples_per_cluster)
+        ci.group.size, alpha, imbalance.penalty, compute.oob.predictions, clusters, samples_per_cluster)
     
+    class(forest) <- c("custom_forest", "grf")
     forest[["X.orig"]] <- X
     forest[["Y.orig"]] <- Y
-
-    class(forest) <- c("custom_forest", "grf")
     forest
 }
 

--- a/r-package/grf/R/custom_forest.R
+++ b/r-package/grf/R/custom_forest.R
@@ -11,8 +11,6 @@
 #' @param num.trees Number of trees grown in the forest. Note: Getting accurate
 #'                  confidence intervals generally requires more trees than
 #'                  getting accurate predictions.
-#' @param num.threads Number of threads used in training. If set to NULL, the software
-#'                    automatically selects an appropriate amount.
 #' @param min.node.size A target for the minimum number of observations in each tree leaf. Note that nodes
 #'                      with size smaller than min.node.size can occur, as in the original randomForest package.
 #' @param honesty Whether to use honest splitting (i.e., sub-sample splitting).
@@ -21,8 +19,6 @@
 #'                         honesty.fraction = NULL), half of the data will be used for determining splits
 #' @param alpha A tuning parameter that controls the maximum imbalance of a split.
 #' @param imbalance.penalty A tuning parameter that controls how harshly imbalanced splits are penalized.
-#' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed. Defaults to FALSE.
-#' @param seed The seed for the C++ random number generator.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
 #' @param samples_per_cluster If sampling by cluster, the number of observations to be sampled from
 #'                            each cluster when training a tree. If NULL, we set samples_per_cluster to the size
@@ -32,6 +28,10 @@
 #'                            smaller weight than others in training the forest, i.e., the contribution
 #'                            of a given cluster to the final forest scales with the minimum of
 #'                            the number of observations in the cluster and samples_per_cluster.
+#' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed.
+#' @param num.threads Number of threads used in training. By default, the number of threads is set
+#'                    to the maximum hardware concurrency
+#' @param seed The seed of the C++ random number generator.
 #'
 #' @return A trained regression forest object.
 #'
@@ -53,16 +53,16 @@ custom_forest <- function(X, Y,
                           sample.fraction = 0.5,
                           mtry = NULL, 
                           num.trees = 2000,
-                          num.threads = NULL,
                           min.node.size = NULL,
                           honesty = TRUE,
                           honesty.fraction = NULL,
                           alpha = 0.05,
                           imbalance.penalty = 0.0,
-                          compute.oob.predictions = FALSE,
-                          seed = NULL,
                           clusters = NULL,
-                          samples_per_cluster = NULL) {
+                          samples_per_cluster = NULL,
+                          compute.oob.predictions = TRUE,
+                          num.threads = NULL,
+                          seed = NULL) {
 
     validate_X(X)
     validate_observations(Y, X)
@@ -82,9 +82,9 @@ custom_forest <- function(X, Y,
     outcome.index <- ncol(X) + 1
     ci.group.size <- 1
 
-    forest <- custom_train(data$default, data$sparse, outcome.index, mtry,num.trees, num.threads,
-        min.node.size, sample.fraction, seed, honesty, coerce_honesty_fraction(honesty.fraction),
-        ci.group.size, alpha, imbalance.penalty, compute.oob.predictions, clusters, samples_per_cluster)
+    forest <- custom_train(data$default, data$sparse, outcome.index, mtry,num.trees, min.node.size,
+        sample.fraction,  honesty, coerce_honesty_fraction(honesty.fraction), ci.group.size, alpha,
+        imbalance.penalty, clusters, samples_per_cluster, num.threads, compute.oob.predictions, seed)
     
     class(forest) <- c("custom_forest", "grf")
     forest[["X.orig"]] <- X

--- a/r-package/grf/R/instrumental_forest.R
+++ b/r-package/grf/R/instrumental_forest.R
@@ -138,8 +138,10 @@ instrumental_forest <- function(X, Y, W, Z,
     forest <- instrumental_train(data$default, data$sparse, outcome.index, treatment.index,
         instrument.index, mtry, num.trees, num.threads, min.node.size, sample.fraction, seed, honesty,
         coerce_honesty_fraction(honesty.fraction), ci.group.size, reduced.form.weight, alpha, 
-        imbalance.penalty, stabilize.splits, clusters, samples_per_cluster)
+        imbalance.penalty, stabilize.splits, compute.oob.predictions, clusters, samples_per_cluster)
 
+
+    class(forest) <- c("instrumental_forest", "grf")
     forest[["ci.group.size"]] <- ci.group.size
     forest[["X.orig"]] <- X
     forest[["Y.orig"]] <- Y
@@ -149,15 +151,6 @@ instrumental_forest <- function(X, Y, W, Z,
     forest[["W.hat"]] <- W.hat
     forest[["Z.hat"]] <- Z.hat
     forest[["clusters"]] <- clusters
-
-    class(forest) <- c("instrumental_forest", "grf")
-
-    if (compute.oob.predictions) {
-        oob.pred <- predict(forest)
-        forest[["predictions"]] <- oob.pred$predictions
-        forest[["debiased.error"]] <- oob.pred$debiased.error
-    }
-
     forest
 }
 

--- a/r-package/grf/R/local_linear_forest.R
+++ b/r-package/grf/R/local_linear_forest.R
@@ -12,8 +12,6 @@
 #' @param num.trees Number of trees grown in the forest. Note: Getting accurate
 #'                  confidence intervals generally requires more trees than
 #'                  getting accurate predictions.
-#' @param num.threads Number of threads used in training. If set to NULL, the software
-#'                    automatically selects an appropriate amount.
 #' @param min.node.size A target for the minimum number of observations in each tree leaf. Note that nodes
 #'                      with size smaller than min.node.size can occur, as in the original randomForest package.
 #' @param honesty Whether or not honest splitting (i.e., sub-sample splitting) should be used.
@@ -25,8 +23,6 @@
 #'                      be at least 2.
 #' @param alpha A tuning parameter that controls the maximum imbalance of a split.
 #' @param imbalance.penalty A tuning parameter that controls how harshly imbalanced splits are penalized.
-#' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed.
-#' @param seed The seed for the C++ random number generator.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
 #' @param samples_per_cluster If sampling by cluster, the number of observations to be sampled from
 #'                            each cluster when training a tree. If NULL, we set samples_per_cluster to the size
@@ -42,6 +38,10 @@
 #' @param num.fit.reps The number of forests used to fit the tuning model.
 #' @param num.optimize.reps The number of random parameter values considered when using the model
 #'                          to select the optimal parameters.
+#' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed.
+#' @param num.threads Number of threads used in training. By default, the number of threads is set
+#'                    to the maximum hardware concurrency.
+#' @param seed The seed of the C++ random number generator.
 #'
 #' @return A trained local linear forest object.
 #'
@@ -58,21 +58,21 @@ ll_regression_forest <- function(X, Y,
                                 sample.fraction = 0.5,
                                 mtry = NULL,
                                 num.trees = 2000,
-                                num.threads = NULL,
                                 min.node.size = NULL,
                                 honesty = TRUE,
                                 honesty.fraction = NULL,
                                 ci.group.size = 1, 
                                 alpha = NULL,
                                 imbalance.penalty = NULL,
-                                compute.oob.predictions = FALSE,
-                                seed = NULL,
                                 clusters = NULL,
                                 samples_per_cluster = NULL,
                                 tune.parameters = FALSE,
                                 num.fit.trees = 10,
                                 num.fit.reps = 100,
-                                num.optimize.reps = 1000) {
+                                num.optimize.reps = 1000,
+                                compute.oob.predictions = FALSE,
+                                num.threads = NULL,
+                                seed = NULL) {
   validate_X(X)
   validate_observations(Y, X)
   
@@ -116,18 +116,18 @@ ll_regression_forest <- function(X, Y,
                              FALSE,
                              as.numeric(tunable.params["mtry"]),
                              num.trees,
-                             num.threads,
                              as.numeric(tunable.params["min.node.size"]),
                              as.numeric(tunable.params["sample.fraction"]),
-                             seed,
                              honesty,
                              coerce_honesty_fraction(honesty.fraction),
                              ci.group.size,
                              as.numeric(tunable.params["alpha"]),
                              as.numeric(tunable.params["imbalance.penalty"]),
-                             compute.oob.predictions,
                              clusters,
-                             samples_per_cluster)
+                             samples_per_cluster,
+                             compute.oob.predictions,
+                             num.threads,
+                             seed)
 
   class(forest) = c("ll_regression_forest", "grf")
   forest[["ci.group.size"]] <- ci.group.size

--- a/r-package/grf/R/local_linear_forest.R
+++ b/r-package/grf/R/local_linear_forest.R
@@ -125,24 +125,16 @@ ll_regression_forest <- function(X, Y,
                              ci.group.size,
                              as.numeric(tunable.params["alpha"]),
                              as.numeric(tunable.params["imbalance.penalty"]),
+                             compute.oob.predictions,
                              clusters,
                              samples_per_cluster)
 
+  class(forest) = c("ll_regression_forest", "grf")
   forest[["ci.group.size"]] <- ci.group.size
   forest[["X.orig"]] <- X
   forest[["Y.orig"]] <- Y
   forest[["clusters"]] <- clusters
   forest[["tunable.params"]] <- tunable.params
-
-  class(forest) <- c("regression_forest", "grf")
-
-  if (compute.oob.predictions) {
-    oob.pred <- predict(forest)
-    forest[["predictions"]] <- oob.pred$predictions
-    forest[["debiased.error"]] <- oob.pred$debiased.error
-  }
-
-  class(forest) = c("ll_regression_forest", "grf")
   forest
 }
 

--- a/r-package/grf/R/quantile_forest.R
+++ b/r-package/grf/R/quantile_forest.R
@@ -17,8 +17,6 @@
 #' @param num.trees Number of trees grown in the forest. Note: Getting accurate
 #'                  confidence intervals generally requires more trees than
 #'                  getting accurate predictions.
-#' @param num.threads Number of threads used in training. If set to NULL, the software
-#'                    automatically selects an appropriate amount.
 #' @param min.node.size A target for the minimum number of observations in each tree leaf. Note that nodes
 #'                      with size smaller than min.node.size can occur, as in the original randomForest package.
 #' @param honesty Whether to use honest splitting (i.e., sub-sample splitting).
@@ -27,7 +25,6 @@
 #'                         honesty.fraction = NULL), half of the data will be used for determining splits
 #' @param alpha A tuning parameter that controls the maximum imbalance of a split.
 #' @param imbalance.penalty A tuning parameter that controls how harshly imbalanced splits are penalized.
-#' @param seed The seed for the C++ random number generator.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
 #' @param samples_per_cluster If sampling by cluster, the number of observations to be sampled from
 #'                            each cluster when training a tree. If NULL, we set samples_per_cluster to the size
@@ -37,6 +34,9 @@
 #'                            smaller weight than others in training the forest, i.e., the contribution
 #'                            of a given cluster to the final forest scales with the minimum of
 #'                            the number of observations in the cluster and samples_per_cluster.
+#' @param num.threads Number of threads used in training. By default, the number of threads is set
+#'                    to the maximum hardware concurrency.
+#' @param seed The seed of the C++ random number generator.
 #'
 #' @return A trained quantile forest object.
 #'
@@ -72,15 +72,15 @@ quantile_forest <- function(X, Y,
                             sample.fraction = 0.5,
                             mtry = NULL,
                             num.trees = 2000,
-                            num.threads = NULL,
                             min.node.size = NULL,
                             honesty = TRUE,
                             honesty.fraction = NULL,
                             alpha = 0.05,
                             imbalance.penalty = 0.0, 
-                            seed = NULL,
                             clusters = NULL,
-                            samples_per_cluster = NULL) {
+                            samples_per_cluster = NULL,
+                            num.threads = NULL,
+                            seed = NULL) {
     if (!is.numeric(quantiles) | length(quantiles) < 1) {
         stop("Error: Must provide numeric quantiles")
     } else if (min(quantiles) <= 0 | max(quantiles) >= 1) {
@@ -105,8 +105,8 @@ quantile_forest <- function(X, Y,
     ci.group.size <- 1
     
     forest <- quantile_train(quantiles, regression.splitting, data$default, data$sparse, outcome.index, mtry, 
-        num.trees, num.threads, min.node.size, sample.fraction, seed, honesty, coerce_honesty_fraction(honesty.fraction), 
-        ci.group.size, alpha, imbalance.penalty, clusters, samples_per_cluster)
+        num.trees, min.node.size, sample.fraction, honesty, coerce_honesty_fraction(honesty.fraction), ci.group.size,
+        alpha, imbalance.penalty, clusters, samples_per_cluster, num.threads, seed)
     
     class(forest) <- c("quantile_forest", "grf")
     forest[["X.orig"]] <- X

--- a/r-package/grf/R/quantile_forest.R
+++ b/r-package/grf/R/quantile_forest.R
@@ -66,11 +66,21 @@
 #' }
 #' 
 #' @export
-quantile_forest <- function(X, Y, quantiles = c(0.1, 0.5, 0.9), regression.splitting = FALSE,
-                            sample.fraction = 0.5, mtry = NULL, num.trees = 2000,
-                            num.threads = NULL, min.node.size = NULL, honesty = TRUE,
-                            honesty.fraction = NULL, alpha = 0.05, imbalance.penalty = 0.0, 
-                            seed = NULL, clusters = NULL, samples_per_cluster = NULL) {
+quantile_forest <- function(X, Y,
+                            quantiles = c(0.1, 0.5, 0.9),
+                            regression.splitting = FALSE,
+                            sample.fraction = 0.5,
+                            mtry = NULL,
+                            num.trees = 2000,
+                            num.threads = NULL,
+                            min.node.size = NULL,
+                            honesty = TRUE,
+                            honesty.fraction = NULL,
+                            alpha = 0.05,
+                            imbalance.penalty = 0.0, 
+                            seed = NULL,
+                            clusters = NULL,
+                            samples_per_cluster = NULL) {
     if (!is.numeric(quantiles) | length(quantiles) < 1) {
         stop("Error: Must provide numeric quantiles")
     } else if (min(quantiles) <= 0 | max(quantiles) >= 1) {
@@ -98,11 +108,10 @@ quantile_forest <- function(X, Y, quantiles = c(0.1, 0.5, 0.9), regression.split
         num.trees, num.threads, min.node.size, sample.fraction, seed, honesty, coerce_honesty_fraction(honesty.fraction), 
         ci.group.size, alpha, imbalance.penalty, clusters, samples_per_cluster)
     
+    class(forest) <- c("quantile_forest", "grf")
     forest[["X.orig"]] <- X
     forest[["Y.orig"]] <- Y
     forest[["clusters"]] <- clusters
-    
-    class(forest) <- c("quantile_forest", "grf")
     forest
 }
 

--- a/r-package/grf/R/regression_forest.R
+++ b/r-package/grf/R/regression_forest.R
@@ -138,25 +138,17 @@ regression_forest <- function(X, Y,
                                ci.group.size,
                                as.numeric(tunable.params["alpha"]),
                                as.numeric(tunable.params["imbalance.penalty"]),
+                               compute.oob.predictions,
                                clusters,
                                samples_per_cluster)
 
+    class(forest) <- c("regression_forest", "grf")
     forest[["ci.group.size"]] <- ci.group.size
     forest[["X.orig"]] <- X
     forest[["Y.orig"]] <- Y
     forest[["sample.weights"]] <- sample.weights
     forest[["clusters"]] <- clusters
     forest[["tunable.params"]] <- tunable.params
-
-    class(forest) <- c("regression_forest", "grf")
-
-    if (compute.oob.predictions) {
-        oob.pred <- predict(forest)
-        forest[["predictions"]] <- oob.pred$predictions
-        forest[["debiased.error"]] <- oob.pred$debiased.error
-        forest[["excess.error"]] <- oob.pred$excess.error
-    }
-
     forest
 }
 

--- a/r-package/grf/R/regression_forest.R
+++ b/r-package/grf/R/regression_forest.R
@@ -12,8 +12,6 @@
 #' @param num.trees Number of trees grown in the forest. Note: Getting accurate
 #'                  confidence intervals generally requires more trees than
 #'                  getting accurate predictions.
-#' @param num.threads Number of threads used in training. If set to NULL, the software
-#'                    automatically selects an appropriate amount.
 #' @param min.node.size A target for the minimum number of observations in each tree leaf. Note that nodes
 #'                      with size smaller than min.node.size can occur, as in the original randomForest package.
 #' @param honesty Whether to use honest splitting (i.e., sub-sample splitting).
@@ -25,8 +23,6 @@
 #'                      be at least 2.
 #' @param alpha A tuning parameter that controls the maximum imbalance of a split.
 #' @param imbalance.penalty A tuning parameter that controls how harshly imbalanced splits are penalized.
-#' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed.
-#' @param seed The seed for the C++ random number generator.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
 #' @param samples_per_cluster If sampling by cluster, the number of observations to be sampled from
 #'                            each cluster when training a tree. If NULL, we set samples_per_cluster to the size
@@ -42,6 +38,10 @@
 #' @param num.fit.reps The number of forests used to fit the tuning model.
 #' @param num.optimize.reps The number of random parameter values considered when using the model
 #'                          to select the optimal parameters.
+#' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed.
+#' @param num.threads Number of threads used in training. By default, the number of threads is set
+#'                    to the maximum hardware concurrency.
+#' @param seed The seed of the C++ random number generator.
 #'
 #' @return A trained regression forest object.
 #'
@@ -71,21 +71,21 @@ regression_forest <- function(X, Y,
                               sample.fraction = 0.5,
                               mtry = NULL,
                               num.trees = 2000,
-                              num.threads = NULL,
                               min.node.size = NULL,
                               honesty = TRUE,
                               honesty.fraction = NULL,
                               ci.group.size = 2,
                               alpha = NULL,
                               imbalance.penalty = NULL,
-                              compute.oob.predictions = TRUE,
-                              seed = NULL,
                               clusters = NULL,
                               samples_per_cluster = NULL,
                               tune.parameters = FALSE,
                               num.fit.trees = 10,
                               num.fit.reps = 100,
-                              num.optimize.reps = 1000) {
+                              num.optimize.reps = 1000,
+                              compute.oob.predictions = TRUE,
+                              num.threads = NULL,
+                              seed = NULL) {
     validate_X(X)
     validate_sample_weights(sample.weights, X)
     validate_observations(Y, X)
@@ -129,18 +129,18 @@ regression_forest <- function(X, Y,
                                !is.null(sample.weights),
                                as.numeric(tunable.params["mtry"]),
                                num.trees,
-                               num.threads,
                                as.numeric(tunable.params["min.node.size"]),
                                as.numeric(tunable.params["sample.fraction"]),
-                               seed,
                                honesty,
                                coerce_honesty_fraction(honesty.fraction),
                                ci.group.size,
                                as.numeric(tunable.params["alpha"]),
                                as.numeric(tunable.params["imbalance.penalty"]),
-                               compute.oob.predictions,
                                clusters,
-                               samples_per_cluster)
+                               samples_per_cluster,
+                               compute.oob.predictions,
+                               num.threads,
+                               seed)
 
     class(forest) <- c("regression_forest", "grf")
     forest[["ci.group.size"]] <- ci.group.size

--- a/r-package/grf/R/regression_tuning.R
+++ b/r-package/grf/R/regression_tuning.R
@@ -22,17 +22,18 @@
 #' @param mtry Number of variables tried for each split.
 #' @param alpha A tuning parameter that controls the maximum imbalance of a split.
 #' @param imbalance.penalty A tuning parameter that controls how harshly imbalanced splits are penalized.
-#' @param num.threads Number of threads used in training. If set to NULL, the software
-#'                    automatically selects an appropriate amount.
 #' @param honesty Whether or not honest splitting (i.e., sub-sample splitting) should be used.
 #' @param honesty.fraction The fraction of data that will be used for determining splits if honesty = TRUE. Corresponds 
 #'                         to set J1 in the notation of the paper. When using the defaults (honesty = TRUE and 
 #'                         honesty.fraction = NULL), half of the data will be used for determining splits
-#' @param seed The seed for the C++ random number generator.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
 #' @param samples_per_cluster If sampling by cluster, the number of observations to be sampled from
 #'                            each cluster. Must be less than the size of the smallest cluster. If set to NULL
 #'                            software will set this value to the size of the smallest cluster.
+#' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed.
+#' @param num.threads Number of threads used in training. By default, the number of threads is set
+#'                    to the maximum hardware concurrency.
+#' @param seed The seed of the C++ random number generator.
 #'
 #' @return A list consisting of the optimal parameter values ('params') along with their debiased
 #'         error ('error').
@@ -64,12 +65,12 @@ tune_regression_forest <- function(X, Y,
                                    mtry = NULL,
                                    alpha = NULL,
                                    imbalance.penalty = NULL,
-                                   num.threads = NULL,
                                    honesty = TRUE,
                                    honesty.fraction = NULL,
-                                   seed = NULL,
                                    clusters = NULL,
-                                   samples_per_cluster = NULL) {
+                                   samples_per_cluster = NULL,
+                                   num.threads = NULL,
+                                   seed = NULL) {
   validate_X(X)
   validate_sample_weights(sample.weights, X)
   if(length(Y) != nrow(X)) { stop("Y has incorrect length.") }
@@ -108,18 +109,18 @@ tune_regression_forest <- function(X, Y,
                                      !is.null(sample.weights),
                                      as.numeric(params["mtry"]),
                                      num.fit.trees,
-                                     num.threads,
                                      as.numeric(params["min.node.size"]),
                                      as.numeric(params["sample.fraction"]),
-                                     seed,
                                      honesty,
                                      coerce_honesty_fraction(honesty.fraction),
                                      ci.group.size,
                                      as.numeric(params["alpha"]),
                                      as.numeric(params["imbalance.penalty"]),
-                                     compute.oob.predictions,
                                      clusters,
-                                     samples_per_cluster)
+                                     samples_per_cluster,
+                                     compute.oob.predictions,
+                                     num.threads,
+                                     seed)
 
     prediction = regression_predict_oob(small.forest, data$default, data$sparse,
         outcome.index, num.threads, FALSE)

--- a/r-package/grf/R/regression_tuning.R
+++ b/r-package/grf/R/regression_tuning.R
@@ -100,6 +100,7 @@ tune_regression_forest <- function(X, Y,
   num.params = length(tuning.params)
   fit.draws = matrix(runif(num.fit.reps * num.params), num.fit.reps, num.params)
   colnames(fit.draws) = names(tuning.params)
+  compute.oob.predictions = TRUE
   
   debiased.errors = apply(fit.draws, 1, function(draw) {
     params = c(fixed.params, get_params_from_draw(X, draw))
@@ -116,6 +117,7 @@ tune_regression_forest <- function(X, Y,
                                      ci.group.size,
                                      as.numeric(params["alpha"]),
                                      as.numeric(params["imbalance.penalty"]),
+                                     compute.oob.predictions,
                                      clusters,
                                      samples_per_cluster)
 

--- a/r-package/grf/bindings/AnalysisToolsBindings.cpp
+++ b/r-package/grf/bindings/AnalysisToolsBindings.cpp
@@ -184,8 +184,6 @@ Rcpp::List merge(const Rcpp::List forest_objects) {
  }
 
   Forest big_forest = Forest::merge(forest_ptrs);
-
-  Rcpp::List result = RcppUtilities::serialize_forest(big_forest);
-  return result;
+  return RcppUtilities::serialize_forest(big_forest);
 }
  

--- a/r-package/grf/bindings/CustomForestBindings.cpp
+++ b/r-package/grf/bindings/CustomForestBindings.cpp
@@ -31,18 +31,18 @@ Rcpp::List custom_train(Rcpp::NumericMatrix train_matrix,
                         size_t outcome_index,
                         unsigned int mtry,
                         unsigned int num_trees,
-                        unsigned int num_threads,
                         unsigned int min_node_size,
                         double sample_fraction,
-                        unsigned int seed,
                         bool honesty,
                         double honesty_fraction,
                         size_t ci_group_size,
                         double alpha,
                         double imbalance_penalty,
-                        bool compute_oob_predictions,
                         std::vector<size_t> clusters,
-                        unsigned int samples_per_cluster) {
+                        unsigned int samples_per_cluster,
+                        bool compute_oob_predictions,
+                        unsigned int num_threads,
+                        unsigned int seed) {
   ForestTrainer trainer = ForestTrainers::custom_trainer();
 
   Data* data = RcppUtilities::convert_data(train_matrix, sparse_train_matrix);

--- a/r-package/grf/bindings/CustomForestBindings.cpp
+++ b/r-package/grf/bindings/CustomForestBindings.cpp
@@ -40,22 +40,27 @@ Rcpp::List custom_train(Rcpp::NumericMatrix train_matrix,
                         size_t ci_group_size,
                         double alpha,
                         double imbalance_penalty,
+                        bool compute_oob_predictions,
                         std::vector<size_t> clusters,
                         unsigned int samples_per_cluster) {
+  ForestTrainer trainer = ForestTrainers::custom_trainer();
+
   Data* data = RcppUtilities::convert_data(train_matrix, sparse_train_matrix);
   data->set_outcome_index(outcome_index - 1);
   data->sort();
 
   ForestOptions options(num_trees, ci_group_size, sample_fraction, mtry, min_node_size, honesty,
       honesty_fraction, alpha, imbalance_penalty, num_threads, seed, clusters, samples_per_cluster);
-
-  ForestTrainer trainer = ForestTrainers::custom_trainer();
-
   Forest forest = trainer.train(data, options);
-  Rcpp::List result = RcppUtilities::serialize_forest(forest);
+
+  std::vector<Prediction> predictions;
+  if (compute_oob_predictions) {
+    ForestPredictor predictor = ForestPredictors::custom_predictor(num_threads);
+    predictions = predictor.predict_oob(forest, data, false);
+  }
 
   delete data;
-  return result;
+  return RcppUtilities::create_forest_object(forest, predictions);
 }
 
 // [[Rcpp::export]]

--- a/r-package/grf/bindings/InstrumentalForestBindings.cpp
+++ b/r-package/grf/bindings/InstrumentalForestBindings.cpp
@@ -17,10 +17,8 @@ Rcpp::List instrumental_train(Rcpp::NumericMatrix train_matrix,
                               size_t instrument_index,
                               unsigned int mtry,
                               unsigned int num_trees,
-                              unsigned int num_threads,
                               unsigned int min_node_size,
                               double sample_fraction,
-                              unsigned int seed,
                               bool honesty,
                               double honesty_fraction,
                               size_t ci_group_size,
@@ -28,9 +26,11 @@ Rcpp::List instrumental_train(Rcpp::NumericMatrix train_matrix,
                               double alpha,
                               double imbalance_penalty,
                               bool stabilize_splits,
-                              bool compute_oob_predictions,
                               std::vector<size_t> clusters,
-                              unsigned int samples_per_cluster) {
+                              unsigned int samples_per_cluster,
+                              bool compute_oob_predictions,
+                              unsigned int num_threads,
+                              unsigned int seed) {
   ForestTrainer trainer = ForestTrainers::instrumental_trainer(reduced_form_weight, stabilize_splits);
 
   Data* data = RcppUtilities::convert_data(train_matrix, sparse_train_matrix);

--- a/r-package/grf/bindings/InstrumentalForestBindings.cpp
+++ b/r-package/grf/bindings/InstrumentalForestBindings.cpp
@@ -28,6 +28,7 @@ Rcpp::List instrumental_train(Rcpp::NumericMatrix train_matrix,
                               double alpha,
                               double imbalance_penalty,
                               bool stabilize_splits,
+                              bool compute_oob_predictions,
                               std::vector<size_t> clusters,
                               unsigned int samples_per_cluster) {
   ForestTrainer trainer = ForestTrainers::instrumental_trainer(reduced_form_weight, stabilize_splits);
@@ -40,12 +41,16 @@ Rcpp::List instrumental_train(Rcpp::NumericMatrix train_matrix,
 
   ForestOptions options(num_trees, ci_group_size, sample_fraction, mtry, min_node_size, honesty,
       honesty_fraction, alpha, imbalance_penalty, num_threads, seed, clusters, samples_per_cluster);
-
   Forest forest = trainer.train(data, options);
-  Rcpp::List result = RcppUtilities::serialize_forest(forest);
+
+  std::vector<Prediction> predictions;
+  if (compute_oob_predictions) {
+    ForestPredictor predictor = ForestPredictors::instrumental_predictor(num_threads);
+    predictions = predictor.predict_oob(forest, data, false);
+  }
 
   delete data;
-  return result;
+  return RcppUtilities::create_forest_object(forest, predictions);
 }
 
 // [[Rcpp::export]]

--- a/r-package/grf/bindings/QuantileForestBindings.cpp
+++ b/r-package/grf/bindings/QuantileForestBindings.cpp
@@ -17,18 +17,17 @@ Rcpp::List quantile_train(std::vector<double> quantiles,
                           size_t outcome_index,
                           unsigned int mtry,
                           unsigned int num_trees,
-                          int num_threads,
                           int min_node_size,
                           double sample_fraction,
-                          unsigned int seed,
                           bool honesty,
                           double honesty_fraction,
                           size_t ci_group_size,
                           double alpha,
                           double imbalance_penalty,
-                          bool compute_oob_predictions,
                           std::vector<size_t> clusters,
-                          unsigned int samples_per_cluster) {
+                          unsigned int samples_per_cluster,
+                          int num_threads,
+                          unsigned int seed) {
   ForestTrainer trainer = regression_splits
       ? ForestTrainers::regression_trainer()
       : ForestTrainers::quantile_trainer(quantiles);
@@ -41,14 +40,8 @@ Rcpp::List quantile_train(std::vector<double> quantiles,
       honesty_fraction, alpha, imbalance_penalty, num_threads, seed, clusters, samples_per_cluster);
   Forest forest = trainer.train(data, options);
 
-  std::vector<Prediction> predictions;
-  if (compute_oob_predictions) {
-    ForestPredictor predictor = ForestPredictors::quantile_predictor(num_threads, quantiles);
-    predictions = predictor.predict_oob(forest, data, false);
-  }
-
   delete data;
-  return RcppUtilities::create_forest_object(forest, predictions);
+  return RcppUtilities::create_forest_object(forest, std::vector<Prediction>());
 }
 
 // [[Rcpp::export]]

--- a/r-package/grf/bindings/RcppUtilities.cpp
+++ b/r-package/grf/bindings/RcppUtilities.cpp
@@ -6,6 +6,15 @@
 #include "forest/ForestOptions.h"
 #include "RcppUtilities.h"
 
+Rcpp::List RcppUtilities::create_forest_object(Forest& forest,
+                                               const std::vector<Prediction>& predictions) {
+  Rcpp::List result = serialize_forest(forest);
+  if (!predictions.empty()) {
+    add_predictions(result, predictions);
+  }
+  return result;
+}
+
 Forest RcppUtilities::deserialize_forest(Rcpp::List forest_object) {
   size_t ci_group_size = forest_object["_ci_group_size"];
   size_t num_variables = forest_object["_num_variables"];
@@ -98,12 +107,17 @@ Data* RcppUtilities::convert_data(Rcpp::NumericMatrix input_data,
 
 Rcpp::List RcppUtilities::create_prediction_object(const std::vector<Prediction>& predictions) {
   Rcpp::List result;
-  result.push_back(RcppUtilities::create_prediction_matrix(predictions), "predictions");
-  result.push_back(RcppUtilities::create_variance_matrix(predictions), "variance.estimates");
-  result.push_back(RcppUtilities::create_error_matrix(predictions), "debiased.error");
-  result.push_back(RcppUtilities::create_excess_error_matrix(predictions), "excess.error");
+  add_predictions(result, predictions);
   return result;
 };
+
+void RcppUtilities::add_predictions(Rcpp::List& output,
+                                    const std::vector<Prediction>& predictions) {
+  output.push_back(RcppUtilities::create_prediction_matrix(predictions), "predictions");
+  output.push_back(RcppUtilities::create_variance_matrix(predictions), "variance.estimates");
+  output.push_back(RcppUtilities::create_error_matrix(predictions), "debiased.error");
+  output.push_back(RcppUtilities::create_excess_error_matrix(predictions), "excess.error");
+}
 
 Rcpp::NumericMatrix RcppUtilities::create_prediction_matrix(const std::vector<Prediction>& predictions) {
   if (predictions.empty()) {

--- a/r-package/grf/bindings/RcppUtilities.h
+++ b/r-package/grf/bindings/RcppUtilities.h
@@ -9,13 +9,17 @@ class RcppUtilities {
 public:
 
   /**
-   * Converts the provided {@link Forest} object to an R list to be returned
-   * through the Rcpp bindings.
+   * Converts the provided {@link Forest} object and OOB predictions to an R list
+   * to be returned through the Rcpp bindings. The provided predictions vector can
+   * be present if OOB predictions were not requested as part of training.
    *
-   * NOTE: To converse memory, this method destructively modifies the forest
+   * NOTE: To conserve memory, this method destructively modifies the forest
    * object by clearing out individual {@link Tree} objects. The forest cannot
    * be used once it has been passed to the method.
    */
+  static Rcpp::List create_forest_object(Forest& forest,
+                                         const std::vector<Prediction>& predictions);
+
   static Rcpp::List serialize_forest(Forest& forest);
   static Forest deserialize_forest(Rcpp::List forest_object);
 
@@ -23,6 +27,9 @@ public:
                             Eigen::SparseMatrix<double>& sparse_input_data);
 
   static Rcpp::List create_prediction_object(const std::vector<Prediction>& predictions);
+  static void add_predictions(Rcpp::List& output,
+                              const std::vector<Prediction>& predictions);
+
   static Rcpp::NumericMatrix create_prediction_matrix(const std::vector<Prediction>& predictions);
   static Rcpp::NumericMatrix create_variance_matrix(const std::vector<Prediction>& predictions);
   static Rcpp::NumericMatrix create_error_matrix(const std::vector<Prediction>& predictions);

--- a/r-package/grf/bindings/RegressionForestBindings.cpp
+++ b/r-package/grf/bindings/RegressionForestBindings.cpp
@@ -34,18 +34,18 @@ Rcpp::List regression_train(Rcpp::NumericMatrix train_matrix,
                             bool use_sample_weights,
                             unsigned int mtry,
                             unsigned int num_trees,
-                            unsigned int num_threads,
                             unsigned int min_node_size,
                             double sample_fraction,
-                            unsigned int seed,
                             bool honesty,
                             double honesty_fraction,
                             size_t ci_group_size,
                             double alpha,
                             double imbalance_penalty,
-                            bool compute_oob_predictions,
                             std::vector<size_t> clusters,
-                            unsigned int samples_per_cluster) {
+                            unsigned int samples_per_cluster,
+                            bool compute_oob_predictions,
+                            unsigned int num_threads,
+                            unsigned int seed) {
   ForestTrainer trainer = ForestTrainers::regression_trainer();
 
   Data* data = RcppUtilities::convert_data(train_matrix, sparse_train_matrix);


### PR DESCRIPTION
For regression, causal, and instrumental forests, we allow precompute OOB
predictions during training by default. This PR pushes that computation into
the C++ bindings to avoid an extra round-trip between R and C++. With this
change in place, many common workflows (such as training a forest, then running
`average_treatment_effect`) should not require any deserialization of the
forest at all.

It also makes the following two refactors related to `compute.oob.predictions`:
- Make sure custom forests accept the `compute.oob.predictions` parameter.
- Group all training parameters together that are related to computation.