### PR TITLE
CI: Disable lintr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ r_binary_packages:
   - devtools
   - testthat
   - roxygen2
-r_github_packages:
-  - jimhester/lintr
 
 matrix:
   include:
@@ -64,7 +62,6 @@ matrix:
         - valgrind --leak-check=full --error-exitcode=1 ./build/grf exclude:[characterization]
 
     - name: "grf R package"
-      env: LINTR_COMMENT_BOT=false
       before_install:
         - cd r-package/grf
       script:

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -16,8 +16,7 @@ The core forest implementation is written in C++, with an R interface powered by
 
 ## R package
 
-To build the R package from source, cd into `r-package` and run `build_package.R`. Required development dependencies are listed there
-(note: it is recommended to install the latest [lintr](https://github.com/jimhester/lintr) package with `devtools::install_github("jimhester/lintr")`). This mimics the tests run when submitting a pull request.
+To build the R package from source, cd into `r-package` and run `build_package.R`. Required development dependencies are listed there. This mimics the tests run when submitting a pull request.
 
 An alternative development workflow is to use the accompanying grf.Rproj and build and test the package with RStudio's build menu, which can be convenient
 for quickly iterating C++/R code changes.

--- a/r-package/build_package.R
+++ b/r-package/build_package.R
@@ -15,18 +15,6 @@ library(lintr)
 
 package.name <- "grf"
 
-# Check code style consistency
-linters <- with_defaults(
-  line_length_linter(120), # Max line length = 120
-  object_name_linter = NULL, # To allow variable.names + function_names
-  commented_code_linter = NULL, # Misc. false positives
-  object_usage_linter = NULL, # Misc. false positives
-  spaces_left_parentheses_linter = NULL, # Misc. false positives
-  default = default_linters);
-
-lint_res <- lint_package(path = package.name, linters = linters, exclusions = file.path(package.name, "R/RcppExports.R"))
-print(lint_res)
-
 # If built for CRAN, exlude all test except ones with "cran" in the filename
 # by adding the following regex to .Rbuildignore.
 if (!is.na(args[1]) && args[1] == "--as-cran") {

--- a/r-package/build_package.R
+++ b/r-package/build_package.R
@@ -11,7 +11,6 @@ library(Rcpp)
 library(devtools)
 library(testthat)
 library(roxygen2)
-library(lintr)
 
 package.name <- "grf"
 


### PR DESCRIPTION
A bug in lintr hinders the CI tests on R 3.6. Disable lintr for now and revert this once https://github.com/jimhester/lintr/issues/384 has been resolved by the lintr developers. 