### PR TITLE
Upgrade to a newer valgrind in CI to avoid a bug.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ r_github_packages:
 
 matrix:
   include:
-
     - name: "core grf C++: gcc"
       compiler: gcc
       addons:
@@ -24,7 +23,12 @@ matrix:
       env: COMPILER=g++-4.9
       before_install:
         - sudo apt-get update -qq
-        - sudo apt-get install -y libopencv-dev valgrind
+        - sudo apt-get install -y libopencv-dev
+
+        # Install a newer version of valgrind, the one that comes with Ubuntu 16.04 has a regression.
+        - sudo add-apt-repository -y ppa:msulikowski/valgrind
+        - sudo apt-get update -qq
+        - sudo apt-get install -qq valgrind
       install: true
       script:
         - cd core
@@ -46,7 +50,12 @@ matrix:
       install: true
       before_install:
         - sudo apt-get update -qq
-        - sudo apt-get install -y libopencv-dev valgrind
+        - sudo apt-get install -y libopencv-dev
+
+        # Install a newer version of valgrind, the one that comes with Ubuntu 16.04 has a regression.
+        - sudo add-apt-repository -y ppa:msulikowski/valgrind
+        - sudo apt-get update -qq
+        - sudo apt-get install -qq valgrind
       script:
         - cd core
         - mkdir build && cd build


### PR DESCRIPTION
Valgrind version 3.11.0 contains the following regression:
https://bugs.launchpad.net/ubuntu/+source/valgrind/+bug/1501545

This commit updates to valgrind 3.12.0 to ensure we don't hit this bug in CI.
Because version 3.12.0 is not available for the version of Ubuntu we use, we
need to download valgrind from a personal package repository.

Thanks to @erikcs for noticing and debugging this issue.