### PR TITLE
Improving some tests

### DIFF
--- a/r-package/grf/tests/testthat/test_average_effect.R
+++ b/r-package/grf/tests/testthat/test_average_effect.R
@@ -214,8 +214,9 @@ test_that("average treatment effect with overlap: larger example works", {
 })
 
 test_that("cluster robust average effects are consistent", {
-  p <- 6
-  n <- 400
+
+  p <- 3
+  n <- 800
 
   X <- matrix(2 * runif(n * p) - 1, n, p)
   W <- rbinom(n, 1, 0.5)
@@ -226,12 +227,11 @@ test_that("cluster robust average effects are consistent", {
   Yc <- c(Y, Y, Y, Y)
   clust <- c(1:n, 1:n, 1:n, 1:n)
 
-  forest.causal <- causal_forest(X, Y, W, num.trees = 1000, ci.group.size = 4)
+  forest.causal <- causal_forest(X, Y, W, num.trees = 2000, ci.group.size = 4)
   forest.causal.clust <- causal_forest(Xc, Yc, Wc,
-    num.trees = 1000,
-    ci.group.size = 4, clusters = clust,
-    samples.per.cluster = 7
-  )
+                                      num.trees = 2000,
+                                      ci.group.size = 4, clusters = clust,
+                                      samples.per.cluster = 7)
 
   cate.aipw <- average_treatment_effect(forest.causal, target.sample = "all", method = "AIPW")
   cate.clust.aipw <- average_treatment_effect(forest.causal.clust, target.sample = "all", method = "AIPW")

--- a/r-package/grf/tests/testthat/test_causal_forest.R
+++ b/r-package/grf/tests/testthat/test_causal_forest.R
@@ -160,19 +160,19 @@ test_that("IPCC weighting in the training of a causal forest with missing data i
   X <- matrix(rnorm(n * p), n, p)
   e <- 1 / (1 + exp(-X[, 1] + 2 * X[, 2]))
   W <- rbinom(n, 1, e)
-  tau <- 2 * (X[, 1] > 0 & X[,5] > 0) -
+  tau <- 2 * (X[, 1] > 0 & X[, 5] > 0) -
       0.5 * (X[, 2] > 0) - 0.5 * (X[, 3] > 0) - 0.5 * (X[, 4] > 0)
   Y <- W * tau + rnorm(n)
 
-  e.cc <- 1 - 0.9 * (X[, 1] > 0 & X[,5] > 0)
+  e.cc <- 1 - 0.9 * (X[, 1] > 0 & X[, 5] > 0)
   cc <- as.logical(rbinom(n, 1, e.cc))
   sample.weights <- 1 / e.cc
 
   num.trees <- 500
   mse <- function(f) {
-      tau.hat = rep(NA, n)
-      tau.hat[cc] = predict(f)$predictions
-      tau.hat[!cc] = predict(f, X[!cc,])$predictions
+      tau.hat <- rep(NA, n)
+      tau.hat[cc] <- predict(f)$predictions
+      tau.hat[!cc] <- predict(f, X[!cc, ])$predictions
       mean((tau.hat - tau)^2)
   }
 

--- a/r-package/grf/tests/testthat/test_causal_forest.R
+++ b/r-package/grf/tests/testthat/test_causal_forest.R
@@ -175,11 +175,11 @@ test_that("IPCC weighting in the training of a causal forest with missing data i
       tau.hat[!cc] = predict(f, X[!cc,])$predictions
       mean((tau.hat - tau)^2)
   }
-  
+
   forest <- causal_forest(X[cc, ], Y[cc], W[cc], num.trees = num.trees)
   weighted.forest <- causal_forest(X[cc, ], Y[cc], W[cc], sample.weights = sample.weights[cc], num.trees = num.trees)
   expect_lt(mse(weighted.forest) / mse(forest), .9)
-  
+
   boosted.forest <- causal_forest(X[cc, ], Y[cc], W[cc], orthog.boosting = TRUE, num.trees = num.trees)
   boosted.weighted.forest <- causal_forest(
       X[cc, ], Y[cc], W[cc],

--- a/r-package/grf/tests/testthat/test_confidence_intervals.R
+++ b/r-package/grf/tests/testthat/test_confidence_intervals.R
@@ -119,7 +119,7 @@ test_that("LL causal CIs are reasonable", {
 
 test_that("LL causal CIs are shorter than standard causal CIS", {
    n <- 1000
-   p <- 6
+   p <- 4
    X <- matrix(rnorm(n * p), n, p)
    W <- rbinom(n, 1, 0.5)
    TAU <- 2 * X[, 1] + X[, 2]

--- a/r-package/grf/tests/testthat/test_error_estimation.R
+++ b/r-package/grf/tests/testthat/test_error_estimation.R
@@ -28,7 +28,7 @@ test_that("regression error estimates are reasonable", {
   mse.200 <- mean((pred.200$predictions - Y)^2, na.rm = TRUE)
 
   expect_equal(err.debiased.200, mse.200, tolerance = 0.01 * sigma^2)
-  expect_equal(err.debiased.5, err.debiased.200, tolerance = 0.02 * sigma^2)
+  expect_equal(err.debiased.5, err.debiased.200, tolerance = 0.025 * sigma^2)
 
   expect_true(mse.5 - mse.200 >= sigma^2 / 10)
 })

--- a/r-package/grf/tests/testthat/test_merge_forests.R
+++ b/r-package/grf/tests/testthat/test_merge_forests.R
@@ -52,10 +52,10 @@ test_that("Merged causal forests give reasonable predictions", {
   num.trees <- 25
 
   # Train a causal forest.
-  c.forest1 <- causal_forest(X, Y, W, num.trees = num.trees, alpha=0, min.node.size = 1)
+  c.forest1 <- causal_forest(X, Y, W, num.trees = num.trees, alpha = 0, min.node.size = 1)
 
   # Train another sequence of forests of equal size, then merge them.
-  c.forests <- lapply(seq(100), function(x) causal_forest(X, Y, W, alpha=0, num.trees = num.trees, min.node.size = 1))
+  c.forests <- lapply(seq(100), function(x) causal_forest(X, Y, W, alpha = 0, num.trees = num.trees, min.node.size = 1))
   big.rf <- merge_forests(c.forests)
 
   # The merged forest should have smaller error
@@ -68,7 +68,7 @@ test_that("Merged causal forests give reasonable predictions", {
   big.error <- mean((Tau - big.preds$predictions)^2, na.rm = TRUE)
 
   expect_lt(big.error / error, 0.95)
-  expect_lt(big.excess.error/excess.error, 0.5)
+  expect_lt(big.excess.error / excess.error, 0.5)
 })
 
 test_that("Incompatible forests are not mergeable", {


### PR DESCRIPTION
These tests were badly calibrated and failing too often. These modifications ensure that they pass at least 95% of the time.

(In fact, they should pass >98% of the time, with the exception of [this](https://github.com/halflearned/grf/blob/c4e0b00497787f14623a91db48620e82cfb24599/r-package/grf/tests/testthat/test_causal_forest.R#L183) test that I could not improve)