### PR TITLE
Update input parameter to samples_per_cluster

### DIFF
--- a/experiments/acic18/script.R
+++ b/experiments/acic18/script.R
@@ -52,7 +52,7 @@ selected.idx = which(varimp > mean(varimp))
 cf = causal_forest(X[,selected.idx], Y, W,
                    Y.hat = Y.hat, W.hat = W.hat,
                    clusters = school.id,
-                   samples.per.cluster = 50,
+                   samples_per_cluster = 50,
                    tune.parameters = TRUE)
 tau.hat = predict(cf)$predictions
 


### PR DESCRIPTION
Seems to have been changed in commit 12a179f6136c7bb6146f0b9fa828ac3e02c8a280 (parent c0bf593), but was not reflect in this example script. Will throw a "unused argument (samples.per.cluster = 50)" otherwise.