### PR TITLE
TreeTrainer::split_node_internal: make samples a const reference

### DIFF
--- a/core/src/tree/TreeTrainer.cpp
+++ b/core/src/tree/TreeTrainer.cpp
@@ -191,7 +191,7 @@ bool TreeTrainer::split_node_internal(size_t node,
                                       const Data* data,
                                       std::shared_ptr<SplittingRule> splitting_rule,
                                       const std::vector<size_t>& possible_split_vars,
-                                      std::vector<std::vector<size_t>>& samples,
+                                      const std::vector<std::vector<size_t>>& samples,
                                       std::vector<size_t>& split_vars,
                                       std::vector<double>& split_values,
                                       uint min_node_size) const {

--- a/core/src/tree/TreeTrainer.h
+++ b/core/src/tree/TreeTrainer.h
@@ -69,7 +69,7 @@ private:
                            const Data* data,
                            std::shared_ptr<SplittingRule> splitting_rule,
                            const std::vector<size_t>& possible_split_vars,
-                           std::vector<std::vector<size_t>>& samples,
+                           const std::vector<std::vector<size_t>>& samples,
                            std::vector<size_t>& split_vars,
                            std::vector<double>& split_values,
                            uint min_node_size) const ;


### PR DESCRIPTION
One step towards #186: split_node_internal() does not alter samples (that is done in split_node): update reference to const.