### PR TITLE
Fix a typo in the `@keywords` roxygen directive.

### DIFF
--- a/r-package/grf/R/plot.R
+++ b/r-package/grf/R/plot.R
@@ -3,7 +3,7 @@
 #' If it is a non-leaf node: show its splitting variable and splitting value
 #' @param tree the tree to convert
 #' @param index the index of the current node
-#' @keyword internal
+#' @keywords internal
 create_dot_body <- function(tree, index = 1) {
   node <- tree$nodes[[index]]
 
@@ -68,7 +68,7 @@ size = ", num_samples, '"];')
 #' This function generates a GraphViz representation of the tree,
 #' which is then written into `dot_string`.
 #' @param tree the tree to convert
-#' @keyword internal
+#' @keywords internal
 export_graphviz <- function(tree) {
   header <- "digraph nodes { \n node [shape=box] ;"
   footer <- "}"


### PR DESCRIPTION
In #342 we tried to exclude private helper methods from being included in the
package documentation. However we accidentally used `@keyword` instead of the
valid directive `@keywords`.