### PR TITLE
Add tuning output

### DIFF
--- a/r-package/grf/NAMESPACE
+++ b/r-package/grf/NAMESPACE
@@ -17,6 +17,7 @@ S3method(predict,regression_forest)
 S3method(print,boosted_regression_forest)
 S3method(print,grf)
 S3method(print,grf_tree)
+S3method(print,tuning_output)
 
 export(average_treatment_effect)
 export(average_partial_effect)

--- a/r-package/grf/R/causal_forest.R
+++ b/r-package/grf/R/causal_forest.R
@@ -248,7 +248,7 @@ causal_forest <- function(X, Y, W,
     forest[["clusters"]] <- clusters
     forest[["tunable.params"]] <- tunable.params
     if (tune.parameters)
-      forest[["tuning.output"]] = tuning.output
+      forest[["tuning.output"]] <- tuning.output
     forest
 }
 

--- a/r-package/grf/R/causal_forest.R
+++ b/r-package/grf/R/causal_forest.R
@@ -62,7 +62,7 @@
 #'                    to the maximum hardware concurrency.
 #' @param seed The seed of the C++ random number generator.
 #'
-#' @return A trained causal forest object.
+#' @return A trained causal forest object. Optional tuning output information is available in `tuning.output`.
 #'
 #' @examples \dontrun{
 #' # Train a causal forest.

--- a/r-package/grf/R/causal_forest.R
+++ b/r-package/grf/R/causal_forest.R
@@ -247,6 +247,8 @@ causal_forest <- function(X, Y, W,
     forest[["W.hat"]] <- W.hat
     forest[["clusters"]] <- clusters
     forest[["tunable.params"]] <- tunable.params
+    if (tune.parameters)
+      forest[["tuning.output"]] = tuning.output
     forest
 }
 

--- a/r-package/grf/R/causal_forest.R
+++ b/r-package/grf/R/causal_forest.R
@@ -66,7 +66,8 @@
 #'                    to the maximum hardware concurrency.
 #' @param seed The seed of the C++ random number generator.
 #'
-#' @return A trained causal forest object. Optional tuning output information is available in `tuning.output`.
+#' @return A trained causal forest object. If tune.parameters is enabled,
+#'  then tuning information will be included through the `tuning.output` attribute.
 #'
 #' @examples \dontrun{
 #' # Train a causal forest.

--- a/r-package/grf/R/causal_tuning.R
+++ b/r-package/grf/R/causal_tuning.R
@@ -155,9 +155,11 @@ tune_causal_forest <- function(X, Y, W, Y.hat, W.hat,
   colnames(optimize.draws) = names(tuning.params)
   model.surface = predict(kriging.model, newdata=data.frame(optimize.draws), type = "SK")
 
-  min.error = min(model.surface$mean)
-  optimal.draw = optimize.draws[which.min(model.surface$mean),]
-  tuned.params = get_params_from_draw(X, optimal.draw)
+  tuned.params = get_params_from_draw(X, optimize.draws)
+  grid = cbind(error=model.surface$mean, tuned.params)
+  optimal.draw = which.min(grid[, "error"])
+  optimal.param = grid[optimal.draw, ]
 
-  list(error = min.error, params = c(fixed.params, tuned.params))
+  list(error = optimal.param[1], params = c(fixed.params, optimal.param[-1]),
+       grid = grid)
 }

--- a/r-package/grf/R/causal_tuning.R
+++ b/r-package/grf/R/causal_tuning.R
@@ -160,6 +160,9 @@ tune_causal_forest <- function(X, Y, W, Y.hat, W.hat,
   optimal.draw = which.min(grid[, "error"])
   optimal.param = grid[optimal.draw, ]
 
-  list(error = optimal.param[1], params = c(fixed.params, optimal.param[-1]),
-       grid = grid)
+  out = list(error = optimal.param[1], params = c(fixed.params, optimal.param[-1]),
+             grid = grid)
+  class(out) = c("tuning_output")
+
+  out
 }

--- a/r-package/grf/R/print.R
+++ b/r-package/grf/R/print.R
@@ -113,7 +113,7 @@ print.tuning_output <- function(x, tuning.quantiles = seq(0, 1, 0.2), ...) {
   cat("Optimal tuning parameters: \n")
   cat(paste0(names(opt), ": ", opt, "\n"))
 
-  cat("Average error :\n", sep="")
+  cat("Average error by ", length(tuning.quantiles) - 1, "-quantile:\n", sep="")
   for (i in out) {
     cat("\n")
     print(i, row.names = FALSE)

--- a/r-package/grf/R/print.R
+++ b/r-package/grf/R/print.R
@@ -113,12 +113,12 @@ print_tuning_params <- function(tuning.output, nq, p) {
 
   err = tuning.output$error
   params = tuning.output$params[colnames(grid)[-1]]
+  opt = formatC(c(err, params))
 
   cat("Optimal tuning parameters: \n")
-  print(noquote(formatC(params)))
-  cat("Error: ", formatC(err))
+  cat(paste0(names(opt), ": ", opt, "\n"))
 
-  cat("\n\nAverage error by ", nq, "-quantile:", sep="")
+  cat("Average error by ", nq, "-quantile:", sep="")
   for (i in out) {
     cat("\n")
     print(i)

--- a/r-package/grf/R/print.R
+++ b/r-package/grf/R/print.R
@@ -118,9 +118,8 @@ print_tuning_params <- function(tuning.output, nq, p) {
   cat("Optimal tuning parameters: \n")
   cat(paste0(names(opt), ": ", opt, "\n"))
 
-  cat("Average error by ", nq, "-quantile:", sep="")
+  cat("Average error by ", nq, "-quantile:\n", sep="")
   for (i in out) {
-    cat("\n")
-    print(i)
+    print(i, row.names = FALSE)
   }
 }

--- a/r-package/grf/R/print.R
+++ b/r-package/grf/R/print.R
@@ -93,8 +93,9 @@ print.boosted_regression_forest <- function(x, ...) {
 
 
 print_tuning_params <- function(tuning.output, nq, p) {
-  # Print average error for `nq`-quantiles of tuned parameters
-  # Extra branches for `mtry` and `min.node.size`
+  # Print average error for nq-quantiles of tuned parameters
+  # Extra branches for mtry and min.node.size (e.g. cannot form quintiles
+  # for mtry if the number of variables is less than 5)
   grid = tuning.output$grid
 
   out = lapply(colnames(grid)[-1], function(name) {

--- a/r-package/grf/R/print.R
+++ b/r-package/grf/R/print.R
@@ -106,7 +106,7 @@ print_tuning_params <- function(tuning.output, nq, p) {
     if (length(unique(q) < length(q)))
       q = unique(q)
     rank = cut(grid[, name], q, include.lowest=TRUE)
-    out = aggregate(grid[, name], by=list(rank), FUN=mean)
+    out = aggregate(grid[, "error"], by=list(rank), FUN=mean)
     colnames(out) = c(name, "error")
     out
   })

--- a/r-package/grf/R/regression_forest.R
+++ b/r-package/grf/R/regression_forest.R
@@ -45,7 +45,8 @@
 #'                    to the maximum hardware concurrency.
 #' @param seed The seed of the C++ random number generator.
 #'
-#' @return A trained regression forest object. Optional tuning output information is available in `tuning.output`.
+#' @return A trained regression forest object. If tune.parameters is enabled,
+#'  then tuning information will be included through the `tuning.output` attribute.
 #'
 #' @examples \dontrun{
 #' # Train a standard regression forest.

--- a/r-package/grf/R/regression_forest.R
+++ b/r-package/grf/R/regression_forest.R
@@ -43,7 +43,7 @@
 #'                    to the maximum hardware concurrency.
 #' @param seed The seed of the C++ random number generator.
 #'
-#' @return A trained regression forest object.
+#' @return A trained regression forest object. Optional tuning output information is available in `tuning.output`.
 #'
 #' @examples \dontrun{
 #' # Train a standard regression forest.

--- a/r-package/grf/R/regression_forest.R
+++ b/r-package/grf/R/regression_forest.R
@@ -149,6 +149,8 @@ regression_forest <- function(X, Y,
     forest[["sample.weights"]] <- sample.weights
     forest[["clusters"]] <- clusters
     forest[["tunable.params"]] <- tunable.params
+    if (tune.parameters)
+      forest[["tuning.output"]] = tuning.output
     forest
 }
 

--- a/r-package/grf/R/regression_forest.R
+++ b/r-package/grf/R/regression_forest.R
@@ -150,7 +150,7 @@ regression_forest <- function(X, Y,
     forest[["clusters"]] <- clusters
     forest[["tunable.params"]] <- tunable.params
     if (tune.parameters)
-      forest[["tuning.output"]] = tuning.output
+      forest[["tuning.output"]] <- tuning.output
     forest
 }
 

--- a/r-package/grf/R/regression_tuning.R
+++ b/r-package/grf/R/regression_tuning.R
@@ -150,6 +150,9 @@ tune_regression_forest <- function(X, Y,
   optimal.draw = which.min(grid[, "error"])
   optimal.param = grid[optimal.draw, ]
 
-  list(error = optimal.param[1], params = c(fixed.params, optimal.param[-1]),
-       grid = grid)
+  out = list(error = optimal.param[1], params = c(fixed.params, optimal.param[-1]),
+             grid = grid)
+  class(out) = c("tuning_output")
+
+  out
 }

--- a/r-package/grf/R/regression_tuning.R
+++ b/r-package/grf/R/regression_tuning.R
@@ -1,5 +1,5 @@
 #' Regression forest tuning
-#' 
+#'
 #' Finds the optimal parameters to be used in training a regression forest. This method
 #' currently tunes over min.node.size, mtry, sample.fraction, alpha, and imbalance.penalty.
 #' Please see the method 'regression_forest' for a description of the standard forest
@@ -23,8 +23,8 @@
 #' @param alpha A tuning parameter that controls the maximum imbalance of a split.
 #' @param imbalance.penalty A tuning parameter that controls how harshly imbalanced splits are penalized.
 #' @param honesty Whether or not honest splitting (i.e., sub-sample splitting) should be used.
-#' @param honesty.fraction The fraction of data that will be used for determining splits if honesty = TRUE. Corresponds 
-#'                         to set J1 in the notation of the paper. When using the defaults (honesty = TRUE and 
+#' @param honesty.fraction The fraction of data that will be used for determining splits if honesty = TRUE. Corresponds
+#'                         to set J1 in the notation of the paper. When using the defaults (honesty = TRUE and
 #'                         honesty.fraction = NULL), half of the data will be used for determining splits
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
 #' @param samples.per.cluster If sampling by cluster, the number of observations to be sampled from
@@ -96,13 +96,13 @@ tune_regression_forest <- function(X, Y,
   if (length(tuning.params) == 0) {
     return(list("error"=NA, "params"=c(all.params)))
   }
-  
+
   # Train several mini-forests, and gather their debiased OOB error estimates.
   num.params = length(tuning.params)
   fit.draws = matrix(runif(num.fit.reps * num.params), num.fit.reps, num.params)
   colnames(fit.draws) = names(tuning.params)
   compute.oob.predictions = TRUE
-  
+
   debiased.errors = apply(fit.draws, 1, function(draw) {
     params = c(fixed.params, get_params_from_draw(X, draw))
     small.forest <- regression_train(data$default, data$sparse, outcome.index, sample.weight.index,
@@ -127,7 +127,7 @@ tune_regression_forest <- function(X, Y,
     error = prediction$debiased.error
     mean(error, na.rm = TRUE)
   })
-  
+
   # Fit the 'dice kriging' model to these error estimates.
   # Note that in the 'km' call, the kriging package prints a large amount of information
   # about the fitting process. Here, capture its console output and discard it.
@@ -138,16 +138,18 @@ tune_regression_forest <- function(X, Y,
                                    response = debiased.errors,
                                    noise.var = variance.guess))
   kriging.model <- env$kriging.model
-  
+
   # To determine the optimal parameter values, predict using the kriging model at a large
   # number of random values, then select those that produced the lowest error.
   optimize.draws = matrix(runif(num.optimize.reps * num.params), num.optimize.reps, num.params)
   colnames(optimize.draws) = names(tuning.params)
   model.surface = predict(kriging.model, newdata=data.frame(optimize.draws), type = "SK")
-  
-  min.error = min(model.surface$mean)
-  optimal.draw = optimize.draws[which.min(model.surface$mean),]
-  tuned.params = get_params_from_draw(X, optimal.draw)
-  
-  list(error = min.error, params = c(fixed.params, tuned.params))
+
+  tuned.params = get_params_from_draw(X, optimize.draws)
+  grid = cbind(error=model.surface$mean, tuned.params)
+  optimal.draw = which.min(grid[, "error"])
+  optimal.param = grid[optimal.draw, ]
+
+  list(error = optimal.param[1], params = c(fixed.params, optimal.param[-1]),
+       grid = grid)
 }

--- a/r-package/grf/R/tuning_utilities.R
+++ b/r-package/grf/R/tuning_utilities.R
@@ -26,6 +26,6 @@ get_params_from_draw <- function(X, draws) {
     else if (param == "imbalance.penalty")
       return (-log(draws[, param]))
     else
-    stop("Unrecognized parameter name provided: ", param)
+      stop("Unrecognized parameter name provided: ", param)
   }, FUN.VALUE = numeric(n))
 }

--- a/r-package/grf/R/tuning_utilities.R
+++ b/r-package/grf/R/tuning_utilities.R
@@ -10,23 +10,22 @@ get_initial_params <- function(min.node.size,
     imbalance.penalty = if (is.null(imbalance.penalty)) NA else validate_imbalance_penalty(imbalance.penalty))
 }
 
-get_params_from_draw <- function(X, draw) {
-  result = c()
-  for (param in names(draw)) {
-    if (param == "min.node.size") {
-      value = floor(2^(draw[param] * (log(nrow(X)) / log(2) - 4)))
-    } else if (param == "sample.fraction") {
-      value = 0.05 + 0.45 * draw[param]
-    } else if (param == "mtry") {
-      value = ceiling(min(ncol(X), sqrt(ncol(X)) + 20) * draw[param])
-    } else if (param == "alpha") {
-      value = draw[param]/4
-    } else if (param == "imbalance.penalty") {
-      value = -log(draw[param])
-    } else {
-      stop("Unrecognized parameter name provided: ", param)
-    }
-    result = c(result, value)
-  }
-  result
+get_params_from_draw <- function(X, draws) {
+  if (is.vector(draws))
+    draws = rbind(c(draws))
+  n = nrow(draws)
+  vapply(colnames(draws), function(param) {
+    if (param == "min.node.size")
+      return(floor(2^(draws[, param] * (log(nrow(X)) / log(2) - 4))))
+    else if (param == "sample.fraction")
+      return(0.05 + 0.45 * draws[, param])
+    else if (param == "mtry")
+      return(ceiling(min(ncol(X), sqrt(ncol(X)) + 20) * draws[, param]))
+    else if (param == "alpha")
+      return(draws[, param] / 4)
+    else if (param == "imbalance.penalty")
+      return (-log(draws[, param]))
+    else
+    stop("Unrecognized parameter name provided: ", param)
+  }, FUN.VALUE = numeric(n))
 }

--- a/r-package/grf/tests/testthat/test_print.R
+++ b/r-package/grf/tests/testthat/test_print.R
@@ -31,3 +31,15 @@ test_that("printing a forest with one regressor is successful", {
   capture_output(print(q.tree))
   expect_true(TRUE)
  })
+
+ test_that("tuning output printing is successful", {
+  p = 4
+  n = 1000
+  X = matrix(2 * runif(n * p) - 1, n, p)
+  W = rbinom(n, 1, 0.5)
+  TAU = 0.1 * (X[,1] > 0)
+  Y = TAU * (W  - 1/2) + 2 * rnorm(n)
+  tuned.forest = causal_forest(X, Y, W, num.trees = 400, tune.parameters = TRUE)
+  capture_output(print(tuned.forest$tuning.output))
+  expect_true(TRUE)
+ })

--- a/r-package/grf/tests/testthat/test_print.R
+++ b/r-package/grf/tests/testthat/test_print.R
@@ -34,12 +34,11 @@ test_that("printing a forest with one regressor is successful", {
 
  test_that("tuning output printing is successful", {
   p = 4
-  n = 1000
-  X = matrix(2 * runif(n * p) - 1, n, p)
+  n = 100
+  X = matrix(runif(n * p), n, p)
+  Y = runif(n)
   W = rbinom(n, 1, 0.5)
-  TAU = 0.1 * (X[,1] > 0)
-  Y = TAU * (W  - 1/2) + 2 * rnorm(n)
-  tuned.forest = causal_forest(X, Y, W, num.trees = 400, tune.parameters = TRUE)
+  tuned.forest = causal_forest(X, Y, W, num.trees = 100, tune.parameters = TRUE)
   capture_output(print(tuned.forest$tuning.output))
   expect_true(TRUE)
  })


### PR DESCRIPTION
Closes #237 

ref. meeting: display tuning output as average error over q-quantiles of parameters


```R
library(grf)
p = 4
n = 1000

X = matrix(2 * runif(n * p) - 1, n, p)
W = rbinom(n, 1, 0.5)
TAU = 0.1 * (X[,1] > 0)
Y = TAU * (W  - 1/2) + 2 * rnorm(n)

tuned.forest = causal_forest(X, Y, W, num.trees = 400, tune.parameters = TRUE)
print(tuned.forest$tuning.output)
```

```
Optimal tuning parameters: 
error: 4.193
 min.node.size: 34
 mtry: 2
 alpha: 0.07687
 imbalance.penalty: 0.8897
Average error by 5-quantile:

 min.node.size    error
         [1,2] 4.260210
         (2,5] 4.235934
        (5,13] 4.212460
       (13,31] 4.198461
       (31,62] 4.196825

  mtry    error
 [1,2] 4.223719
 (2,3] 4.219167
 (3,4] 4.224174

            alpha    error
 [1.32e-05,0.053] 4.222068
    (0.053,0.106] 4.220535
    (0.106,0.146] 4.225789
    (0.146,0.201] 4.224805
     (0.201,0.25] 4.221015

 imbalance.penalty    error
   [0.00027,0.215] 4.234910
     (0.215,0.516] 4.227504
     (0.516,0.944] 4.221520
      (0.944,1.62] 4.218216
       (1.62,8.59] 4.212060
```