### PR TITLE
R Docs: add default parameter value in all doc strings

### DIFF
--- a/r-package/grf/R/average_partial_effect.R
+++ b/r-package/grf/R/average_partial_effect.R
@@ -18,7 +18,7 @@
 #'               estimate the ATE. WARNING: For valid statistical performance,
 #'               the subset should be defined only using features Xi, not using
 #'               the treatment Wi or the outcome Yi.
-#' @param num.trees.for.variance Number of trees used to estimate Var[Wi | Xi = x].
+#' @param num.trees.for.variance Number of trees used to estimate Var[Wi | Xi = x]. Default is 500.
 #'
 #' @examples
 #' \dontrun{

--- a/r-package/grf/R/boosted_regression_forest.R
+++ b/r-package/grf/R/boosted_regression_forest.R
@@ -8,33 +8,37 @@
 #' @param X The covariates used in the regression.
 #' @param Y The outcome.
 #' @param sample.weights Weights given to each observation in estimation.
-#'                       If NULL, each observation receives the same weight.
+#'                       If NULL, each observation receives the same weight. Default is NULL.
 #' @param sample.fraction Fraction of the data used to build each tree.
 #'                        Note: If honesty = TRUE, these subsamples will
-#'                        further be cut by a factor of honesty.fraction.
-#' @param mtry Number of variables tried for each split.
+#'                        further be cut by a factor of honesty.fraction. Default is 0.5.
+#' @param mtry Number of variables tried for each split. Default is
+#'             \eqn{\sqrt p + 20} where p is the number of variables.
 #' @param num.trees Number of trees grown in the forest. Note: Getting accurate
 #'                  confidence intervals generally requires more trees than
-#'                  getting accurate predictions.
+#'                  getting accurate predictions. Default is 2000.
 #' @param num.threads Number of threads used in training. If set to NULL, the software
 #'                    automatically selects an appropriate amount.
 #' @param min.node.size A target for the minimum number of observations in each tree leaf. Note that nodes
 #'                      with size smaller than min.node.size can occur, as in the original randomForest package.
-#' @param honesty Whether to use honest splitting (i.e., sub-sample splitting).
+#'                      Default is 5.
+#' @param honesty Whether to use honest splitting (i.e., sub-sample splitting). Default is TRUE.
 #' @param honesty.fraction The fraction of data that will be used for determining splits if honesty = TRUE. Corresponds
 #'                         to set J1 in the notation of the paper. When using the defaults (honesty = TRUE and
-#'                         honesty.fraction = NULL), half of the data will be used for determining splits
+#'                         honesty.fraction = NULL), half of the data will be used for determining splits.
+#'                         Default is 0.5.
 #' @param prune.empty.leaves (experimental) If true, prunes the estimation sample tree such that no leaves
 #'  are empty. If false, keep the same tree as determined in the splits sample (if an empty leave is encountered, that
 #'  tree is skipped and does not contribute to the estimate). Setting this to false may improve performance on
-#'  small/marginally powered data, but requires more trees. Only applies if honesty is enabled. Default: TRUE.
+#'  small/marginally powered data, but requires more trees. Only applies if honesty is enabled. Default is TRUE.
 #' @param ci.group.size The forest will grow ci.group.size trees on each subsample.
 #'                      In order to provide confidence intervals, ci.group.size must
-#'                      be at least 2.
-#' @param alpha A tuning parameter that controls the maximum imbalance of a split.
-#' @param imbalance.penalty A tuning parameter that controls how harshly imbalanced splits are penalized.
+#'                      be at least 2. Default is 2.
+#' @param alpha A tuning parameter that controls the maximum imbalance of a split. Default is 0.05.
+#' @param imbalance.penalty A tuning parameter that controls how harshly imbalanced splits are penalized. Default is 0.
 #' @param seed The seed for the C++ random number generator.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
+#'                 Default is NULL (ignored).
 #' @param samples.per.cluster If sampling by cluster, the number of observations to be sampled from
 #'                            each cluster when training a tree. If NULL, we set samples.per.cluster to the size
 #'                            of the smallest cluster. If some clusters are smaller than samples.per.cluster,
@@ -42,19 +46,19 @@
 #'                            clusters with less than samples.per.cluster observations get relatively
 #'                            smaller weight than others in training the forest, i.e., the contribution
 #'                            of a given cluster to the final forest scales with the minimum of
-#'                            the number of observations in the cluster and samples.per.cluster.
+#'                            the number of observations in the cluster and samples.per.cluster. Default is NULL.
 #' @param tune.parameters If true, NULL parameters are tuned by cross-validation; if false
-#'                        NULL parameters are set to defaults.
-#' @param num.fit.trees The number of trees in each 'mini forest' used to fit the tuning model.
-#' @param num.fit.reps The number of forests used to fit the tuning model.
+#'                        NULL parameters are set to defaults. Default is FALSE.
+#' @param num.fit.trees The number of trees in each 'mini forest' used to fit the tuning model. Default is 10.
+#' @param num.fit.reps The number of forests used to fit the tuning model. Default is 100.
 #' @param num.optimize.reps The number of random parameter values considered when using the model
-#'                          to select the optimal parameters.
-#' @param boost.steps The number of boosting iterations. If NULL, selected by cross-validation
+#'                          to select the optimal parameters. Default is 1000.
+#' @param boost.steps The number of boosting iterations. If NULL, selected by cross-validation. Default is NULL.
 #' @param boost.error.reduction If boost.steps is NULL, the percentage of previous steps' error that must be estimated
-#'                  by cross validation in order to take a new step, default 0.95
-#' @param boost.max.steps The maximum number of boosting iterations to try when boost.steps NULL
+#'                  by cross validation in order to take a new step, default 0.97.
+#' @param boost.max.steps The maximum number of boosting iterations to try when boost.steps=NULL. Default is 5.
 #' @param boost.trees.tune If boost.steps is NULL, the number of trees used to test a new boosting step when tuning
-#'        boost.steps
+#'        boost.steps. Default is 10.
 #'
 #' @return A boosted regression forest object. $error contains the mean debiased error for each step, and $forests
 #'         contains the trained regression forest for each step.

--- a/r-package/grf/R/causal_forest.R
+++ b/r-package/grf/R/causal_forest.R
@@ -15,41 +15,45 @@
 #' @param Y.hat Estimates of the expected responses E[Y | Xi], marginalizing
 #'              over treatment. If Y.hat = NULL, these are estimated using
 #'              a separate regression forest. See section 6.1.1 of the GRF paper for
-#'              further discussion of this quantity.
+#'              further discussion of this quantity. Default is NULL.
 #' @param W.hat Estimates of the treatment propensities E[W | Xi]. If W.hat = NULL,
-#'              these are estimated using a separate regression forest.
+#'              these are estimated using a separate regression forest. Default is NULL.
 #' @param sample.weights (experimental) Weights given to each sample in estimation.
 #'                       If NULL, each observation receives the same weight.
 #'                       Note: To avoid introducing confounding, weights should be
-#'                       independent of the potential outcomes given X.
+#'                       independent of the potential outcomes given X. Default is NULL.
 #' @param orthog.boosting (experimental) If TRUE, then when Y.hat = NULL or W.hat is NULL,
 #'                 the missing quantities are estimated using boosted regression forests.
-#'                 The number of boosting steps is selected automatically.
+#'                 The number of boosting steps is selected automatically. Default is FALSE.
 #' @param sample.fraction Fraction of the data used to build each tree.
 #'                        Note: If honesty = TRUE, these subsamples will
-#'                        further be cut by a factor of honesty.fraction.
-#' @param mtry Number of variables tried for each split.
+#'                        further be cut by a factor of honesty.fraction. Default is 0.5.
+#' @param mtry Number of variables tried for each split. Default is
+#'             \eqn{\sqrt p + 20} where p is the number of variables.
 #' @param num.trees Number of trees grown in the forest. Note: Getting accurate
 #'                  confidence intervals generally requires more trees than
-#'                  getting accurate predictions.
+#'                  getting accurate predictions. Default is 2000.
 #' @param min.node.size A target for the minimum number of observations in each tree leaf. Note that nodes
 #'                      with size smaller than min.node.size can occur, as in the original randomForest package.
-#' @param honesty Whether to use honest splitting (i.e., sub-sample splitting).
+#'                      Default is 5.
+#' @param honesty Whether to use honest splitting (i.e., sub-sample splitting). Default is TRUE.
 #' @param honesty.fraction The fraction of data that will be used for determining splits if honesty = TRUE. Corresponds
 #'                         to set J1 in the notation of the paper. When using the defaults (honesty = TRUE and
-#'                         honesty.fraction = NULL), half of the data will be used for determining splits
+#'                         honesty.fraction = NULL), half of the data will be used for determining splits.
+#'                         Default is 0.5.
 #' @param prune.empty.leaves (experimental) If true, prunes the estimation sample tree such that no leaves
 #'  are empty. If false, keep the same tree as determined in the splits sample (if an empty leave is encountered, that
 #'  tree is skipped and does not contribute to the estimate). Setting this to false may improve performance on
-#'  small/marginally powered data, but requires more trees. Only applies if honesty is enabled. Default: TRUE.
+#'  small/marginally powered data, but requires more trees. Only applies if honesty is enabled. Default is TRUE.
 #' @param ci.group.size The forest will grow ci.group.size trees on each subsample.
 #'                      In order to provide confidence intervals, ci.group.size must
-#'                      be at least 2.
-#' @param alpha A tuning parameter that controls the maximum imbalance of a split.
-#' @param imbalance.penalty A tuning parameter that controls how harshly imbalanced splits are penalized.
+#'                      be at least 2. Default is 2.
+#' @param alpha A tuning parameter that controls the maximum imbalance of a split. Default is 0.05.
+#' @param imbalance.penalty A tuning parameter that controls how harshly imbalanced splits are penalized. Default is 0.
 #' @param stabilize.splits Whether or not the treatment should be taken into account when
-#'                         determining the imbalance of a split.
+#'                         determining the imbalance of a split. Default is TRUE.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
+#'                 Default is NULL (ignored).
 #' @param samples.per.cluster If sampling by cluster, the number of observations to be sampled from
 #'                            each cluster when training a tree. If NULL, we set samples.per.cluster to the size
 #'                            of the smallest cluster. If some clusters are smaller than samples.per.cluster,
@@ -57,14 +61,14 @@
 #'                            clusters with less than samples.per.cluster observations get relatively
 #'                            smaller weight than others in training the forest, i.e., the contribution
 #'                            of a given cluster to the final forest scales with the minimum of
-#'                            the number of observations in the cluster and samples.per.cluster.
+#'                            the number of observations in the cluster and samples.per.cluster. Default is NULL.
 #' @param tune.parameters If true, NULL parameters are tuned by cross-validation; if false
-#'                        NULL parameters are set to defaults.
-#' @param num.fit.trees The number of trees in each 'mini forest' used to fit the tuning model.
-#' @param num.fit.reps The number of forests used to fit the tuning model.
+#'                        NULL parameters are set to defaults. Default is FALSE.
+#' @param num.fit.trees The number of trees in each 'mini forest' used to fit the tuning model. Default is 200.
+#' @param num.fit.reps The number of forests used to fit the tuning model. Default is 50.
 #' @param num.optimize.reps The number of random parameter values considered when using the model
-#'                          to select the optimal parameters.
-#' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed.
+#'                          to select the optimal parameters. Default is 1000.
+#' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed. Default is TRUE.
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency.
 #' @param seed The seed of the C++ random number generator.

--- a/r-package/grf/R/causal_tuning.R
+++ b/r-package/grf/R/causal_tuning.R
@@ -18,34 +18,37 @@
 #' @param sample.weights Weights defining the population on which we want our estimator of tau(x) to perform well
 #'                       on average. If NULL, this is the population from which X1 ... Xn are sampled. Otherwise,
 #'                       it is a reweighted version, in which we observe Xi with probability proportional to
-#'                       sample.weights[i].
-#' @param num.fit.trees The number of trees in each 'mini forest' used to fit the tuning model.
-#' @param num.fit.reps The number of forests used to fit the tuning model.
+#'                       sample.weights[i]. Default is NULL.
+#' @param num.fit.trees The number of trees in each 'mini forest' used to fit the tuning model. Default is 200.
+#' @param num.fit.reps The number of forests used to fit the tuning model. Default is 50.
 #' @param num.optimize.reps The number of random parameter values considered when using the model
-#'                          to select the optimal parameters.
+#'                          to select the optimal parameters. Default is 1000.
 #' @param sample.fraction Fraction of the data used to build each tree.
 #'                        Note: If honesty = TRUE, these subsamples will
-#'                        further be cut by a factor of honesty.fraction.
-#' @param mtry Number of variables tried for each split.
-
+#'                        further be cut by a factor of honesty.fraction. Default is 0.5.
+#' @param mtry Number of variables tried for each split. Default is
+#'             \eqn{\sqrt p + 20} where p is the number of variables.
 #' @param min.node.size A target for the minimum number of observations in each tree leaf. Note that nodes
 #'                      with size smaller than min.node.size can occur, as in the original randomForest package.
-#' @param honesty Whether to use honest splitting (i.e., sub-sample splitting).
+#'                      Default is 5.
+#' @param honesty Whether to use honest splitting (i.e., sub-sample splitting). Default is TRUE.
 #' @param honesty.fraction The fraction of data that will be used for determining splits if honesty = TRUE. Corresponds
 #'                         to set J1 in the notation of the paper. When using the defaults (honesty = TRUE and
-#'                         honesty.fraction = NULL), half of the data will be used for determining splits
+#'                         honesty.fraction = NULL), half of the data will be used for determining splits.
+#'                         Default is 0.5.
 #' @param prune.empty.leaves (experimental) If true, prunes the estimation sample tree such that no leaves
 #'  are empty. If false, keep the same tree as determined in the splits sample (if an empty leave is encountered, that
 #'  tree is skipped and does not contribute to the estimate). Setting this to false may improve performance on
-#'  small/marginally powered data, but requires more trees. Only applies if honesty is enabled. Default: TRUE.
-#' @param alpha A tuning parameter that controls the maximum imbalance of a split.
-#' @param imbalance.penalty A tuning parameter that controls how harshly imbalanced splits are penalized.
+#'  small/marginally powered data, but requires more trees. Only applies if honesty is enabled. Default is TRUE.
+#' @param alpha A tuning parameter that controls the maximum imbalance of a split. Default is 0.05.
+#' @param imbalance.penalty A tuning parameter that controls how harshly imbalanced splits are penalized. Default is 0.
 #' @param stabilize.splits Whether or not the treatment should be taken into account when
-#'                         determining the imbalance of a split (experimental).
+#'                         determining the imbalance of a split (experimental). Default is TRUE.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
+#'                 Default is NULL (ignored).
 #' @param samples.per.cluster If sampling by cluster, the number of observations to be sampled from
 #'                            each cluster. Must be less than the size of the smallest cluster. If set to NULL
-#'                            software will set this value to the size of the smallest cluster.#'
+#'                            software will set this value to the size of the smallest cluster. Default is NULL.
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency.
 #' @param seed The seed of the C++ random number generator.

--- a/r-package/grf/R/custom_forest.R
+++ b/r-package/grf/R/custom_forest.R
@@ -6,24 +6,28 @@
 #' @param Y The outcome.
 #' @param sample.fraction Fraction of the data used to build each tree.
 #'                        Note: If honesty = TRUE, these subsamples will
-#'                        further be cut by a factor of honesty.fraction.
-#' @param mtry Number of variables tried for each split.
+#'                        further be cut by a factor of honesty.fraction. Default is 0.5.
+#' @param mtry Number of variables tried for each split. Default is
+#'             \eqn{\sqrt p + 20} where p is the number of variables.
 #' @param num.trees Number of trees grown in the forest. Note: Getting accurate
 #'                  confidence intervals generally requires more trees than
-#'                  getting accurate predictions.
+#'                  getting accurate predictions. Default is 2000.
 #' @param min.node.size A target for the minimum number of observations in each tree leaf. Note that nodes
 #'                      with size smaller than min.node.size can occur, as in the original randomForest package.
-#' @param honesty Whether to use honest splitting (i.e., sub-sample splitting).
+#'                      Default is 5.
+#' @param honesty Whether to use honest splitting (i.e., sub-sample splitting). Default is TRUE.
 #' @param honesty.fraction The fraction of data that will be used for determining splits if honesty = TRUE. Corresponds
 #'                         to set J1 in the notation of the paper. When using the defaults (honesty = TRUE and
-#'                         honesty.fraction = NULL), half of the data will be used for determining splits
+#'                         honesty.fraction = NULL), half of the data will be used for determining splits.
+#'                         Default is 0.5.
 #' @param prune.empty.leaves (experimental) If true, prunes the estimation sample tree such that no leaves
 #'  are empty. If false, keep the same tree as determined in the splits sample (if an empty leave is encountered, that
 #'  tree is skipped and does not contribute to the estimate). Setting this to false may improve performance on
-#'  small/marginally powered data, but requires more trees. Only applies if honesty is enabled. Default: TRUE.
-#' @param alpha A tuning parameter that controls the maximum imbalance of a split.
-#' @param imbalance.penalty A tuning parameter that controls how harshly imbalanced splits are penalized.
+#'  small/marginally powered data, but requires more trees. Only applies if honesty is enabled. Default is TRUE.
+#' @param alpha A tuning parameter that controls the maximum imbalance of a split. Default is 0.05.
+#' @param imbalance.penalty A tuning parameter that controls how harshly imbalanced splits are penalized. Default is 0.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
+#'                 Default is NULL (ignored).
 #' @param samples.per.cluster If sampling by cluster, the number of observations to be sampled from
 #'                            each cluster when training a tree. If NULL, we set samples.per.cluster to the size
 #'                            of the smallest cluster. If some clusters are smaller than samples.per.cluster,
@@ -31,8 +35,8 @@
 #'                            clusters with less than samples.per.cluster observations get relatively
 #'                            smaller weight than others in training the forest, i.e., the contribution
 #'                            of a given cluster to the final forest scales with the minimum of
-#'                            the number of observations in the cluster and samples.per.cluster.
-#' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed.
+#'                            the number of observations in the cluster and samples.per.cluster. Default is NULL.
+#' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed. Default is TRUE.
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency
 #' @param seed The seed of the C++ random number generator.

--- a/r-package/grf/R/instrumental_forest.R
+++ b/r-package/grf/R/instrumental_forest.R
@@ -13,41 +13,45 @@
 #' @param Z The instrument (may be binary or real).
 #' @param Y.hat Estimates of the expected responses E[Y | Xi], marginalizing
 #'              over treatment. If Y.hat = NULL, these are estimated using
-#'              a separate regression forest.
+#'              a separate regression forest. Default is NULL.
 #' @param W.hat Estimates of the treatment propensities E[W | Xi]. If W.hat = NULL,
-#'              these are estimated using a separate regression forest.
+#'              these are estimated using a separate regression forest. Default is NULL.
 #' @param Z.hat Estimates of the instrument propensities E[Z | Xi]. If Z.hat = NULL,
-#'              these are estimated using a separate regression forest.
+#'              these are estimated using a separate regression forest. Default is NULL.
 #' @param sample.weights (experimental) Weights given to each observation in estimation.
-#'                       If NULL, each observation receives equal weight.
+#'                       If NULL, each observation receives equal weight. Default is NULL.
 #' @param sample.fraction Fraction of the data used to build each tree.
 #'                        Note: If honesty = TRUE, these subsamples will
-#'                        further be cut by a factor of honesty.fraction.
-#' @param mtry Number of variables tried for each split.
+#'                        further be cut by a factor of honesty.fraction. Default is 0.5.
+#' @param mtry Number of variables tried for each split. Default is
+#'             \eqn{\sqrt p + 20} where p is the number of variables.
 #' @param num.trees Number of trees grown in the forest. Note: Getting accurate
 #'                  confidence intervals generally requires more trees than
-#'                  getting accurate predictions.
+#'                  getting accurate predictions. Default is 2000.
 #' @param min.node.size A target for the minimum number of observations in each tree leaf. Note that nodes
 #'                      with size smaller than min.node.size can occur, as in the original randomForest package.
-#' @param honesty Whether to use honest splitting (i.e., sub-sample splitting).
+#'                      Default is 5.
+#' @param honesty Whether to use honest splitting (i.e., sub-sample splitting). Default is TRUE.
 #' @param honesty.fraction The fraction of data that will be used for determining splits if honesty = TRUE. Corresponds
 #'                         to set J1 in the notation of the paper. When using the defaults (honesty = TRUE and
-#'                         honesty.fraction = NULL), half of the data will be used for determining splits
+#'                         honesty.fraction = NULL), half of the data will be used for determining splits.
+#'                         Default is 0.5.
 #' @param prune.empty.leaves (experimental) If true, prunes the estimation sample tree such that no leaves
 #'  are empty. If false, keep the same tree as determined in the splits sample (if an empty leave is encountered, that
 #'  tree is skipped and does not contribute to the estimate). Setting this to false may improve performance on
-#'  small/marginally powered data, but requires more trees. Only applies if honesty is enabled. Default: TRUE.
+#'  small/marginally powered data, but requires more trees. Only applies if honesty is enabled. Default is TRUE.
 #' @param ci.group.size The forst will grow ci.group.size trees on each subsample.
 #'                      In order to provide confidence intervals, ci.group.size must
-#'                      be at least 2.
+#'                      be at least 2. Default is 2.
 #' @param reduced.form.weight Whether splits should be regularized towards a naive
 #'                            splitting criterion that ignores the instrument (and
 #'                            instead emulates a causal forest).
-#' @param alpha A tuning parameter that controls the maximum imbalance of a split.
-#' @param imbalance.penalty A tuning parameter that controls how harshly imbalanced splits are penalized.
+#' @param alpha A tuning parameter that controls the maximum imbalance of a split. Default is 0.05.
+#' @param imbalance.penalty A tuning parameter that controls how harshly imbalanced splits are penalized. Default is 0.
 #' @param stabilize.splits Whether or not the instrument should be taken into account when
-#'                         determining the imbalance of a split.
+#'                         determining the imbalance of a split. Default is TRUE.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
+#'                 Default is NULL (ignored).
 #' @param samples.per.cluster If sampling by cluster, the number of observations to be sampled from
 #'                            each cluster when training a tree. If NULL, we set samples.per.cluster to the size
 #'                            of the smallest cluster. If some clusters are smaller than samples.per.cluster,
@@ -55,8 +59,8 @@
 #'                            clusters with less than samples.per.cluster observations get relatively
 #'                            smaller weight than others in training the forest, i.e., the contribution
 #'                            of a given cluster to the final forest scales with the minimum of
-#'                            the number of observations in the cluster and samples.per.cluster.
-#' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed.
+#'                            the number of observations in the cluster and samples.per.cluster. Default is NULL.
+#' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed. Default is TRUE.
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency.
 #' @param seed The seed of the C++ random number generator.

--- a/r-package/grf/R/local_linear_causal_tuning.R
+++ b/r-package/grf/R/local_linear_causal_tuning.R
@@ -4,7 +4,7 @@
 #'
 #' @param forest The forest used for prediction.
 #' @param linear.correction.variables Variables to use for local linear prediction. If left null,
-#'          all variables are used.
+#'          all variables are used. Default is NULL.
 #' @param ll.weight.penalty Option to standardize ridge penalty by covariance (TRUE),
 #'                            or penalize all covariates equally (FALSE). Defaults to FALSE.
 #' @param num.threads Number of threads used in training. If set to NULL, the software

--- a/r-package/grf/R/local_linear_forest.R
+++ b/r-package/grf/R/local_linear_forest.R
@@ -6,28 +6,32 @@
 #' @param X The covariates used in the regression.
 #' @param Y The outcome.
 #' @param sample.fraction Fraction of the data used to build each tree.
-#'                        Note: If honesty is used, these subsamples will
-#'                        further be cut in half.
-#' @param mtry Number of variables tried for each split.
+#'                        Note: If honesty = TRUE, these subsamples will
+#'                        further be cut by a factor of honesty.fraction. Default is 0.5.
+#' @param mtry Number of variables tried for each split. Default is
+#'             \eqn{\sqrt p + 20} where p is the number of variables.
 #' @param num.trees Number of trees grown in the forest. Note: Getting accurate
 #'                  confidence intervals generally requires more trees than
-#'                  getting accurate predictions.
+#'                  getting accurate predictions. Default is 2000.
 #' @param min.node.size A target for the minimum number of observations in each tree leaf. Note that nodes
 #'                      with size smaller than min.node.size can occur, as in the original randomForest package.
-#' @param honesty Whether or not honest splitting (i.e., sub-sample splitting) should be used.
+#'                      Default is 5.
+#' @param honesty Whether or not honest splitting (i.e., sub-sample splitting) should be used. Default is TRUE.
 #' @param honesty.fraction The fraction of data that will be used for determining splits if honesty = TRUE. Corresponds
 #'                         to set J1 in the notation of the paper. When using the defaults (honesty = TRUE and
-#'                         honesty.fraction = NULL), half of the data will be used for determining splits
+#'                         honesty.fraction = NULL), half of the data will be used for determining splits.
+#'                         Default is 0.5.
 #' @param prune.empty.leaves (experimental) If true, prunes the estimation sample tree such that no leaves
 #'  are empty. If false, keep the same tree as determined in the splits sample (if an empty leave is encountered, that
 #'  tree is skipped and does not contribute to the estimate). Setting this to false may improve performance on
-#'  small/marginally powered data, but requires more trees. Only applies if honesty is enabled. Default: TRUE.
+#'  small/marginally powered data, but requires more trees. Only applies if honesty is enabled. Default is TRUE.
 #' @param ci.group.size The forest will grow ci.group.size trees on each subsample.
 #'                      In order to provide confidence intervals, ci.group.size must
-#'                      be at least 2.
-#' @param alpha A tuning parameter that controls the maximum imbalance of a split.
-#' @param imbalance.penalty A tuning parameter that controls how harshly imbalanced splits are penalized.
+#'                      be at least 2. Default is 1.
+#' @param alpha A tuning parameter that controls the maximum imbalance of a split. Default is 0.05.
+#' @param imbalance.penalty A tuning parameter that controls how harshly imbalanced splits are penalized. Default is 0.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
+#'                 Default is NULL (ignored).
 #' @param samples.per.cluster If sampling by cluster, the number of observations to be sampled from
 #'                            each cluster when training a tree. If NULL, we set samples.per.cluster to the size
 #'                            of the smallest cluster. If some clusters are smaller than samples.per.cluster,
@@ -35,13 +39,13 @@
 #'                            clusters with less than samples.per.cluster observations get relatively
 #'                            smaller weight than others in training the forest, i.e., the contribution
 #'                            of a given cluster to the final forest scales with the minimum of
-#'                            the number of observations in the cluster and samples.per.cluster.
+#'                            the number of observations in the cluster and samples.per.cluster. Default is NULL.
 #' @param tune.parameters If true, NULL parameters are tuned by cross-validation; if false
-#'                        NULL parameters are set to defaults.
-#' @param num.fit.trees The number of trees in each 'mini forest' used to fit the tuning model.
-#' @param num.fit.reps The number of forests used to fit the tuning model.
+#'                        NULL parameters are set to defaults. Default is FALSE.
+#' @param num.fit.trees The number of trees in each 'mini forest' used to fit the tuning model. Default is 10.
+#' @param num.fit.reps The number of forests used to fit the tuning model. Default is 100.
 #' @param num.optimize.reps The number of random parameter values considered when using the model
-#'                          to select the optimal parameters.
+#'                          to select the optimal parameters. Default is 1000.
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency.
 #' @param seed The seed of the C++ random number generator.

--- a/r-package/grf/R/local_linear_tuning.R
+++ b/r-package/grf/R/local_linear_tuning.R
@@ -4,7 +4,7 @@
 #'
 #' @param forest The forest used for prediction.
 #' @param linear.correction.variables Variables to use for local linear prediction. If left null,
-#'          all variables are used.
+#'          all variables are used. Default is NULL.
 #' @param ll.weight.penalty Option to standardize ridge penalty by covariance (TRUE),
 #'                            or penalize all covariates equally (FALSE). Defaults to FALSE.
 #' @param num.threads Number of threads used in training. If set to NULL, the software

--- a/r-package/grf/R/merge_forests.R
+++ b/r-package/grf/R/merge_forests.R
@@ -9,7 +9,7 @@
 #' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed.
 #'        Note that even if OOB predictions have already been precomputed for the forests in 'forest_list',
 #'        those predictions are not used. Instead, a new set of oob predictions is computed anew using the
-#'        larger forest.
+#'        larger forest. Default is TRUE.
 #'
 #' @return A single forest containing all the trees in each forest in the input list.
 #'

--- a/r-package/grf/R/quantile_forest.R
+++ b/r-package/grf/R/quantile_forest.R
@@ -5,31 +5,35 @@
 #'
 #' @param X The covariates used in the quantile regression.
 #' @param Y The outcome.
-#' @param quantiles Vector of quantiles used to calibrate the forest.
+#' @param quantiles Vector of quantiles used to calibrate the forest. Default is (0.1, 0.5, 0.9).
 #' @param regression.splitting Whether to use regression splits when growing trees instead
 #'                             of specialized splits based on the quantiles (the default).
 #'                             Setting this flag to true corresponds to the approach to
-#'                             quantile forests from Meinshausen (2006).
+#'                             quantile forests from Meinshausen (2006). Default is FALSE.
 #' @param sample.fraction Fraction of the data used to build each tree.
 #'                        Note: If honesty = TRUE, these subsamples will
-#'                        further be cut by a factor of honesty.fraction.
-#' @param mtry Number of variables tried for each split.
+#'                        further be cut by a factor of honesty.fraction. Default is 0.5.
+#' @param mtry Number of variables tried for each split. Default is
+#'             \eqn{\sqrt p + 20} where p is the number of variables.
 #' @param num.trees Number of trees grown in the forest. Note: Getting accurate
 #'                  confidence intervals generally requires more trees than
-#'                  getting accurate predictions.
+#'                  getting accurate predictions. Default is 2000.
 #' @param min.node.size A target for the minimum number of observations in each tree leaf. Note that nodes
 #'                      with size smaller than min.node.size can occur, as in the original randomForest package.
-#' @param honesty Whether to use honest splitting (i.e., sub-sample splitting).
+#'                      Default is 5.
+#' @param honesty Whether to use honest splitting (i.e., sub-sample splitting). Default is TRUE.
 #' @param honesty.fraction The fraction of data that will be used for determining splits if honesty = TRUE. Corresponds
 #'                         to set J1 in the notation of the paper. When using the defaults (honesty = TRUE and
-#'                         honesty.fraction = NULL), half of the data will be used for determining splits
+#'                         honesty.fraction = NULL), half of the data will be used for determining splits.
+#'                         Default is 0.5.
 #' @param prune.empty.leaves (experimental) If true, prunes the estimation sample tree such that no leaves
 #'  are empty. If false, keep the same tree as determined in the splits sample (if an empty leave is encountered, that
 #'  tree is skipped and does not contribute to the estimate). Setting this to false may improve performance on
-#'  small/marginally powered data, but requires more trees. Only applies if honesty is enabled. Default: TRUE.
-#' @param alpha A tuning parameter that controls the maximum imbalance of a split.
-#' @param imbalance.penalty A tuning parameter that controls how harshly imbalanced splits are penalized.
+#'  small/marginally powered data, but requires more trees. Only applies if honesty is enabled. Default is TRUE.
+#' @param alpha A tuning parameter that controls the maximum imbalance of a split. Default is 0.05.
+#' @param imbalance.penalty A tuning parameter that controls how harshly imbalanced splits are penalized. Default is 0.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
+#'                 Default is NULL (ignored).
 #' @param samples.per.cluster If sampling by cluster, the number of observations to be sampled from
 #'                            each cluster when training a tree. If NULL, we set samples.per.cluster to the size
 #'                            of the smallest cluster. If some clusters are smaller than samples.per.cluster,
@@ -37,7 +41,7 @@
 #'                            clusters with less than samples.per.cluster observations get relatively
 #'                            smaller weight than others in training the forest, i.e., the contribution
 #'                            of a given cluster to the final forest scales with the minimum of
-#'                            the number of observations in the cluster and samples.per.cluster.
+#'                            the number of observations in the cluster and samples.per.cluster. Default is NULL.
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency.
 #' @param seed The seed of the C++ random number generator.

--- a/r-package/grf/R/regression_forest.R
+++ b/r-package/grf/R/regression_forest.R
@@ -6,30 +6,34 @@
 #' @param X The covariates used in the regression.
 #' @param Y The outcome.
 #' @param sample.weights (experimental) Weights given to an observation in estimation.
-#'                       If NULL, each observation is given the same weight.
+#'                       If NULL, each observation is given the same weight. Default is NULL.
 #' @param sample.fraction Fraction of the data used to build each tree.
 #'                        Note: If honesty = TRUE, these subsamples will
-#'                        further be cut by a factor of honesty.fraction.
-#' @param mtry Number of variables tried for each split.
+#'                        further be cut by a factor of honesty.fraction. Default is 0.5.
+#' @param mtry Number of variables tried for each split. Default is
+#'             \eqn{\sqrt p + 20} where p is the number of variables.
 #' @param num.trees Number of trees grown in the forest. Note: Getting accurate
 #'                  confidence intervals generally requires more trees than
-#'                  getting accurate predictions.
+#'                  getting accurate predictions. Default is 2000.
 #' @param min.node.size A target for the minimum number of observations in each tree leaf. Note that nodes
 #'                      with size smaller than min.node.size can occur, as in the original randomForest package.
-#' @param honesty Whether to use honest splitting (i.e., sub-sample splitting).
+#'                      Default is 5.
+#' @param honesty Whether to use honest splitting (i.e., sub-sample splitting). Default is TRUE.
 #' @param honesty.fraction The fraction of data that will be used for determining splits if honesty = TRUE. Corresponds
 #'                         to set J1 in the notation of the paper. When using the defaults (honesty = TRUE and
-#'                         honesty.fraction = NULL), half of the data will be used for determining splits
+#'                         honesty.fraction = NULL), half of the data will be used for determining splits.
+#'                         Default is 0.5.
 #' @param prune.empty.leaves (experimental) If true, prunes the estimation sample tree such that no leaves
 #'  are empty. If false, keep the same tree as determined in the splits sample (if an empty leave is encountered, that
 #'  tree is skipped and does not contribute to the estimate). Setting this to false may improve performance on
-#'  small/marginally powered data, but requires more trees. Only applies if honesty is enabled. Default: TRUE.
+#'  small/marginally powered data, but requires more trees. Only applies if honesty is enabled. Default is TRUE.
 #' @param ci.group.size The forest will grow ci.group.size trees on each subsample.
 #'                      In order to provide confidence intervals, ci.group.size must
-#'                      be at least 2.
-#' @param alpha A tuning parameter that controls the maximum imbalance of a split.
-#' @param imbalance.penalty A tuning parameter that controls how harshly imbalanced splits are penalized.
+#'                      be at least 2. Default is 2.
+#' @param alpha A tuning parameter that controls the maximum imbalance of a split. Default is 0.05.
+#' @param imbalance.penalty A tuning parameter that controls how harshly imbalanced splits are penalized. Default is 0.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
+#'                 Default is NULL (ignored).
 #' @param samples.per.cluster If sampling by cluster, the number of observations to be sampled from
 #'                            each cluster when training a tree. If NULL, we set samples.per.cluster to the size
 #'                            of the smallest cluster. If some clusters are smaller than samples.per.cluster,
@@ -37,14 +41,14 @@
 #'                            clusters with less than samples.per.cluster observations get relatively
 #'                            smaller weight than others in training the forest, i.e., the contribution
 #'                            of a given cluster to the final forest scales with the minimum of
-#'                            the number of observations in the cluster and samples.per.cluster.
+#'                            the number of observations in the cluster and samples.per.cluster. Default is NULL.
 #' @param tune.parameters If true, NULL parameters are tuned by cross-validation; if false
-#'                        NULL parameters are set to defaults.
-#' @param num.fit.trees The number of trees in each 'mini forest' used to fit the tuning model.
-#' @param num.fit.reps The number of forests used to fit the tuning model.
+#'                        NULL parameters are set to defaults. Default is FALSE.
+#' @param num.fit.trees The number of trees in each 'mini forest' used to fit the tuning model. Default is 10.
+#' @param num.fit.reps The number of forests used to fit the tuning model. Default is 100.
 #' @param num.optimize.reps The number of random parameter values considered when using the model
-#'                          to select the optimal parameters.
-#' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed.
+#'                          to select the optimal parameters. Default is 1000.
+#' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed. Default is TRUE.
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency.
 #' @param seed The seed of the C++ random number generator.

--- a/r-package/grf/R/regression_tuning.R
+++ b/r-package/grf/R/regression_tuning.R
@@ -11,31 +11,35 @@
 #' @param X The covariates used in the regression.
 #' @param Y The outcome.
 #' @param sample.weights (experimental) Weights given to an observation in estimation.
-#'                       If NULL, each observation is given the same weight.
-#' @param num.fit.trees The number of trees in each 'mini forest' used to fit the tuning model.
-#' @param num.fit.reps The number of forests used to fit the tuning model.
+#'                       If NULL, each observation is given the same weight. Default is NULL.
+#' @param num.fit.trees The number of trees in each 'mini forest' used to fit the tuning model. Default is 10.
+#' @param num.fit.reps The number of forests used to fit the tuning model. Default is 100.
 #' @param num.optimize.reps The number of random parameter values considered when using the model
-#'                          to select the optimal parameters.
+#'                          to select the optimal parameters. Default is 1000.
 #' @param sample.fraction Fraction of the data used to build each tree.
 #'                        Note: If honesty = TRUE, these subsamples will
-#'                        further be cut by a factor of honesty.fraction.
+#'                        further be cut by a factor of honesty.fraction. Default is 0.5.
 #' @param min.node.size A target for the minimum number of observations in each tree leaf. Note that nodes
 #'                      with size smaller than min.node.size can occur, as in the original randomForest package.
-#' @param mtry Number of variables tried for each split.
-#' @param alpha A tuning parameter that controls the maximum imbalance of a split.
-#' @param imbalance.penalty A tuning parameter that controls how harshly imbalanced splits are penalized.
-#' @param honesty Whether or not honest splitting (i.e., sub-sample splitting) should be used.
+#'                      Default is 5.
+#' @param mtry Number of variables tried for each split. Default is
+#'             \eqn{\sqrt p + 20} where p is the number of variables.
+#' @param alpha A tuning parameter that controls the maximum imbalance of a split. Default is 0.05.
+#' @param imbalance.penalty A tuning parameter that controls how harshly imbalanced splits are penalized. Default is 0.
+#' @param honesty Whether or not honest splitting (i.e., sub-sample splitting) should be used. Default is TRUE.
 #' @param honesty.fraction The fraction of data that will be used for determining splits if honesty = TRUE. Corresponds
 #'                         to set J1 in the notation of the paper. When using the defaults (honesty = TRUE and
-#'                         honesty.fraction = NULL), half of the data will be used for determining splits
+#'                         honesty.fraction = NULL), half of the data will be used for determining splits.
+#'                         Default is 0.5.
 #' @param prune.empty.leaves (experimental) If true, prunes the estimation sample tree such that no leaves
 #'  are empty. If false, keep the same tree as determined in the splits sample (if an empty leave is encountered, that
 #'  tree is skipped and does not contribute to the estimate). Setting this to false may improve performance on
-#'  small/marginally powered data, but requires more trees. Only applies if honesty is enabled. Default: TRUE.
+#'  small/marginally powered data, but requires more trees. Only applies if honesty is enabled. Default is TRUE.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
+#'                 Default is NULL (ignored).
 #' @param samples.per.cluster If sampling by cluster, the number of observations to be sampled from
 #'                            each cluster. Must be less than the size of the smallest cluster. If set to NULL
-#'                            software will set this value to the size of the smallest cluster.
+#'                            software will set this value to the size of the smallest cluster. Default is NULL.
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency.
 #' @param seed The seed of the C++ random number generator.


### PR DESCRIPTION
This PR adds the default value of the parameter in all function signature descriptions (even when a default value is set in the function declaration it is convenient to not have to scroll between that and the documentation).

Also explicitly note the default values of tunable parameters (that are set internally): `min.node.size`, `sample.fraction`, `mtry`, `alpha`, `imbalance.penalty`)