### PR TITLE
Clean-up the causal forest bindings and related logic.

### DIFF
--- a/r-package/grf/R/RcppExports.R
+++ b/r-package/grf/R/RcppExports.R
@@ -21,20 +21,24 @@ merge <- function(forest_objects) {
     .Call('_grf_merge', PACKAGE = 'grf', forest_objects)
 }
 
-causal_predict <- function(forest_object, train_matrix, sparse_train_matrix, outcome_index, treatment_index, instrument_index, test_matrix, sparse_test_matrix, num_threads, estimate_variance) {
-    .Call('_grf_causal_predict', PACKAGE = 'grf', forest_object, train_matrix, sparse_train_matrix, outcome_index, treatment_index, instrument_index, test_matrix, sparse_test_matrix, num_threads, estimate_variance)
+causal_train <- function(train_matrix, sparse_train_matrix, outcome_index, treatment_index, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, ci_group_size, reduced_form_weight, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed) {
+    .Call('_grf_causal_train', PACKAGE = 'grf', train_matrix, sparse_train_matrix, outcome_index, treatment_index, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, ci_group_size, reduced_form_weight, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed)
 }
 
-causal_predict_oob <- function(forest_object, train_matrix, sparse_train_matrix, outcome_index, treatment_index, instrument_index, num_threads, estimate_variance) {
-    .Call('_grf_causal_predict_oob', PACKAGE = 'grf', forest_object, train_matrix, sparse_train_matrix, outcome_index, treatment_index, instrument_index, num_threads, estimate_variance)
+causal_predict <- function(forest_object, train_matrix, sparse_train_matrix, outcome_index, treatment_index, test_matrix, sparse_test_matrix, num_threads, estimate_variance) {
+    .Call('_grf_causal_predict', PACKAGE = 'grf', forest_object, train_matrix, sparse_train_matrix, outcome_index, treatment_index, test_matrix, sparse_test_matrix, num_threads, estimate_variance)
 }
 
-ll_causal_predict <- function(forest, input_data, training_data, sparse_input_data, sparse_training_data, outcome_index, treatment_index, instrument_index, lambdas, use_unweighted_penalty, linear_correction_variables, num_threads) {
-    .Call('_grf_ll_causal_predict', PACKAGE = 'grf', forest, input_data, training_data, sparse_input_data, sparse_training_data, outcome_index, treatment_index, instrument_index, lambdas, use_unweighted_penalty, linear_correction_variables, num_threads)
+causal_predict_oob <- function(forest_object, train_matrix, sparse_train_matrix, outcome_index, treatment_index, num_threads, estimate_variance) {
+    .Call('_grf_causal_predict_oob', PACKAGE = 'grf', forest_object, train_matrix, sparse_train_matrix, outcome_index, treatment_index, num_threads, estimate_variance)
 }
 
-ll_causal_predict_oob <- function(forest, input_data, sparse_input_data, outcome_index, treatment_index, instrument_index, lambdas, use_unweighted_penalty, linear_correction_variables, num_threads) {
-    .Call('_grf_ll_causal_predict_oob', PACKAGE = 'grf', forest, input_data, sparse_input_data, outcome_index, treatment_index, instrument_index, lambdas, use_unweighted_penalty, linear_correction_variables, num_threads)
+ll_causal_predict <- function(forest, input_data, training_data, sparse_input_data, sparse_training_data, outcome_index, treatment_index, lambdas, use_unweighted_penalty, linear_correction_variables, num_threads) {
+    .Call('_grf_ll_causal_predict', PACKAGE = 'grf', forest, input_data, training_data, sparse_input_data, sparse_training_data, outcome_index, treatment_index, lambdas, use_unweighted_penalty, linear_correction_variables, num_threads)
+}
+
+ll_causal_predict_oob <- function(forest, input_data, sparse_input_data, outcome_index, treatment_index, lambdas, use_unweighted_penalty, linear_correction_variables, num_threads) {
+    .Call('_grf_ll_causal_predict_oob', PACKAGE = 'grf', forest, input_data, sparse_input_data, outcome_index, treatment_index, lambdas, use_unweighted_penalty, linear_correction_variables, num_threads)
 }
 
 custom_train <- function(train_matrix, sparse_train_matrix, outcome_index, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed) {

--- a/r-package/grf/R/causal_forest.R
+++ b/r-package/grf/R/causal_forest.R
@@ -218,26 +218,25 @@ causal_forest <- function(X, Y, W,
     data <- create_data_matrices(X, Y.centered, W.centered)
     outcome.index <- ncol(X) + 1
     treatment.index <- ncol(X) + 2
-    instrument.index <- treatment.index
 
-    forest <- instrumental_train(data$default, data$sparse,
-                                 outcome.index, treatment.index, instrument.index,
-                                 as.numeric(tunable.params["mtry"]),
-                                 num.trees,
-                                 as.numeric(tunable.params["min.node.size"]),
-                                 as.numeric(tunable.params["sample.fraction"]),
-                                 honesty,
-                                 coerce_honesty_fraction(honesty.fraction),
-                                 ci.group.size,
-                                 reduced.form.weight,
-                                 as.numeric(tunable.params["alpha"]),
-                                 as.numeric(tunable.params["imbalance.penalty"]),
-                                 stabilize.splits,
-                                 clusters,
-                                 samples.per.cluster,
-                                 compute.oob.predictions,
-                                 num.threads,
-                                 seed)
+    forest <- causal_train(data$default, data$sparse,
+                           outcome.index, treatment.index,
+                           as.numeric(tunable.params["mtry"]),
+                           num.trees,
+                           as.numeric(tunable.params["min.node.size"]),
+                           as.numeric(tunable.params["sample.fraction"]),
+                           honesty,
+                           coerce_honesty_fraction(honesty.fraction),
+                           ci.group.size,
+                           reduced.form.weight,
+                           as.numeric(tunable.params["alpha"]),
+                           as.numeric(tunable.params["imbalance.penalty"]),
+                           stabilize.splits,
+                           clusters,
+                           samples.per.cluster,
+                           compute.oob.predictions,
+                           num.threads,
+                           seed)
 
     class(forest) <- c("causal_forest", "grf")
     forest[["ci.group.size"]] <- ci.group.size
@@ -335,7 +334,6 @@ predict.causal_forest <- function(object, newdata = NULL,
 
     outcome.index <- ncol(X) + 1
     treatment.index <- ncol(X) + 2
-    instrument.index <- treatment.index
 
     num.threads <- validate_num_threads(num.threads)
 
@@ -353,22 +351,18 @@ predict.causal_forest <- function(object, newdata = NULL,
         data = create_data_matrices(newdata)
         if (!local.linear) {
             ret <- causal_predict(forest.short, train.data$default, train.data$sparse,
-                        outcome.index, treatment.index, instrument.index,
-                        data$default, data$sparse, num.threads, estimate.variance)
+                    outcome.index, treatment.index, data$default, data$sparse, num.threads, estimate.variance)
         } else {
             ret <- ll_causal_predict(forest.short, data$default, train.data$default, data$sparse, train.data$sparse,
-                        outcome.index, treatment.index, instrument.index,
-                        ll.lambda, ll.weight.penalty, linear.correction.variables, num.threads)
+                    outcome.index, treatment.index, ll.lambda, ll.weight.penalty, linear.correction.variables, num.threads)
         }
     } else {
         if (!local.linear) {
             ret <- causal_predict_oob(forest.short, train.data$default, train.data$sparse,
-                      outcome.index, treatment.index, instrument.index,
-                      num.threads, estimate.variance)
+                    outcome.index, treatment.index, num.threads, estimate.variance)
         } else {
             ret <- ll_causal_predict_oob(forest.short, train.data$default, train.data$sparse,
-                      outcome.index, treatment.index, instrument.index,
-                      ll.lambda, ll.weight.penalty, linear.correction.variables, num.threads)
+                    outcome.index, treatment.index, ll.lambda, ll.weight.penalty, linear.correction.variables, num.threads)
         }
     }
 

--- a/r-package/grf/R/causal_tuning.R
+++ b/r-package/grf/R/causal_tuning.R
@@ -96,7 +96,6 @@ tune_causal_forest <- function(X, Y, W, Y.hat, W.hat,
   data <- create_data_matrices(X, Y - Y.hat, W - W.hat)
   outcome.index <- ncol(X) + 1
   treatment.index <- ncol(X) + 2
-  instrument.index <- treatment.index
 
   # Separate out the tuning parameters with supplied values, and those that were
   # left as 'NULL'. We will only tune those parameters that the user didn't supply.
@@ -116,26 +115,26 @@ tune_causal_forest <- function(X, Y, W, Y.hat, W.hat,
 
   debiased.errors = apply(fit.draws, 1, function(draw) {
     params = c(fixed.params, get_params_from_draw(X, draw))
-    small.forest <- instrumental_train(data$default, data$sparse,
-                                       outcome.index, treatment.index, instrument.index,
-                                       as.numeric(params["mtry"]),
-                                       num.fit.trees,
-                                       as.numeric(params["min.node.size"]),
-                                       as.numeric(params["sample.fraction"]),
-                                       honesty,
-                                       coerce_honesty_fraction(honesty.fraction),
-                                       ci.group.size,
-                                       reduced.form.weight,
-                                       as.numeric(params["alpha"]),
-                                       as.numeric(params["imbalance.penalty"]),
-                                       stabilize.splits,
-                                       clusters,
-                                       samples.per.cluster,
-                                       compute.oob.predictions,
-                                       num.threads,
-                                       seed)
-    prediction = instrumental_predict_oob(small.forest, data$default, data$sparse,
-        outcome.index, treatment.index, instrument.index, num.threads, FALSE)
+    small.forest <- causal_train(data$default, data$sparse,
+                                 outcome.index, treatment.index,
+                                 as.numeric(params["mtry"]),
+                                 num.fit.trees,
+                                 as.numeric(params["min.node.size"]),
+                                 as.numeric(params["sample.fraction"]),
+                                 honesty,
+                                 coerce_honesty_fraction(honesty.fraction),
+                                 ci.group.size,
+                                 reduced.form.weight,
+                                 as.numeric(params["alpha"]),
+                                 as.numeric(params["imbalance.penalty"]),
+                                 stabilize.splits,
+                                 clusters,
+                                 samples.per.cluster,
+                                 compute.oob.predictions,
+                                 num.threads,
+                                 seed)
+    prediction = causal_predict_oob(small.forest, data$default, data$sparse,
+        outcome.index, treatment.index, num.threads, FALSE)
     mean(prediction$debiased.error, na.rm = TRUE)
   })
 

--- a/r-package/grf/R/local_linear_forest.R
+++ b/r-package/grf/R/local_linear_forest.R
@@ -15,8 +15,8 @@
 #' @param min.node.size A target for the minimum number of observations in each tree leaf. Note that nodes
 #'                      with size smaller than min.node.size can occur, as in the original randomForest package.
 #' @param honesty Whether or not honest splitting (i.e., sub-sample splitting) should be used.
-#' @param honesty.fraction The fraction of data that will be used for determining splits if honesty = TRUE. Corresponds 
-#'                         to set J1 in the notation of the paper. When using the defaults (honesty = TRUE and 
+#' @param honesty.fraction The fraction of data that will be used for determining splits if honesty = TRUE. Corresponds
+#'                         to set J1 in the notation of the paper. When using the defaults (honesty = TRUE and
 #'                         honesty.fraction = NULL), half of the data will be used for determining splits
 #' @param ci.group.size The forest will grow ci.group.size trees on each subsample.
 #'                      In order to provide confidence intervals, ci.group.size must
@@ -61,7 +61,7 @@ ll_regression_forest <- function(X, Y,
                                 min.node.size = NULL,
                                 honesty = TRUE,
                                 honesty.fraction = NULL,
-                                ci.group.size = 1, 
+                                ci.group.size = 1,
                                 alpha = NULL,
                                 imbalance.penalty = NULL,
                                 clusters = NULL,
@@ -75,7 +75,7 @@ ll_regression_forest <- function(X, Y,
                                 seed = NULL) {
   validate_X(X)
   validate_observations(Y, X)
-  
+
   num.threads <- validate_num_threads(num.threads)
   seed <- validate_seed(seed)
   clusters <- validate_clusters(clusters, X)

--- a/r-package/grf/bindings/CausalForestBindings.cpp
+++ b/r-package/grf/bindings/CausalForestBindings.cpp
@@ -27,12 +27,55 @@
 #include "RcppUtilities.h"
 
 // [[Rcpp::export]]
+Rcpp::List causal_train(Rcpp::NumericMatrix train_matrix,
+                        Eigen::SparseMatrix<double> sparse_train_matrix,
+                        size_t outcome_index,
+                        size_t treatment_index,
+                        unsigned int mtry,
+                        unsigned int num_trees,
+                        unsigned int min_node_size,
+                        double sample_fraction,
+                        bool honesty,
+                        double honesty_fraction,
+                        size_t ci_group_size,
+                        double reduced_form_weight,
+                        double alpha,
+                        double imbalance_penalty,
+                        bool stabilize_splits,
+                        std::vector<size_t> clusters,
+                        unsigned int samples_per_cluster,
+                        bool compute_oob_predictions,
+                        unsigned int num_threads,
+                        unsigned int seed) {
+  ForestTrainer trainer = ForestTrainers::instrumental_trainer(reduced_form_weight, stabilize_splits);
+
+  Data* data = RcppUtilities::convert_data(train_matrix, sparse_train_matrix);
+  data->set_outcome_index(outcome_index - 1);
+  data->set_treatment_index(treatment_index - 1);
+  data->set_instrument_index(treatment_index - 1);
+  data->sort();
+
+  ForestOptions options(num_trees, ci_group_size, sample_fraction, mtry, min_node_size, honesty,
+                        honesty_fraction, alpha, imbalance_penalty, num_threads, seed, clusters, samples_per_cluster);
+  Forest forest = trainer.train(data, options);
+
+  std::vector<Prediction> predictions;
+  if (compute_oob_predictions) {
+    ForestPredictor predictor = ForestPredictors::instrumental_predictor(num_threads);
+    predictions = predictor.predict_oob(forest, data, false);
+  }
+
+  delete data;
+  return RcppUtilities::create_forest_object(forest, predictions);
+}
+
+
+// [[Rcpp::export]]
 Rcpp::List causal_predict(Rcpp::List forest_object,
                           Rcpp::NumericMatrix train_matrix,
                           Eigen::SparseMatrix<double> sparse_train_matrix,
                           size_t outcome_index,
                           size_t treatment_index,
-                          size_t instrument_index,
                           Rcpp::NumericMatrix test_matrix,
                           Eigen::SparseMatrix<double> sparse_test_matrix,
                           unsigned int num_threads,
@@ -40,7 +83,7 @@ Rcpp::List causal_predict(Rcpp::List forest_object,
   Data* train_data = RcppUtilities::convert_data(train_matrix, sparse_train_matrix);
   train_data->set_outcome_index(outcome_index - 1);
   train_data->set_treatment_index(treatment_index - 1);
-  train_data->set_instrument_index(instrument_index - 1);
+  train_data->set_instrument_index(treatment_index - 1);
   Data* data = RcppUtilities::convert_data(test_matrix, sparse_test_matrix);
 
   Forest forest = RcppUtilities::deserialize_forest(forest_object);
@@ -60,13 +103,12 @@ Rcpp::List causal_predict_oob(Rcpp::List forest_object,
                               Eigen::SparseMatrix<double> sparse_train_matrix,
                               size_t outcome_index,
                               size_t treatment_index,
-                              size_t instrument_index,
                               unsigned int num_threads,
                               bool estimate_variance) {
   Data* data = RcppUtilities::convert_data(train_matrix, sparse_train_matrix);
   data->set_outcome_index(outcome_index - 1);
   data->set_treatment_index(treatment_index - 1);
-  data->set_instrument_index(instrument_index - 1);
+  data->set_instrument_index(treatment_index - 1);
 
   Forest forest = RcppUtilities::deserialize_forest(forest_object);
 
@@ -86,7 +128,6 @@ Rcpp::List ll_causal_predict(Rcpp::List forest,
                                  Eigen::SparseMatrix<double> sparse_training_data,
                                  size_t outcome_index,
                                  size_t treatment_index,
-                                 size_t instrument_index,
                                  std::vector<double> lambdas,
                                  bool use_unweighted_penalty,
                                  std::vector<size_t> linear_correction_variables,
@@ -96,7 +137,7 @@ Rcpp::List ll_causal_predict(Rcpp::List forest,
 
   train_data->set_outcome_index(outcome_index - 1);
   train_data->set_treatment_index(treatment_index - 1);
-  train_data->set_instrument_index(instrument_index - 1);
+  train_data->set_instrument_index(treatment_index - 1);
 
   Forest deserialized_forest = RcppUtilities::deserialize_forest(forest);
 
@@ -116,7 +157,6 @@ Rcpp::List ll_causal_predict_oob(Rcpp::List forest,
                                      Eigen::SparseMatrix<double> sparse_input_data,
                                      size_t outcome_index,
                                      size_t treatment_index,
-                                     size_t instrument_index,
                                      std::vector<double> lambdas,
                                      bool use_unweighted_penalty,
                                      std::vector<size_t> linear_correction_variables,
@@ -125,7 +165,7 @@ Rcpp::List ll_causal_predict_oob(Rcpp::List forest,
 
   data->set_outcome_index(outcome_index - 1);
   data->set_treatment_index(treatment_index - 1);
-  data->set_instrument_index(instrument_index - 1);
+  data->set_instrument_index(treatment_index - 1);
 
   Forest deserialized_forest = RcppUtilities::deserialize_forest(forest);
 


### PR DESCRIPTION
* Add a binding for `causal_train`, so that the  R `causal_forest` methods consistently call into `CausalForestBindings` (and not `InstrumentalForestBindings` as well).
* Remove the `instrument_index` parameter from all methods in `CausalForestBindings`.