### PR TITLE
CI: Only warn on lint error

### DIFF
--- a/r-package/build_package.R
+++ b/r-package/build_package.R
@@ -25,9 +25,7 @@ linters <- with_defaults(
   default = default_linters);
 
 lint_res <- lint_package(path = package.name, linters = linters, exclusions = file.path(package.name, "R/RcppExports.R"))
-lint_res
-
-if (length(lint_res) > 0) quit(status = 1)
+print(lint_res)
 
 # If built for CRAN, exlude all test except ones with "cran" in the filename
 # by adding the following regex to .Rbuildignore.

--- a/r-package/grf/tests/testthat/test_causal_forest.R
+++ b/r-package/grf/tests/testthat/test_causal_forest.R
@@ -160,26 +160,26 @@ test_that("IPCC weighting in the training of a causal forest with missing data i
   X <- matrix(rnorm(n * p), n, p)
   e <- 1 / (1 + exp(-X[, 1] + 2 * X[, 2]))
   W <- rbinom(n, 1, e)
-  tau <- 2 * (X[, 1] > 0 & X[,5] > 0) -
+  tau <- 2 * (X[, 1] > 0 & X[, 5] > 0) -
       0.5 * (X[, 2] > 0) - 0.5 * (X[, 3] > 0) - 0.5 * (X[, 4] > 0)
   Y <- W * tau + rnorm(n)
 
-  e.cc <- 1 - 0.9 * (X[, 1] > 0 & X[,5] > 0)
+  e.cc <- 1 - 0.9 * (X[, 1] > 0 & X[, 5] > 0)
   cc <- as.logical(rbinom(n, 1, e.cc))
   sample.weights <- 1 / e.cc
 
   num.trees <- 500
   mse <- function(f) {
-      tau.hat = rep(NA, n)
-      tau.hat[cc] = predict(f)$predictions
-      tau.hat[!cc] = predict(f, X[!cc,])$predictions
+      tau.hat <- rep(NA, n)
+      tau.hat[cc] <- predict(f)$predictions
+      tau.hat[!cc] <- predict(f, X[!cc, ])$predictions
       mean((tau.hat - tau)^2)
   }
-  
+
   forest <- causal_forest(X[cc, ], Y[cc], W[cc], num.trees = num.trees)
   weighted.forest <- causal_forest(X[cc, ], Y[cc], W[cc], sample.weights = sample.weights[cc], num.trees = num.trees)
   expect_lt(mse(weighted.forest) / mse(forest), .9)
-  
+
   boosted.forest <- causal_forest(X[cc, ], Y[cc], W[cc], orthog.boosting = TRUE, num.trees = num.trees)
   boosted.weighted.forest <- causal_forest(
       X[cc, ], Y[cc], W[cc],


### PR DESCRIPTION
Previously a lint error would halt `build_package.R`, now it continues, but prints a warning. A print() statement is added so one sees the output if sourcing the script from R.

Closes #471 

~Misc: some leftover lints in test_causal_forest.R.~ (done in _Improving some tests_ (#468))