### PR TITLE
Ensure merged forests contain the necessary saved attributes.

### DIFF
--- a/r-package/grf/R/merge_forests.R
+++ b/r-package/grf/R/merge_forests.R
@@ -1,16 +1,16 @@
 #' Merges a list of forests that were grown using the same data into one large forest.
 #'
-#' @param forest_list A `list` of forests to be concatenated. 
+#' @param forest_list A `list` of forests to be concatenated.
 #'                        All forests must be of the same type, and the type must be a subclass of `grf`.
-#'                        In addition, all forests must have the same 'ci.group.size'. 
+#'                        In addition, all forests must have the same 'ci.group.size'.
 #'                        Other tuning parameters (e.g. alpha, mtry, min.node.size, imbalance.penalty) are
 #'                        allowed to differ across forests.
-#'                        
+#'
 #' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed.
 #'        Note that even if OOB predictions have already been precomputed for the forests in 'forest_list',
-#'        those predictions are not used. Instead, a new set of oob predictions is computed anew using the 
+#'        those predictions are not used. Instead, a new set of oob predictions is computed anew using the
 #'        larger forest.
-#' 
+#'
 #' @return A single forest containing all the trees in each forest in the input list.
 #'
 #' @examples \dontrun{
@@ -24,53 +24,52 @@
 #' # Join the forests together. The resulting forest will contain 200 trees.
 #' big_rf = merge_forests(list(r.forest1, r.forest2))
 #' }
-#' 
+#'
 #' @export
 merge_forests <- function(forest_list, compute.oob.predictions=TRUE) {
-  
-  validate_forest_list(forest_list)
-  
-  first_forest <- forest_list[[1]]
-  data <- create_data_matrices(first_forest$X.orig, first_forest$Y.orig)
-  
-  big_forest <- merge(forest_list)
-  
-  big_forest[["ci.group.size"]] <- first_forest$ci.group.size
-  big_forest[["X.orig"]] <- first_forest$X.orig
-  big_forest[["Y.orig"]] <- first_forest$Y.orig
-  big_forest[["clusters"]] <- first_forest$clusters
 
+  validate_forest_list(forest_list)
+  first_forest <- forest_list[[1]]
+
+  big_forest <- merge(forest_list)
+
+  # Make sure the new forest contains the necessary saved components like 'X.orig'.
   class(big_forest) <- class(first_forest)
-  
+  for (name in names(first_forest)) {
+    if (!startsWith(name, "_")
+        && name != "predictions"
+        && name != "debiased.error"
+        && name != "excess.error") {
+      big_forest[[name]] <- first_forest[[name]]
+    }
+  }
+
   if (compute.oob.predictions) {
     oob.pred <- predict(big_forest)
     big_forest[["predictions"]] <- oob.pred$predictions
     big_forest[["debiased.error"]] <- oob.pred$debiased.error
     big_forest[["excess.error"]] <- oob.pred$excess.error
   }
-  
+
   big_forest
 }
 
 
 validate_forest_list <- function(forest_list) {
-  
+
   if (length(forest_list) == 0) {
     stop("Length of argument 'forest_list' must be positive.")
   }
-  
+
   first_forest <- forest_list[[1]]
   if (!is(first_forest, "grf")) {
-    stop("Argument 'forest_list' must be a list of grf objects. 
+    stop("Argument 'forest_list' must be a list of grf objects.
            Be sure to use 'list(forest1, forest2), not 'c(forest1, forest2)'.")
   }
-  
+
   classes <- unique(sapply(forest_list, class)[1,])
   if (length(classes) > 1) {
-    stop(paste("All forests in 'forest_list' must be of the same type, but we found:", 
+    stop(paste("All forests in 'forest_list' must be of the same type, but we found:",
                paste(classes, collapse=", ")))
   }
 }
-
-
-

--- a/r-package/grf/tests/testthat/test_merge_forests.R
+++ b/r-package/grf/tests/testthat/test_merge_forests.R
@@ -1,6 +1,6 @@
 library(grf)
 
-test_that("Concatenated regression forest attributes are sensible", {
+test_that("Merged regression forest attributes are sensible", {
   # Train regression forests
   n = 50; p = 2
   X = matrix(rnorm(n*p), n, p)
@@ -9,17 +9,16 @@ test_that("Concatenated regression forest attributes are sensible", {
   r.forest1 = regression_forest(X, Y, compute.oob.predictions = FALSE, num.trees = 10)
   r.forest2 = regression_forest(X, Y, compute.oob.predictions = FALSE, num.trees = 10)
 
-  # Join the forests together. 
-  big_rf = merge_forests(list(r.forest1, r.forest2))
+  # Join the forests together.
+  big.rf = merge_forests(list(r.forest1, r.forest2))
 
   # Result is also a regression_forest of the same class
-  expect_true(is(big_rf, "grf"))
-  expect_equal(r.forest1[["_num_trees"]] + r.forest2[["_num_trees"]], big_rf[["_num_trees"]])
-  expect_equal(class(r.forest1), class(big_rf))
+  expect_true(is(big.rf, "grf"))
+  expect_equal(r.forest1[["_num_trees"]] + r.forest2[["_num_trees"]], big.rf[["_num_trees"]])
+  expect_equal(class(r.forest1), class(big.rf))
 })
 
-
-test_that("Concatenated causal forest attributes are sensible", {
+test_that("Merged causal forest attributes are sensible", {
   # Train causal forests
   n = 50; p = 2
   X = matrix(rnorm(n*p), n, p)
@@ -27,14 +26,43 @@ test_that("Concatenated causal forest attributes are sensible", {
   W = X[,2] > 0
   c.forest1 = causal_forest(X, Y, W, compute.oob.predictions = FALSE, num.trees = 10)
   c.forest2 = causal_forest(X, Y, W, compute.oob.predictions = FALSE, num.trees = 10)
-  
-  # Join the forests together. 
-  big_rf = merge_forests(list(c.forest1, c.forest2))
-  
+
+  # Join the forests together.
+  big.rf = merge_forests(list(c.forest1, c.forest2))
+
   # Result is also a causal forest of the same class
-  expect_true(big_rf[["_num_trees"]] == (c.forest1[["_num_trees"]] + c.forest2[["_num_trees"]]))
-  expect_true(is(big_rf, "grf"))
-  expect_equal(class(c.forest1), class(big_rf))
+  expect_true(big.rf[["_num_trees"]] == (c.forest1[["_num_trees"]] + c.forest2[["_num_trees"]]))
+  expect_true(is(big.rf, "grf"))
+  expect_equal(class(c.forest1), class(big.rf))
+
+  expect_equal(c.forest1$Y.hat, big.rf$Y.hat)
+  expect_equal(c.forest1$W.hat, big.rf$W.hat)
+})
+
+
+test_that("Merged causal forests give reasonable predictions", {
+  n = 50; p = 2
+  X = matrix(rnorm(n*p), n, p)
+  Y = X[,1] * rnorm(n)
+  W = X[,2] > 0
+
+  # Train a causal forest.
+  c.forest1 = causal_forest(X, Y, W, num.trees = 100)
+
+  # Train another forest and merge it into the first.
+  c.forest2 = causal_forest(X, Y, W, num.trees = 100)
+  big.rf = merge_forests(list(c.forest1, c.forest2))
+
+  preds = predict(c.forest1)
+  excess.error = mean(preds$excess.error)
+  error = mean(preds$debiased.error) + excess.error
+
+  big.preds = predict(big.rf)
+  big.excess.error = mean(big.preds$excess.error)
+  big.error = mean(big.preds$debiased.error) + big.excess.error
+
+  expect_lt(big.error, error)
+  expect_lt(big.excess.error, excess.error)
 })
 
 test_that("Incompatible forests are not mergeable", {
@@ -43,21 +71,17 @@ test_that("Incompatible forests are not mergeable", {
   X = matrix(rnorm(n*p), n, p)
   Y = X[,1] * rnorm(n)
   W = X[,2] > 0
-  
+
   c.forest1 = causal_forest(X, Y, W, compute.oob.predictions = FALSE, num.trees = 10,
                             ci.group.size=3)
   c.forest2 = causal_forest(X, Y, W, compute.oob.predictions = FALSE, num.trees = 10,
                             ci.group.size=4)
   r.forest1 = regression_forest(X, Y, ci.group.size=3)
-  
+
   #  Empty input
-  expect_error(merge_forests(list()))  
-  # Incompatible classes 
+  expect_error(merge_forests(list()))
+  # Incompatible classes
   expect_error(merge_forests(list(c.forest1, r.forest1)))
   # Incompatible ci.group.size
   expect_error(merge_forests(list(c.forest1, c.forest2)))
 })
-
-
-
-


### PR DESCRIPTION
This fixes a bug where merged forests did not contain some attributes that are
required for calling follow-up methods such as `Y.hat` and `W.hat`.