### PR TITLE
Fix inconsistent formatting in print methods.

### DIFF
--- a/r-package/grf/R/analysis_tools.R
+++ b/r-package/grf/R/analysis_tools.R
@@ -50,7 +50,7 @@ get_tree <- function(forest, index) {
       paste("X", i, sep = ".")
     }
   })
-  
+
   # for each node, calculate the leaf stats
   tree$nodes <- lapply(tree$nodes, function(node) {
     if (node$is_leaf) {
@@ -58,8 +58,8 @@ get_tree <- function(forest, index) {
     }
     node
   })
-  
-  
+
+
   tree
 }
 
@@ -193,7 +193,7 @@ leaf_stats.default <- function(forest, samples, ...){
 #' @method leaf_stats regression_forest
 leaf_stats.regression_forest <- function(forest, samples, ...){
   leaf_stats <- c()
-  leaf_stats["avg Y"] <- round(mean(forest$Y.orig[samples]), 2)
+  leaf_stats["avg_Y"] <- round(mean(forest$Y.orig[samples]), 2)
   return(leaf_stats)
 }
 
@@ -207,8 +207,8 @@ leaf_stats.regression_forest <- function(forest, samples, ...){
 #' @method leaf_stats causal_forest
 leaf_stats.causal_forest <- function(forest, samples, ...){
   leaf_stats <- c()
-  leaf_stats["avg Y"] <- round(mean(forest$Y.orig[samples]), 2)
-  leaf_stats["avg W"] <- round(mean(forest$W.orig[samples]), 2)
+  leaf_stats["avg_Y"] <- round(mean(forest$Y.orig[samples]), 2)
+  leaf_stats["avg_W"] <- round(mean(forest$W.orig[samples]), 2)
   return(leaf_stats)
 }
 
@@ -221,10 +221,10 @@ leaf_stats.causal_forest <- function(forest, samples, ...){
 #'
 #' @method leaf_stats instrumental_forest
 leaf_stats.instrumental_forest <- function(forest, samples, ...){
-  
+
   leaf_stats <- c()
-  leaf_stats["avg Y"] <- round(mean(forest$Y.orig[samples]), 2)
-  leaf_stats["avg W"] <- round(mean(forest$W.orig[samples]), 2)
-  leaf_stats["avg Z"] <- round(mean(forest$Z.orig[samples]), 2)
+  leaf_stats["avg_Y"] <- round(mean(forest$Y.orig[samples]), 2)
+  leaf_stats["avg_W"] <- round(mean(forest$W.orig[samples]), 2)
+  leaf_stats["avg_Z"] <- round(mean(forest$Z.orig[samples]), 2)
   return(leaf_stats)
 }

--- a/r-package/grf/R/print.R
+++ b/r-package/grf/R/print.R
@@ -15,7 +15,7 @@ print.grf <- function(x, decay.exponent = 2, max.depth = 4, ...) {
   num.samples <- nrow(x$X.orig)
 
   cat("GRF forest object of type", main.class, "\n")
-  cat("Number of trees: ", x[["_num_trees"]], "\n")
+  cat("Number of trees:", x[["_num_trees"]], "\n")
   cat("Number of training samples:", num.samples, "\n")
 
   cat("Variable importance:", "\n")
@@ -30,7 +30,7 @@ print.grf <- function(x, decay.exponent = 2, max.depth = 4, ...) {
 #' @export
 print.grf_tree <- function(x, ...) {
   cat("GRF tree object", "\n")
-  cat("Number of training samples: ", x$num_samples, "\n")
+  cat("Number of training samples:", x$num_samples, "\n")
   cat("Variable splits:", "\n")
 
   # Add the index of each node as an attribute for easy access.
@@ -56,7 +56,7 @@ print.grf_tree <- function(x, ...) {
       if(!is.null(node$leaf_stats)){
         leaf_stats_text <- paste(paste(names(node$leaf_stats), unname(node$leaf_stats), sep = ": ", collapse = " "))
       }
-      output <- paste(output, "* num_samples:", length(node$samples), leaf_stats_text)
+      output <- paste(output, "* num_samples:", length(node$samples), "", leaf_stats_text)
     } else {
       split.var <- node$split_variable
       split.var.name <- x$columns[split.var]

--- a/r-package/grf/tests/testthat/test_analysis_tools.R
+++ b/r-package/grf/tests/testthat/test_analysis_tools.R
@@ -124,7 +124,7 @@ test_that("computing sample weights gives reasonable results", {
   expect_true(all(row.sums - 1.0 < 1e-10))
 })
 
-test_that("regression forest leaf nodes contains 'avg Y' only", {
+test_that("regression forest leaf nodes contains 'avg_Y' only", {
   n <- 50
   p <- 1
   X <- matrix(rnorm(n * p), n, p)
@@ -134,12 +134,12 @@ test_that("regression forest leaf nodes contains 'avg Y' only", {
   for(n in r.tree$nodes){
     if(n$is_leaf){
       expect_false(is.null(names(n$leaf_stats)))
-      expect_setequal(names(n$leaf_stats), c("avg Y"))
+      expect_setequal(names(n$leaf_stats), c("avg_Y"))
     }
   }
 })
 
-test_that("causal forest leaf nodes contains 'avg Y' and 'avg W' only", {
+test_that("causal forest leaf nodes contains 'avg_Y' and 'avg_W' only", {
   p <- 4
   n <- 100
   X <- matrix(runif(n * p), n, p)
@@ -150,35 +150,34 @@ test_that("causal forest leaf nodes contains 'avg Y' and 'avg W' only", {
   for(n in c.tree$nodes){
     if(n$is_leaf){
       expect_false(is.null(names(n$leaf_stats)))
-      expect_setequal(names(n$leaf_stats), c("avg Y", "avg W"))
+      expect_setequal(names(n$leaf_stats), c("avg_Y", "avg_W"))
     }
   }
 })
 
-test_that("instrumental forest leaf nodes contains 'avg Y', 'avg W', and 'avg Z' only", {
+test_that("instrumental forest leaf nodes contains 'avg_Y', 'avg_W', and 'avg_Z' only", {
   p <- 6
   n <- 200
 
   X <- matrix(rnorm(n * p), n, p)
-  
+
   eps <- rnorm(n)
   Z <- rbinom(n, 1, 2 / 3)
   filter <- rbinom(n, 1, 1 / (1 + exp(-1 * eps)))
   W <- Z * filter
-  
+
   tau <- apply(X[, 1:2], 1, function(xx) sum(pmax(0, xx)))
   mu <- apply(X[, 2 + 1:2], 1, function(xx) sum(pmax(0, xx)))
-  
+
   Y <- (2 * W - 1) / 2 * tau + mu + eps
-  
+
   iv.forest <- instrumental_forest(X, Y, W, Z, num.trees = 100)
   iv.tree <- get_tree(iv.forest,1)
 
   for(n in iv.tree$nodes){
     if(n$is_leaf){
       expect_false(is.null(names(n$leaf_stats)))
-      expect_setequal(names(n$leaf_stats), c("avg Y", "avg W", "avg Z"))
+      expect_setequal(names(n$leaf_stats), c("avg_Y", "avg_W", "avg_Z"))
     }
   }
 })
-


### PR DESCRIPTION
* Use underscores in leaf stats labels like `avg_Y`.
* Ensure we use spaces consistently.