### PR TITLE
CI: Separate core C++ and R package tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,17 +12,29 @@ r_github_packages:
 
 matrix:
   include:
-    - compiler: gcc
+
+    - name: "core grf C++: gcc"
+      compiler: gcc
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
           packages:
             - g++-4.9
-      env:
-        - COMPILER=g++-4.9
-        - LINTR_COMMENT_BOT=false
-    - compiler: clang
+      env: COMPILER=g++-4.9
+      before_install:
+        - sudo apt-get update -qq
+        - sudo apt-get install -y libopencv-dev valgrind
+      install: true
+      script:
+        - cd core
+        - mkdir build && cd build
+        - cmake -DCMAKE_CXX_COMPILER=$COMPILER .. && make
+        - cd ..
+        - valgrind --leak-check=full --error-exitcode=1 ./build/grf exclude:[characterization]
+
+    - name: "core grf C++: clang"
+      compiler: clang
       addons:
         apt:
           sources:
@@ -30,22 +42,22 @@ matrix:
             - llvm-toolchain-precise-3.7
           packages:
             - clang-3.7
-      env:
-        - COMPILER=clang++-3.7
-        - LINTR_COMMENT_BOT=false
+      env: COMPILER=clang++-3.7
+      install: true
+      before_install:
+        - sudo apt-get update -qq
+        - sudo apt-get install -y libopencv-dev valgrind
+      script:
+        - cd core
+        - mkdir build && cd build
+        - cmake -DCMAKE_CXX_COMPILER=$COMPILER .. && make
+        - cd ..
+        - valgrind --leak-check=full --error-exitcode=1 ./build/grf exclude:[characterization]
 
-before_install:
-  - cd r-package/grf
-  - sudo apt-get update -qq
-  - sudo apt-get install -y libopencv-dev valgrind
-
-script:
-  # Checks for core C++
-  - cd ../../core/
-  - mkdir build && cd build
-  - cmake -DCMAKE_CXX_COMPILER=$COMPILER .. && make
-  - cd ..
-  - valgrind --leak-check=full --error-exitcode=1 ./build/grf exclude:[characterization]
-  # Checks for R package
-  - cd ../r-package
-  - Rscript build_package.R
+    - name: "grf R package"
+      env: LINTR_COMMENT_BOT=false
+      before_install:
+        - cd r-package/grf
+      script:
+        - cd ..
+        - Rscript build_package.R


### PR DESCRIPTION
This streamlines the build process a bit by separating it into 3 Travis matrices:
 
1. core grf C++ test compiled with gcc
2. core grf C++ test compiled with clang
3. R package tests (extension compiled with gcc, same as the image's R version)

(the `install: true` line in # 1-2 is just a blank dummy statement to prevent the travis R image from complaining about not finding a DESCRIPTION file, which is not needed)

There is some duplication, but is it enough to warrant a separate `build_core_grf.sh` that is run from `script` in 1.-2.?

[Here](https://travis-ci.com/grf-labs/grf/builds/119096869) is an example build output