### PR TITLE
Run the characterization tests in CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
         - mkdir build && cd build
         - cmake -DCMAKE_CXX_COMPILER=$COMPILER .. && make
         - cd ..
-        - valgrind --leak-check=full --error-exitcode=1 ./build/grf exclude:[characterization]
+        - valgrind --leak-check=full --error-exitcode=1 ./build/grf
 
     - name: "core grf C++: clang"
       compiler: clang
@@ -59,7 +59,7 @@ matrix:
         - mkdir build && cd build
         - cmake -DCMAKE_CXX_COMPILER=$COMPILER .. && make
         - cd ..
-        - valgrind --leak-check=full --error-exitcode=1 ./build/grf exclude:[characterization]
+        - valgrind --leak-check=full --error-exitcode=1 ./build/grf
 
     - name: "grf R package"
       before_install:


### PR DESCRIPTION
Previously, the C++ characterization tests only passed when using clang because
of differences in the way random numbers were generated across platforms.
Because we build on a couple different platforms, we had to disable these tests
in CI.

Now that we've added platform-independent random number generation in #469, we
can enable the characterization tests.