### PR TITLE
CI: compile R extension with clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ matrix:
           packages:
             - clang-3.7
       env: COMPILER=clang++-3.7
+      before_script: shopt -s expand_aliases && alias g++=clang++-3.7
 
 before_install:
   - cd r-package/grf


### PR DESCRIPTION
@halflearned pointed out that in some cases his core C++ compilation would fail, but the R build would pass, that was because the C++ failed with clang, but the R package was built with GNU g++ 

With the R Makevars R CMD runs `g++`:
<img width="847" alt="Screen Shot 2019-06-15 at 21 43 48" src="https://user-images.githubusercontent.com/7185264/59559362-51c40280-8fba-11e9-8a18-1d02e6612b87.png">

Which in both build matrices is the GNU compiler
<img width="648" alt="Screen Shot 2019-06-15 at 21 43 33" src="https://user-images.githubusercontent.com/7185264/59559373-9780cb00-8fba-11e9-9c81-6a52b0f641c5.png">

Solution: alias g++ to clang++-3.7 in the clang matrix:
<img width="768" alt="Screen Shot 2019-06-15 at 22 03 14" src="https://user-images.githubusercontent.com/7185264/59559380-bb441100-8fba-11e9-957e-11eec7ec1b88.png">


