### PR TITLE
Fix the naming style of samples.per.cluster.

### DIFF
--- a/experiments/acic18/script.R
+++ b/experiments/acic18/script.R
@@ -52,7 +52,7 @@ selected.idx = which(varimp > mean(varimp))
 cf = causal_forest(X[,selected.idx], Y, W,
                    Y.hat = Y.hat, W.hat = W.hat,
                    clusters = school.id,
-                   samples_per_cluster = 50,
+                   samples.per.cluster = 50,
                    tune.parameters = TRUE)
 tau.hat = predict(cf)$predictions
 
@@ -197,7 +197,7 @@ summary(aov(dr.score ~ factor(school.id)))
 cf.noprop = causal_forest(X[,selected.idx], Y, W,
                           Y.hat = Y.hat, W.hat = mean(W),
                           tune.parameters = TRUE,
-                          samples_per_cluster = 50,
+                          samples.per.cluster = 50,
                           clusters = school.id)
 tau.hat.noprop = predict(cf.noprop)$predictions
 

--- a/r-package/grf/R/causal_forest.R
+++ b/r-package/grf/R/causal_forest.R
@@ -43,14 +43,14 @@
 #' @param stabilize.splits Whether or not the treatment should be taken into account when
 #'                         determining the imbalance of a split (experimental).
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
-#' @param samples_per_cluster If sampling by cluster, the number of observations to be sampled from
-#'                            each cluster when training a tree. If NULL, we set samples_per_cluster to the size
-#'                            of the smallest cluster. If some clusters are smaller than samples_per_cluster,
+#' @param samples.per.cluster If sampling by cluster, the number of observations to be sampled from
+#'                            each cluster when training a tree. If NULL, we set samples.per.cluster to the size
+#'                            of the smallest cluster. If some clusters are smaller than samples.per.cluster,
 #'                            the whole cluster is used every time the cluster is drawn. Note that
-#'                            clusters with less than samples_per_cluster observations get relatively
+#'                            clusters with less than samples.per.cluster observations get relatively
 #'                            smaller weight than others in training the forest, i.e., the contribution
 #'                            of a given cluster to the final forest scales with the minimum of
-#'                            the number of observations in the cluster and samples_per_cluster.
+#'                            the number of observations in the cluster and samples.per.cluster.
 #' @param tune.parameters If true, NULL parameters are tuned by cross-validation; if false
 #'                        NULL parameters are set to defaults.
 #' @param num.fit.trees The number of trees in each 'mini forest' used to fit the tuning model.
@@ -129,7 +129,7 @@ causal_forest <- function(X, Y, W,
                           imbalance.penalty = NULL,
                           stabilize.splits = TRUE,
                           clusters = NULL,
-                          samples_per_cluster = NULL,
+                          samples.per.cluster = NULL,
                           tune.parameters = FALSE,
                           num.fit.trees = 200,
                           num.fit.reps = 50,
@@ -139,10 +139,11 @@ causal_forest <- function(X, Y, W,
                           seed = NULL) {
     validate_X(X)
     validate_observations(list(Y,W), X)
+
     num.threads <- validate_num_threads(num.threads)
     seed <- validate_seed(seed)
     clusters <- validate_clusters(clusters, X)
-    samples_per_cluster <- validate_samples_per_cluster(samples_per_cluster, clusters)
+    samples.per.cluster <- validate_samples_per_cluster(samples.per.cluster, clusters)
     honesty.fraction <- validate_honesty_fraction(honesty.fraction, honesty)
 
     reduced.form.weight <- 0
@@ -151,7 +152,7 @@ causal_forest <- function(X, Y, W,
       forest.Y <- regression_forest(X, Y, sample.fraction = sample.fraction, mtry = mtry, tune.parameters = tune.parameters,
                                     num.trees = min(500, num.trees), num.threads = num.threads, min.node.size = NULL, honesty = TRUE,
                                     honesty.fraction = NULL, seed = seed, ci.group.size = 1, alpha = alpha, imbalance.penalty = imbalance.penalty,
-                                    clusters = clusters, samples_per_cluster = samples_per_cluster);
+                                    clusters = clusters, samples.per.cluster = samples.per.cluster);
       Y.hat <- predict(forest.Y)$predictions
     } else if (is.null(Y.hat) && orthog.boosting) {
       forest.Y <- boosted_regression_forest(X, Y, sample.fraction = sample.fraction, mtry = mtry, tune.parameters = tune.parameters,
@@ -169,7 +170,7 @@ causal_forest <- function(X, Y, W,
       forest.W <- regression_forest(X, W, sample.fraction = sample.fraction, mtry = mtry, tune.parameters = tune.parameters,
                                     num.trees = min(500, num.trees), num.threads = num.threads, min.node.size = NULL, honesty = TRUE,
                                     honesty.fraction = NULL, seed = seed, ci.group.size = 1, alpha = alpha, imbalance.penalty = imbalance.penalty,
-                                    clusters = clusters, samples_per_cluster = samples_per_cluster);
+                                    clusters = clusters, samples.per.cluster = samples.per.cluster);
       W.hat <- predict(forest.W)$predictions
 
     } else if (is.null(W.hat) && orthog.boosting) {
@@ -200,7 +201,7 @@ causal_forest <- function(X, Y, W,
                                           honesty.fraction = honesty.fraction,
                                           seed = seed,
                                           clusters = clusters,
-                                          samples_per_cluster = samples_per_cluster)
+                                          samples.per.cluster = samples.per.cluster)
       tunable.params <- tuning.output$params
     } else {
       tunable.params <- c(
@@ -233,7 +234,7 @@ causal_forest <- function(X, Y, W,
                                  as.numeric(tunable.params["imbalance.penalty"]),
                                  stabilize.splits,
                                  clusters,
-                                 samples_per_cluster,
+                                 samples.per.cluster,
                                  compute.oob.predictions,
                                  num.threads,
                                  seed)

--- a/r-package/grf/R/causal_tuning.R
+++ b/r-package/grf/R/causal_tuning.R
@@ -35,7 +35,7 @@
 #' @param stabilize.splits Whether or not the treatment should be taken into account when
 #'                         determining the imbalance of a split (experimental).
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
-#' @param samples_per_cluster If sampling by cluster, the number of observations to be sampled from
+#' @param samples.per.cluster If sampling by cluster, the number of observations to be sampled from
 #'                            each cluster. Must be less than the size of the smallest cluster. If set to NULL
 #'                            software will set this value to the size of the smallest cluster.#'
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
@@ -79,7 +79,7 @@ tune_causal_forest <- function(X, Y, W, Y.hat, W.hat,
                                honesty = TRUE,
                                honesty.fraction = NULL,
                                clusters = NULL,
-                               samples_per_cluster = NULL,
+                               samples.per.cluster = NULL,
                                num.threads = NULL,
                                seed = NULL) {
   validate_X(X)
@@ -88,7 +88,7 @@ tune_causal_forest <- function(X, Y, W, Y.hat, W.hat,
   num.threads <- validate_num_threads(num.threads)
   seed <- validate_seed(seed)
   clusters <- validate_clusters(clusters, X)
-  samples_per_cluster <- validate_samples_per_cluster(samples_per_cluster, clusters)
+  samples.per.cluster <- validate_samples_per_cluster(samples.per.cluster, clusters)
   ci.group.size <- 1
   reduced.form.weight <- 0
   honesty.fraction <- validate_honesty_fraction(honesty.fraction, honesty)
@@ -130,7 +130,7 @@ tune_causal_forest <- function(X, Y, W, Y.hat, W.hat,
                                        as.numeric(params["imbalance.penalty"]),
                                        stabilize.splits,
                                        clusters,
-                                       samples_per_cluster,
+                                       samples.per.cluster,
                                        compute.oob.predictions,
                                        num.threads,
                                        seed)

--- a/r-package/grf/R/custom_forest.R
+++ b/r-package/grf/R/custom_forest.R
@@ -20,14 +20,14 @@
 #' @param alpha A tuning parameter that controls the maximum imbalance of a split.
 #' @param imbalance.penalty A tuning parameter that controls how harshly imbalanced splits are penalized.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
-#' @param samples_per_cluster If sampling by cluster, the number of observations to be sampled from
-#'                            each cluster when training a tree. If NULL, we set samples_per_cluster to the size
-#'                            of the smallest cluster. If some clusters are smaller than samples_per_cluster,
+#' @param samples.per.cluster If sampling by cluster, the number of observations to be sampled from
+#'                            each cluster when training a tree. If NULL, we set samples.per.cluster to the size
+#'                            of the smallest cluster. If some clusters are smaller than samples.per.cluster,
 #'                            the whole cluster is used every time the cluster is drawn. Note that
-#'                            clusters with less than samples_per_cluster observations get relatively
+#'                            clusters with less than samples.per.cluster observations get relatively
 #'                            smaller weight than others in training the forest, i.e., the contribution
 #'                            of a given cluster to the final forest scales with the minimum of
-#'                            the number of observations in the cluster and samples_per_cluster.
+#'                            the number of observations in the cluster and samples.per.cluster.
 #' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed.
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency
@@ -59,7 +59,7 @@ custom_forest <- function(X, Y,
                           alpha = 0.05,
                           imbalance.penalty = 0.0,
                           clusters = NULL,
-                          samples_per_cluster = NULL,
+                          samples.per.cluster = NULL,
                           compute.oob.predictions = TRUE,
                           num.threads = NULL,
                           seed = NULL) {
@@ -73,7 +73,7 @@ custom_forest <- function(X, Y,
     sample.fraction <- validate_sample_fraction(sample.fraction)
     seed <- validate_seed(seed)
     clusters <- validate_clusters(clusters, X)
-    samples_per_cluster <- validate_samples_per_cluster(samples_per_cluster, clusters)
+    samples.per.cluster <- validate_samples_per_cluster(samples.per.cluster, clusters)
     honesty.fraction <- validate_honesty_fraction(honesty.fraction, honesty)
     
     no.split.variables <- numeric(0)
@@ -84,7 +84,7 @@ custom_forest <- function(X, Y,
 
     forest <- custom_train(data$default, data$sparse, outcome.index, mtry,num.trees, min.node.size,
         sample.fraction,  honesty, coerce_honesty_fraction(honesty.fraction), ci.group.size, alpha,
-        imbalance.penalty, clusters, samples_per_cluster, num.threads, compute.oob.predictions, seed)
+        imbalance.penalty, clusters, samples.per.cluster, num.threads, compute.oob.predictions, seed)
     
     class(forest) <- c("custom_forest", "grf")
     forest[["X.orig"]] <- X

--- a/r-package/grf/R/input_utilities.R
+++ b/r-package/grf/R/input_utilities.R
@@ -119,18 +119,18 @@ validate_clusters <- function(clusters, X) {
   clusters
 }
 
-validate_samples_per_cluster <- function(samples_per_cluster, clusters) {
+validate_samples_per_cluster <- function(samples.per.cluster, clusters) {
   if (is.null(clusters) || length(clusters) == 0) {
     return(0)
   }
   cluster_size_counts <- table(clusters)
   min_size <- unname(cluster_size_counts[order(cluster_size_counts)][1])
-  if (is.null(samples_per_cluster)) {
-    samples_per_cluster <- min_size
-  } else if (samples_per_cluster <= 0) {
+  if (is.null(samples.per.cluster)) {
+    samples.per.cluster <- min_size
+  } else if (samples.per.cluster <= 0) {
     stop("samples_per_cluster must be positive")
   }
-  samples_per_cluster
+  samples.per.cluster
 }
 
 validate_honesty_fraction <- function(honesty.fraction, honesty) {

--- a/r-package/grf/R/instrumental_forest.R
+++ b/r-package/grf/R/instrumental_forest.R
@@ -42,14 +42,14 @@
 #' @param stabilize.splits Whether or not the instrument should be taken into account when
 #'                         determining the imbalance of a split (experimental).
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
-#' @param samples_per_cluster If sampling by cluster, the number of observations to be sampled from
-#'                            each cluster when training a tree. If NULL, we set samples_per_cluster to the size
-#'                            of the smallest cluster. If some clusters are smaller than samples_per_cluster,
+#' @param samples.per.cluster If sampling by cluster, the number of observations to be sampled from
+#'                            each cluster when training a tree. If NULL, we set samples.per.cluster to the size
+#'                            of the smallest cluster. If some clusters are smaller than samples.per.cluster,
 #'                            the whole cluster is used every time the cluster is drawn. Note that
-#'                            clusters with less than samples_per_cluster observations get relatively
+#'                            clusters with less than samples.per.cluster observations get relatively
 #'                            smaller weight than others in training the forest, i.e., the contribution
 #'                            of a given cluster to the final forest scales with the minimum of
-#'                            the number of observations in the cluster and samples_per_cluster.
+#'                            the number of observations in the cluster and samples.per.cluster.
 #' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed.
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency.
@@ -73,7 +73,7 @@ instrumental_forest <- function(X, Y, W, Z,
                                 imbalance.penalty = 0.0,
                                 stabilize.splits = TRUE,
                                 clusters = NULL,
-                                samples_per_cluster = NULL,
+                                samples.per.cluster = NULL,
                                 compute.oob.predictions = TRUE,
                                 num.threads = NULL,
                                 seed = NULL) {
@@ -86,7 +86,7 @@ instrumental_forest <- function(X, Y, W, Z,
     sample.fraction <- validate_sample_fraction(sample.fraction)
     seed <- validate_seed(seed)
     clusters <- validate_clusters(clusters, X)
-    samples_per_cluster <- validate_samples_per_cluster(samples_per_cluster, clusters)
+    samples.per.cluster <- validate_samples_per_cluster(samples.per.cluster, clusters)
     honesty.fraction <- validate_honesty_fraction(honesty.fraction, honesty)
     
     if (!is.numeric(reduced.form.weight) | reduced.form.weight < 0 | reduced.form.weight > 1) {
@@ -97,7 +97,7 @@ instrumental_forest <- function(X, Y, W, Z,
       forest.Y <- regression_forest(X, Y, sample.fraction = sample.fraction, mtry = mtry, 
                                     num.trees = min(500, num.trees), num.threads = num.threads, min.node.size = NULL, honesty = TRUE,
                                     honesty.fraction = NULL, seed = seed, ci.group.size = 1, alpha = alpha, imbalance.penalty = imbalance.penalty,
-                                    clusters = clusters, samples_per_cluster = samples_per_cluster);
+                                    clusters = clusters, samples.per.cluster = samples.per.cluster);
       Y.hat <- predict(forest.Y)$predictions
     } else if (length(Y.hat) == 1) {
       Y.hat <- rep(Y.hat, nrow(X))
@@ -109,7 +109,7 @@ instrumental_forest <- function(X, Y, W, Z,
       forest.W <- regression_forest(X, W, sample.fraction = sample.fraction, mtry = mtry, 
                                     num.trees = min(500, num.trees), num.threads = num.threads, min.node.size = NULL, honesty = TRUE,
                                     honesty.fraction = NULL, seed = seed, ci.group.size = 1, alpha = alpha, imbalance.penalty = imbalance.penalty,
-                                    clusters = clusters, samples_per_cluster = samples_per_cluster);
+                                    clusters = clusters, samples.per.cluster = samples.per.cluster);
       W.hat <- predict(forest.W)$predictions
     } else if (length(W.hat) == 1) {
       W.hat <- rep(W.hat, nrow(X))
@@ -121,7 +121,7 @@ instrumental_forest <- function(X, Y, W, Z,
       forest.Z <- regression_forest(X, Z, sample.fraction = sample.fraction, mtry = mtry, 
                                     num.trees = min(500, num.trees), num.threads = num.threads, min.node.size = NULL, honesty = TRUE,
                                     honesty.fraction = NULL, seed = seed, ci.group.size = 1, alpha = alpha, imbalance.penalty = imbalance.penalty,
-                                    clusters = clusters, samples_per_cluster = samples_per_cluster);
+                                    clusters = clusters, samples.per.cluster = samples.per.cluster);
       Z.hat <- predict(forest.Z)$predictions
     } else if (length(Z.hat) == 1) {
       Z.hat <- rep(Z.hat, nrow(X))
@@ -138,7 +138,7 @@ instrumental_forest <- function(X, Y, W, Z,
     forest <- instrumental_train(data$default, data$sparse, outcome.index, treatment.index, instrument.index,
         mtry, num.trees,  min.node.size, sample.fraction, honesty, coerce_honesty_fraction(honesty.fraction),
         ci.group.size, reduced.form.weight, alpha,  imbalance.penalty, stabilize.splits,  clusters,
-        samples_per_cluster, compute.oob.predictions, num.threads, seed)
+        samples.per.cluster, compute.oob.predictions, num.threads, seed)
 
     class(forest) <- c("instrumental_forest", "grf")
     forest[["ci.group.size"]] <- ci.group.size

--- a/r-package/grf/R/local_linear_forest.R
+++ b/r-package/grf/R/local_linear_forest.R
@@ -24,14 +24,14 @@
 #' @param alpha A tuning parameter that controls the maximum imbalance of a split.
 #' @param imbalance.penalty A tuning parameter that controls how harshly imbalanced splits are penalized.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
-#' @param samples_per_cluster If sampling by cluster, the number of observations to be sampled from
-#'                            each cluster when training a tree. If NULL, we set samples_per_cluster to the size
-#'                            of the smallest cluster. If some clusters are smaller than samples_per_cluster,
+#' @param samples.per.cluster If sampling by cluster, the number of observations to be sampled from
+#'                            each cluster when training a tree. If NULL, we set samples.per.cluster to the size
+#'                            of the smallest cluster. If some clusters are smaller than samples.per.cluster,
 #'                            the whole cluster is used every time the cluster is drawn. Note that
-#'                            clusters with less than samples_per_cluster observations get relatively
+#'                            clusters with less than samples.per.cluster observations get relatively
 #'                            smaller weight than others in training the forest, i.e., the contribution
 #'                            of a given cluster to the final forest scales with the minimum of
-#'                            the number of observations in the cluster and samples_per_cluster.
+#'                            the number of observations in the cluster and samples.per.cluster.
 #' @param tune.parameters If true, NULL parameters are tuned by cross-validation; if false
 #'                        NULL parameters are set to defaults.
 #' @param num.fit.trees The number of trees in each 'mini forest' used to fit the tuning model.
@@ -65,7 +65,7 @@ ll_regression_forest <- function(X, Y,
                                 alpha = NULL,
                                 imbalance.penalty = NULL,
                                 clusters = NULL,
-                                samples_per_cluster = NULL,
+                                samples.per.cluster = NULL,
                                 tune.parameters = FALSE,
                                 num.fit.trees = 10,
                                 num.fit.reps = 100,
@@ -79,7 +79,7 @@ ll_regression_forest <- function(X, Y,
   num.threads <- validate_num_threads(num.threads)
   seed <- validate_seed(seed)
   clusters <- validate_clusters(clusters, X)
-  samples_per_cluster <- validate_samples_per_cluster(samples_per_cluster, clusters)
+  samples.per.cluster <- validate_samples_per_cluster(samples.per.cluster, clusters)
   honesty.fraction <- validate_honesty_fraction(honesty.fraction, honesty)
 
   if (tune.parameters) {
@@ -97,7 +97,7 @@ ll_regression_forest <- function(X, Y,
                                             honesty.fraction = honesty.fraction,
                                             seed = seed,
                                             clusters = clusters,
-                                            samples_per_cluster = samples_per_cluster)
+                                            samples.per.cluster = samples.per.cluster)
       tunable.params <- tuning.output$params
   } else {
     tunable.params <- c(
@@ -124,7 +124,7 @@ ll_regression_forest <- function(X, Y,
                              as.numeric(tunable.params["alpha"]),
                              as.numeric(tunable.params["imbalance.penalty"]),
                              clusters,
-                             samples_per_cluster,
+                             samples.per.cluster,
                              compute.oob.predictions,
                              num.threads,
                              seed)

--- a/r-package/grf/R/quantile_forest.R
+++ b/r-package/grf/R/quantile_forest.R
@@ -26,14 +26,14 @@
 #' @param alpha A tuning parameter that controls the maximum imbalance of a split.
 #' @param imbalance.penalty A tuning parameter that controls how harshly imbalanced splits are penalized.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
-#' @param samples_per_cluster If sampling by cluster, the number of observations to be sampled from
-#'                            each cluster when training a tree. If NULL, we set samples_per_cluster to the size
-#'                            of the smallest cluster. If some clusters are smaller than samples_per_cluster,
+#' @param samples.per.cluster If sampling by cluster, the number of observations to be sampled from
+#'                            each cluster when training a tree. If NULL, we set samples.per.cluster to the size
+#'                            of the smallest cluster. If some clusters are smaller than samples.per.cluster,
 #'                            the whole cluster is used every time the cluster is drawn. Note that
-#'                            clusters with less than samples_per_cluster observations get relatively
+#'                            clusters with less than samples.per.cluster observations get relatively
 #'                            smaller weight than others in training the forest, i.e., the contribution
 #'                            of a given cluster to the final forest scales with the minimum of
-#'                            the number of observations in the cluster and samples_per_cluster.
+#'                            the number of observations in the cluster and samples.per.cluster.
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency.
 #' @param seed The seed of the C++ random number generator.
@@ -78,7 +78,7 @@ quantile_forest <- function(X, Y,
                             alpha = 0.05,
                             imbalance.penalty = 0.0, 
                             clusters = NULL,
-                            samples_per_cluster = NULL,
+                            samples.per.cluster = NULL,
                             num.threads = NULL,
                             seed = NULL) {
     if (!is.numeric(quantiles) | length(quantiles) < 1) {
@@ -96,7 +96,7 @@ quantile_forest <- function(X, Y,
     sample.fraction <- validate_sample_fraction(sample.fraction)
     seed <- validate_seed(seed)
     clusters <- validate_clusters(clusters, X)
-    samples_per_cluster <- validate_samples_per_cluster(samples_per_cluster, clusters)
+    samples.per.cluster <- validate_samples_per_cluster(samples.per.cluster, clusters)
     honesty.fraction <- validate_honesty_fraction(honesty.fraction, honesty)
     
     data <- create_data_matrices(X, Y)
@@ -106,7 +106,7 @@ quantile_forest <- function(X, Y,
     
     forest <- quantile_train(quantiles, regression.splitting, data$default, data$sparse, outcome.index, mtry, 
         num.trees, min.node.size, sample.fraction, honesty, coerce_honesty_fraction(honesty.fraction), ci.group.size,
-        alpha, imbalance.penalty, clusters, samples_per_cluster, num.threads, seed)
+        alpha, imbalance.penalty, clusters, samples.per.cluster, num.threads, seed)
     
     class(forest) <- c("quantile_forest", "grf")
     forest[["X.orig"]] <- X

--- a/r-package/grf/R/regression_forest.R
+++ b/r-package/grf/R/regression_forest.R
@@ -24,14 +24,14 @@
 #' @param alpha A tuning parameter that controls the maximum imbalance of a split.
 #' @param imbalance.penalty A tuning parameter that controls how harshly imbalanced splits are penalized.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
-#' @param samples_per_cluster If sampling by cluster, the number of observations to be sampled from
-#'                            each cluster when training a tree. If NULL, we set samples_per_cluster to the size
-#'                            of the smallest cluster. If some clusters are smaller than samples_per_cluster,
+#' @param samples.per.cluster If sampling by cluster, the number of observations to be sampled from
+#'                            each cluster when training a tree. If NULL, we set samples.per.cluster to the size
+#'                            of the smallest cluster. If some clusters are smaller than samples.per.cluster,
 #'                            the whole cluster is used every time the cluster is drawn. Note that
-#'                            clusters with less than samples_per_cluster observations get relatively
+#'                            clusters with less than samples.per.cluster observations get relatively
 #'                            smaller weight than others in training the forest, i.e., the contribution
 #'                            of a given cluster to the final forest scales with the minimum of
-#'                            the number of observations in the cluster and samples_per_cluster.
+#'                            the number of observations in the cluster and samples.per.cluster.
 #' @param tune.parameters If true, NULL parameters are tuned by cross-validation; if false
 #'                        NULL parameters are set to defaults.
 #' @param num.fit.trees The number of trees in each 'mini forest' used to fit the tuning model.
@@ -78,7 +78,7 @@ regression_forest <- function(X, Y,
                               alpha = NULL,
                               imbalance.penalty = NULL,
                               clusters = NULL,
-                              samples_per_cluster = NULL,
+                              samples.per.cluster = NULL,
                               tune.parameters = FALSE,
                               num.fit.trees = 10,
                               num.fit.reps = 100,
@@ -93,7 +93,7 @@ regression_forest <- function(X, Y,
     num.threads <- validate_num_threads(num.threads)
     seed <- validate_seed(seed)
     clusters <- validate_clusters(clusters, X)
-    samples_per_cluster <- validate_samples_per_cluster(samples_per_cluster, clusters)
+    samples.per.cluster <- validate_samples_per_cluster(samples.per.cluster, clusters)
     honesty.fraction <- validate_honesty_fraction(honesty.fraction, honesty)
 
     if (tune.parameters) {
@@ -111,7 +111,7 @@ regression_forest <- function(X, Y,
                                               honesty.fraction = honesty.fraction,
                                               seed = seed,
                                               clusters = clusters,
-                                              samples_per_cluster = samples_per_cluster)
+                                              samples.per.cluster = samples.per.cluster)
       tunable.params <- tuning.output$params
     } else {
       tunable.params <- c(
@@ -137,7 +137,7 @@ regression_forest <- function(X, Y,
                                as.numeric(tunable.params["alpha"]),
                                as.numeric(tunable.params["imbalance.penalty"]),
                                clusters,
-                               samples_per_cluster,
+                               samples.per.cluster,
                                compute.oob.predictions,
                                num.threads,
                                seed)
@@ -181,11 +181,11 @@ regression_forest <- function(X, Y,
 #'         estimates of E[Y|X=x]. The square-root of column 'variance.estimates' is the standard error
 #          of these predictions. Column 'debiased.error' contains out-of-bag estimates of
 #'         the test mean-squared error. Column 'excess.error' contains
-#'         jackknife estimates of the Monte-carlo error. The sum of 'debiased.error' 
+#'         jackknife estimates of the Monte-carlo error. The sum of 'debiased.error'
 #'         and 'excess.error' is the raw error attained by the current forest, and
 #'         'debiased.error' alone is an estimate of the error attained by a forest with
 #'         an infinite number of trees. We recommend that users grow
-#'         enough forests to make the excess.error' negligible.
+#'         enough forests to make the 'excess.error' negligible.
 #'
 #' @examples \dontrun{
 #' # Train a standard regression forest.

--- a/r-package/grf/R/regression_tuning.R
+++ b/r-package/grf/R/regression_tuning.R
@@ -27,7 +27,7 @@
 #'                         to set J1 in the notation of the paper. When using the defaults (honesty = TRUE and 
 #'                         honesty.fraction = NULL), half of the data will be used for determining splits
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
-#' @param samples_per_cluster If sampling by cluster, the number of observations to be sampled from
+#' @param samples.per.cluster If sampling by cluster, the number of observations to be sampled from
 #'                            each cluster. Must be less than the size of the smallest cluster. If set to NULL
 #'                            software will set this value to the size of the smallest cluster.
 #' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed.
@@ -68,7 +68,7 @@ tune_regression_forest <- function(X, Y,
                                    honesty = TRUE,
                                    honesty.fraction = NULL,
                                    clusters = NULL,
-                                   samples_per_cluster = NULL,
+                                   samples.per.cluster = NULL,
                                    num.threads = NULL,
                                    seed = NULL) {
   validate_X(X)
@@ -77,7 +77,7 @@ tune_regression_forest <- function(X, Y,
   num.threads <- validate_num_threads(num.threads)
   seed <- validate_seed(seed)
   clusters <- validate_clusters(clusters, X)
-  samples_per_cluster <- validate_samples_per_cluster(samples_per_cluster, clusters)
+  samples.per.cluster <- validate_samples_per_cluster(samples.per.cluster, clusters)
   ci.group.size <- 1
   honesty.fraction <- validate_honesty_fraction(honesty.fraction, honesty)
 
@@ -117,7 +117,7 @@ tune_regression_forest <- function(X, Y,
                                      as.numeric(params["alpha"]),
                                      as.numeric(params["imbalance.penalty"]),
                                      clusters,
-                                     samples_per_cluster,
+                                     samples.per.cluster,
                                      compute.oob.predictions,
                                      num.threads,
                                      seed)

--- a/r-package/grf/tests/testthat/test_average_effect.R
+++ b/r-package/grf/tests/testthat/test_average_effect.R
@@ -224,7 +224,7 @@ test_that("cluster robust average effects are consistent", {
   forest.causal = causal_forest(X, Y, W, num.trees = 1000, ci.group.size = 4)
   forest.causal.clust = causal_forest(Xc, Yc, Wc, num.trees = 1000,
                                       ci.group.size = 4, clusters = clust,
-                                      samples_per_cluster = 7)
+                                      samples.per.cluster = 7)
 
   cate.aipw = average_treatment_effect(forest.causal, target.sample = "all", method = "AIPW")
   cate.clust.aipw = average_treatment_effect(forest.causal.clust, target.sample = "all", method = "AIPW")

--- a/r-package/grf/tests/testthat/test_clustered_standard_errors.R
+++ b/r-package/grf/tests/testthat/test_clustered_standard_errors.R
@@ -22,33 +22,33 @@ test_that("Clustered standard errors are greater than unclustered", {
                                         Y_cluster,
                                         ci.group.size = 4,
                                         clusters = clusters,
-                                        samples_per_cluster = 1)
+                                        samples.per.cluster = 1)
   preds_corrected.oob <- predict(forest_corrected, estimate.variance = TRUE)
 
   forest_no_cluster <- regression_forest(X,
                                          Y,
                                          ci.group.size = 4,
-                                         samples_per_cluster = 1)
+                                         samples.per.cluster = 1)
   preds_no_cluster.oob <- predict(forest_no_cluster, estimate.variance = TRUE)
 
   forest_uncorrected <- regression_forest(X_cluster,
                                           Y_cluster,
                                           ci.group.size = 4,
-                                          samples_per_cluster = 1)
+                                          samples.per.cluster = 1)
   preds_uncorrected.oob <- predict(forest_uncorrected, estimate.variance = TRUE)
 
   forest_corrected_no_clusters <- regression_forest(X,
                                                     Y,
                                                     ci.group.size = 4,
                                                     clusters = no_clusters,
-                                                    samples_per_cluster = 1)
+                                                    samples.per.cluster = 1)
   preds_corrected_no_cluster.oob <- predict(forest_corrected_no_clusters, estimate.variance = TRUE)
 
   mean_no_cluster <- mean(preds_no_cluster.oob$variance.estimates)
   mean_uncorrected <- mean(preds_uncorrected.oob$variance.estimates)
   mean_corrected <- mean(preds_corrected.oob$variance.estimates)
   mean_corrected_no_cluster <- mean(preds_corrected_no_cluster.oob$variance.estimates)
- 
+
   expect_equal(mean_no_cluster, mean_corrected, tolerance = 0.2 * mean_no_cluster)
   expect_equal(mean_no_cluster, mean_corrected_no_cluster, tolerance = 0.2 * mean_no_cluster)
   expect_true(mean_no_cluster > 2 * mean_uncorrected)
@@ -85,26 +85,26 @@ test_that("Clustered predictions are reasonable with unevenly sized clusters", {
                                         Y_cluster,
                                         ci.group.size = 1,
                                         clusters = clusters,
-                                        samples_per_cluster = 1)
+                                        samples.per.cluster = 1)
   preds_corrected.oob <- predict(forest_corrected, estimate.variance = FALSE)
 
   forest_no_cluster <- regression_forest(X,
                                          Y,
                                          ci.group.size = 1,
-                                         samples_per_cluster = 1)
+                                         samples.per.cluster = 1)
   preds_no_cluster.oob <- predict(forest_no_cluster, estimate.variance = FALSE)
 
   forest_uncorrected <- regression_forest(X_cluster,
                                           Y_cluster,
                                           ci.group.size = 1,
-                                          samples_per_cluster = 1)
+                                          samples.per.cluster = 1)
   preds_uncorrected.oob <- predict(forest_uncorrected, estimate.variance = FALSE)
 
   forest_corrected_no_clusters <- regression_forest(X,
                                                     Y,
                                                     ci.group.size = 1,
                                                     clusters = no_clusters,
-                                                    samples_per_cluster = 1)
+                                                    samples.per.cluster = 1)
   preds_corrected_no_cluster.oob <- predict(forest_corrected_no_clusters, estimate.variance = FALSE)
 
   mse_no_cluster <- mean((preds_no_cluster.oob$predictions - MU)^2)


### PR DESCRIPTION
In our R code, method parameters always contain dots instead of underscores.