### PR TITLE
Mark methods and parameters 'const' when possible.

### DIFF
--- a/core/src/analysis/SplitFrequencyComputer.cpp
+++ b/core/src/analysis/SplitFrequencyComputer.cpp
@@ -20,11 +20,11 @@
 #include "SplitFrequencyComputer.h"
 
 std::vector<std::vector<size_t>> SplitFrequencyComputer::compute(const Forest& forest,
-                                                                 size_t max_depth) {
+                                                                 size_t max_depth) const {
   size_t num_variables = forest.get_num_variables();
   std::vector<std::vector<size_t>> result(max_depth, std::vector<size_t>(num_variables));
 
-  for (std::shared_ptr<Tree> tree : forest.get_trees()) {
+  for (const auto& tree : forest.get_trees()) {
     const std::vector<std::vector<size_t>>& child_nodes = tree->get_child_nodes();
 
     size_t depth = 0;

--- a/core/src/analysis/SplitFrequencyComputer.h
+++ b/core/src/analysis/SplitFrequencyComputer.h
@@ -31,7 +31,7 @@
 class SplitFrequencyComputer {
 public:
   std::vector<std::vector<size_t>> compute(const Forest& forest,
-                                           size_t max_depth);
+                                           size_t max_depth) const;
 };
 
 

--- a/core/src/commons/Data.cpp
+++ b/core/src/commons/Data.cpp
@@ -39,7 +39,7 @@ Data::~Data() {
   }
 }
 
-bool Data::load_from_file(std::string filename) {
+bool Data::load_from_file(const std::string& filename) {
   bool result;
 
   // Open input file
@@ -78,7 +78,8 @@ bool Data::load_from_file(std::string filename) {
   return result;
 }
 
-bool Data::load_from_whitespace_file(std::ifstream& input_file, std::string first_line) {
+bool Data::load_from_whitespace_file(std::ifstream& input_file,
+                                     const std::string& first_line) {
   // Read the first line to determine the number of columns.
   std::string dummy_token;
   std::stringstream first_line_stream(first_line);
@@ -110,7 +111,9 @@ bool Data::load_from_whitespace_file(std::ifstream& input_file, std::string firs
   return error;
 }
 
-bool Data::load_from_other_file(std::ifstream& input_file, std::string first_line, char seperator) {
+bool Data::load_from_other_file(std::ifstream& input_file,
+                                const std::string& first_line,
+                                char seperator) {
   // Read the first line to determine the number of columns.
   std::string dummy_token;
   std::stringstream first_line_stream(first_line);

--- a/core/src/commons/Data.h
+++ b/core/src/commons/Data.h
@@ -36,9 +36,9 @@ public:
 
   void sort();
 
-  bool load_from_file(std::string filename);
-  bool load_from_whitespace_file(std::ifstream& input_file, std::string first_line);
-  bool load_from_other_file(std::ifstream& input_file, std::string first_line, char seperator);
+  bool load_from_file(const std::string& filename);
+  bool load_from_whitespace_file(std::ifstream& input_file, const std::string& first_line);
+  bool load_from_other_file(std::ifstream& input_file, const std::string& first_line, char seperator);
 
   void set_outcome_index(size_t index);
   void set_treatment_index(size_t index);

--- a/core/src/commons/utility.cpp
+++ b/core/src/commons/utility.cpp
@@ -66,7 +66,7 @@ bool equal_doubles(double first, double second, double epsilon) {
   return std::abs(first - second) < epsilon;
 }
 
-Data* load_data(std::string file_name) {
+Data* load_data(const std::string& file_name) {
   Data* data = new DefaultData();
   bool rounding_error = data->load_from_file(file_name);
   if (rounding_error) {
@@ -76,7 +76,7 @@ Data* load_data(std::string file_name) {
   return data;
 }
 
-Data* load_sparse_data(std::string file_name) {
+Data* load_sparse_data(const std::string& file_name) {
   Data* data = new SparseData();
   bool rounding_error = data->load_from_file(file_name);
   if (rounding_error) {

--- a/core/src/commons/utility.h
+++ b/core/src/commons/utility.h
@@ -39,8 +39,8 @@ void split_sequence(std::vector<uint>& result, uint start, uint end, uint num_pa
 
 bool equal_doubles(double first, double second, double epsilon);
 
-Data* load_data(std::string file_name);
+Data* load_data(const std::string& file_name);
 
-Data* load_sparse_data(std::string file_name);
+Data* load_sparse_data(const std::string& file_name);
 
 #endif /* GRF_UTILITY_H_ */

--- a/core/src/forest/Forest.cpp
+++ b/core/src/forest/Forest.cpp
@@ -18,7 +18,7 @@
 #include "commons/DefaultData.h"
 #include "forest/Forest.h"
 
-Forest Forest::create(std::vector<std::shared_ptr<Tree>> trees,
+Forest Forest::create(const std::vector<std::shared_ptr<Tree>>& trees,
                       const ForestOptions& forest_options,
                       const Data* data) {
   size_t num_independent_variables = data->get_num_cols() -

--- a/core/src/forest/Forest.h
+++ b/core/src/forest/Forest.h
@@ -26,7 +26,7 @@
 
 class Forest {
 public:
-  static Forest create(std::vector<std::shared_ptr<Tree>> trees,
+  static Forest create(const std::vector<std::shared_ptr<Tree>>& trees,
                        const ForestOptions& forest_options,
                        const Data* data);
 

--- a/core/src/prediction/CustomPredictionStrategy.cpp
+++ b/core/src/prediction/CustomPredictionStrategy.cpp
@@ -17,14 +17,14 @@
 
 #include "CustomPredictionStrategy.h"
 
-size_t CustomPredictionStrategy::prediction_length() {
+size_t CustomPredictionStrategy::prediction_length() const {
   return 1;
 }
 
 std::vector<double> CustomPredictionStrategy::predict(size_t sample,
     const std::unordered_map<size_t, double>& weights_by_sample,
     const Data* train_data,
-    const Data* data) {
+    const Data* data) const {
   return { 0.0 };
 }
 
@@ -34,6 +34,6 @@ std::vector<double> CustomPredictionStrategy::compute_variance(
     std::unordered_map<size_t, double> weights_by_sampleID,
     const Data* train_data,
     const Data* data,
-    size_t ci_group_size){
+    size_t ci_group_size) const {
   return { 0.0 };
 }

--- a/core/src/prediction/CustomPredictionStrategy.h
+++ b/core/src/prediction/CustomPredictionStrategy.h
@@ -23,12 +23,12 @@
 class CustomPredictionStrategy: public DefaultPredictionStrategy {
 public:
 
-  size_t prediction_length();
+  size_t prediction_length() const;
 
   std::vector<double> predict(size_t sample,
     const std::unordered_map<size_t, double>& weights_by_sample,
     const Data* train_data,
-    const Data* data);
+    const Data* data) const;
 
   std::vector<double> compute_variance(
       size_t sampleD,
@@ -36,7 +36,7 @@ public:
       std::unordered_map<size_t, double> weights_by_sampleID,
       const Data* train_data,
       const Data* data,
-      size_t ci_group_size);
+      size_t ci_group_size) const;
 };
 
 

--- a/core/src/prediction/DefaultPredictionStrategy.h
+++ b/core/src/prediction/DefaultPredictionStrategy.h
@@ -40,7 +40,7 @@ public:
    * The number of values in a prediction, e.g. 1 for regression
    * or the number of quantiles for quantile forests.
    */
-  virtual size_t prediction_length() = 0;
+  virtual size_t prediction_length() const = 0;
 
   /**
    * Computes a prediction for a single test sample.
@@ -56,7 +56,7 @@ public:
   virtual std::vector<double> predict(size_t sample,
     const std::unordered_map<size_t, double>& weights_by_sample,
     const Data* train_data,
-    const Data* data) = 0;
+    const Data* data) const = 0;
 
   /**
    * Computes a prediction variance estimate for a single test sample.
@@ -79,7 +79,7 @@ public:
       std::unordered_map<size_t, double> weights_by_sampleID,
       const Data* train_data,
       const Data* data,
-      size_t ci_group_size) = 0;
+      size_t ci_group_size) const = 0;
 };
 
 #endif //GRF_PREDICTIONSTRATEGY_H

--- a/core/src/prediction/InstrumentalPredictionStrategy.cpp
+++ b/core/src/prediction/InstrumentalPredictionStrategy.cpp
@@ -31,11 +31,11 @@ const std::size_t InstrumentalPredictionStrategy::TREATMENT_INSTRUMENT = 4;
 
 const std::size_t NUM_TYPES = 5;
 
-size_t InstrumentalPredictionStrategy::prediction_length() {
+size_t InstrumentalPredictionStrategy::prediction_length() const {
     return 1;
 }
 
-std::vector<double> InstrumentalPredictionStrategy::predict(const std::vector<double>& average) {
+std::vector<double> InstrumentalPredictionStrategy::predict(const std::vector<double>& average) const {
   double instrument_effect_numerator = average.at(OUTCOME_INSTRUMENT) - average.at(OUTCOME) * average.at(INSTRUMENT);
   double first_stage_numerator = average.at(TREATMENT_INSTRUMENT) - average.at(TREATMENT) * average.at(INSTRUMENT);
 
@@ -45,7 +45,7 @@ std::vector<double> InstrumentalPredictionStrategy::predict(const std::vector<do
 std::vector<double> InstrumentalPredictionStrategy::compute_variance(
     const std::vector<double>& average,
     const PredictionValues& leaf_values,
-    size_t ci_group_size) {
+    size_t ci_group_size) const {
 
   double instrument_effect_numerator = average.at(OUTCOME_INSTRUMENT)
      - average.at(OUTCOME) * average.at(INSTRUMENT);
@@ -145,13 +145,13 @@ std::vector<double> InstrumentalPredictionStrategy::compute_variance(
   return { variance_estimate };
 }
 
-size_t InstrumentalPredictionStrategy::prediction_value_length() {
+size_t InstrumentalPredictionStrategy::prediction_value_length() const {
   return NUM_TYPES;
 }
 
 PredictionValues InstrumentalPredictionStrategy::precompute_prediction_values(
     const std::vector<std::vector<size_t>>& leaf_samples,
-    const Data* data) {
+    const Data* data) const {
   size_t num_leaves = leaf_samples.size();
 
   std::vector<std::vector<double>> values(num_leaves);
@@ -201,7 +201,7 @@ std::vector<std::pair<double, double>> InstrumentalPredictionStrategy::compute_e
     size_t sample,
     const std::vector<double>& average,
     const PredictionValues& leaf_values,
-    const Data* data) {
+    const Data* data) const {
 
   double instrument_effect_numerator = average.at(OUTCOME_INSTRUMENT) - average.at(OUTCOME) * average.at(INSTRUMENT);
   double first_stage_numerator = average.at(TREATMENT_INSTRUMENT) - average.at(TREATMENT) * average.at(INSTRUMENT);

--- a/core/src/prediction/InstrumentalPredictionStrategy.h
+++ b/core/src/prediction/InstrumentalPredictionStrategy.h
@@ -35,24 +35,24 @@ public:
   static const std::size_t OUTCOME_INSTRUMENT;
   static const std::size_t TREATMENT_INSTRUMENT;
 
-  size_t prediction_value_length();
+  size_t prediction_value_length() const;
   PredictionValues precompute_prediction_values(
       const std::vector<std::vector<size_t>>& leaf_samples,
-      const Data* data);
+      const Data* data) const;
 
-  size_t prediction_length();
+  size_t prediction_length() const;
 
-  std::vector<double> predict(const std::vector<double>& average);
+  std::vector<double> predict(const std::vector<double>& average) const;
 
   std::vector<double> compute_variance(const std::vector<double>& average,
                           const PredictionValues& leaf_values,
-                          size_t ci_group_size);
+                          size_t ci_group_size) const;
 
   std::vector<std::pair<double, double>>  compute_error(
       size_t sample,
       const std::vector<double>& average,
       const PredictionValues& leaf_values,
-      const Data* data);
+      const Data* data) const;
 
 private:
   ObjectiveBayesDebiaser bayes_debiaser;

--- a/core/src/prediction/LLCausalPredictionStrategy.cpp
+++ b/core/src/prediction/LLCausalPredictionStrategy.cpp
@@ -24,10 +24,6 @@
 #include "commons/Data.h"
 #include "prediction/LLCausalPredictionStrategy.h"
 
-size_t LLCausalPredictionStrategy::prediction_length() {
-  return lambdas.size();
-}
-
 LLCausalPredictionStrategy::LLCausalPredictionStrategy(std::vector<double> lambdas,
                                                    bool weight_penalty,
                                                    std::vector<size_t> linear_correction_variables):
@@ -36,11 +32,15 @@ LLCausalPredictionStrategy::LLCausalPredictionStrategy(std::vector<double> lambd
         linear_correction_variables(linear_correction_variables){
 };
 
+size_t LLCausalPredictionStrategy::prediction_length() const {
+  return lambdas.size();
+}
+
 std::vector<double> LLCausalPredictionStrategy::predict(
         size_t sampleID,
         const std::unordered_map<size_t, double>& weights_by_sampleID,
         const Data *train_data,
-        const Data *test_data) {
+        const Data *test_data) const {
 
   // Number of predictor variables to use in local linear regression step
   size_t num_variables = linear_correction_variables.size();
@@ -149,7 +149,7 @@ std::vector<double> LLCausalPredictionStrategy::compute_variance(
         std::unordered_map<size_t, double> weights_by_sampleID,
         const Data* train_data,
         const Data* test_data,
-        size_t ci_group_size){
+        size_t ci_group_size) const {
 
   double lambda = lambdas[0];
 

--- a/core/src/prediction/LLCausalPredictionStrategy.h
+++ b/core/src/prediction/LLCausalPredictionStrategy.h
@@ -31,13 +31,12 @@ public:
                                bool weight_penalty,
                                std::vector<size_t> linear_correction_variables);
 
-    size_t prediction_value_length();
+    size_t prediction_length() const;
 
-    size_t prediction_length();
     std::vector<double> predict(size_t sampleID,
                                 const std::unordered_map<size_t, double>& weights_by_sampleID,
                                 const Data *original_data,
-                                const Data *test_data);
+                                const Data *test_data) const;
 
     std::vector<double> compute_variance(
             size_t sampleID,
@@ -45,7 +44,7 @@ public:
             std::unordered_map<size_t, double> weights_by_sampleID,
             const Data* train_data,
             const Data* data,
-            size_t ci_group_size);
+            size_t ci_group_size) const;
 
 private:
     const Data *train_data;

--- a/core/src/prediction/LocalLinearPredictionStrategy.cpp
+++ b/core/src/prediction/LocalLinearPredictionStrategy.cpp
@@ -24,10 +24,6 @@
 #include "commons/Data.h"
 #include "prediction/LocalLinearPredictionStrategy.h"
 
-size_t LocalLinearPredictionStrategy::prediction_length() {
-  return lambdas.size();
-}
-
 LocalLinearPredictionStrategy::LocalLinearPredictionStrategy(std::vector<double> lambdas,
                                                              bool weight_penalty,
                                                              std::vector<size_t> linear_correction_variables):
@@ -36,11 +32,15 @@ LocalLinearPredictionStrategy::LocalLinearPredictionStrategy(std::vector<double>
         linear_correction_variables(linear_correction_variables){
 };
 
+size_t LocalLinearPredictionStrategy::prediction_length() const {
+  return lambdas.size();
+}
+
 std::vector<double> LocalLinearPredictionStrategy::predict(
     size_t sampleID,
     const std::unordered_map<size_t, double>& weights_by_sampleID,
     const Data* train_data,
-    const Data* data) {
+    const Data* data) const {
   size_t num_variables = linear_correction_variables.size();
   size_t num_nonzero_weights = weights_by_sampleID.size();
 
@@ -107,7 +107,7 @@ std::vector<double> LocalLinearPredictionStrategy::compute_variance(
     std::unordered_map<size_t, double> weights_by_sampleID,
     const Data* train_data,
     const Data* data,
-    size_t ci_group_size) {
+    size_t ci_group_size) const {
 
   double lambda = lambdas[0];
 

--- a/core/src/prediction/LocalLinearPredictionStrategy.h
+++ b/core/src/prediction/LocalLinearPredictionStrategy.h
@@ -35,7 +35,7 @@ public:
                                   bool weight_penalty,
                                   std::vector<size_t> linear_correction_variables);
 
-    size_t prediction_length();
+    size_t prediction_length() const;
 
     /**
     * LocalLinearPredictionStrategy::predict computes a regularization path.
@@ -46,7 +46,7 @@ public:
     std::vector<double> predict(size_t sampleID,
                                 const std::unordered_map<size_t, double>& weights_by_sampleID,
                                 const Data* train_data,
-                                const Data* data);
+                                const Data* data) const;
 
     std::vector<double> compute_variance(
         size_t sampleID,
@@ -54,7 +54,7 @@ public:
         std::unordered_map<size_t, double> weights_by_sampleID,
         const Data* train_data,
         const Data* data,
-        size_t ci_group_size);
+        size_t ci_group_size) const;
 
 private:
     std::vector<double> lambdas;

--- a/core/src/prediction/ObjectiveBayesDebiaser.cpp
+++ b/core/src/prediction/ObjectiveBayesDebiaser.cpp
@@ -24,7 +24,7 @@
 
 double ObjectiveBayesDebiaser::debias(double var_between,
                                       double group_noise,
-                                      double num_good_groups) {
+                                      double num_good_groups) const {
   
   // Let S denote the true between-groups variance, and assume that
   // group_noise is measured exactly; our method-of-moments estimate is

--- a/core/src/prediction/ObjectiveBayesDebiaser.h
+++ b/core/src/prediction/ObjectiveBayesDebiaser.h
@@ -23,7 +23,7 @@ class ObjectiveBayesDebiaser {
 public:
   double debias(double var_between,
                 double group_noise,
-                double num_good_groups);
+                double num_good_groups) const;
 private:
   const double ONE_over_SQRT_TWO_PI = 0.3989422804;
   const double ONE_over_SQRT_TWO = 0.70710678118;

--- a/core/src/prediction/OptimizedPredictionStrategy.h
+++ b/core/src/prediction/OptimizedPredictionStrategy.h
@@ -42,7 +42,7 @@ public:
   * The number of values in a prediction, e.g. 1 for regression,
   * or the number of quantiles for quantile forests.
   */
-  virtual size_t prediction_length() = 0;
+  virtual size_t prediction_length() const = 0;
 
   /**
   * Computes a prediction for a single test sample.
@@ -50,7 +50,7 @@ public:
   * average_prediction_values: the 'prediction values' computed during
   *     training, averaged across all leaves this test sample landed in.
   */
-  virtual std::vector<double> predict(const std::vector<double>& average_prediction_values) = 0;
+  virtual std::vector<double> predict(const std::vector<double>& average_prediction_values) const = 0;
 
  /**
   * Computes a prediction variance estimate for a single test sample.
@@ -66,14 +66,14 @@ public:
   virtual std::vector<double> compute_variance(
       const std::vector<double>& average_prediction_values,
       const PredictionValues& leaf_prediction_values,
-      size_t ci_group_size) = 0;
+      size_t ci_group_size) const = 0;
 
  /**
   * The number of types of precomputed prediction values. For regression
   * this is 1 (the average outcome), whereas for instrumental forests this
   * is larger, as it includes the average treatment, average instrument etc.
   */
-  virtual size_t prediction_value_length() = 0;
+  virtual size_t prediction_value_length() const = 0;
 
  /**
   * This method is called during training on each tree to precompute
@@ -84,7 +84,7 @@ public:
   */
   virtual PredictionValues precompute_prediction_values(
       const std::vector<std::vector<size_t>>& leaf_samples,
-      const Data* data) = 0;
+      const Data* data) const = 0;
 
  /**
   * Computes a pair of estimates for (out-of-bag debiased error, monte-carlo error) for a single sample.
@@ -102,7 +102,7 @@ public:
       size_t sample,
       const std::vector<double>& average,
       const PredictionValues& leaf_values,
-      const Data* data) = 0;
+      const Data* data) const = 0;
 };
 
 

--- a/core/src/prediction/QuantilePredictionStrategy.cpp
+++ b/core/src/prediction/QuantilePredictionStrategy.cpp
@@ -27,7 +27,7 @@ QuantilePredictionStrategy::QuantilePredictionStrategy(std::vector<double> quant
     quantiles(quantiles) {
 };
 
-size_t QuantilePredictionStrategy::prediction_length() {
+size_t QuantilePredictionStrategy::prediction_length() const {
     return quantiles.size();
 }
 
@@ -35,7 +35,7 @@ std::vector<double> QuantilePredictionStrategy::predict(
     size_t prediction_sample,
     const std::unordered_map<size_t, double>& weights_by_sample,
     const Data* train_data,
-    const Data* data) {
+    const Data* data) const {
   std::vector<std::pair<size_t, double>> samples_and_values;
   for (auto it = weights_by_sample.begin(); it != weights_by_sample.end(); it++) {
     size_t sample = it->first;
@@ -48,7 +48,7 @@ std::vector<double> QuantilePredictionStrategy::predict(
 
 std::vector<double> QuantilePredictionStrategy::compute_quantile_cutoffs(
     const std::unordered_map<size_t, double>& weights_by_sample,
-    std::vector<std::pair<size_t, double>>& samples_and_values) {
+    std::vector<std::pair<size_t, double>>& samples_and_values) const {
   std::sort(samples_and_values.begin(),
             samples_and_values.end(),
             [](std::pair<size_t, double> first_pair, std::pair<size_t, double> second_pair) {
@@ -87,6 +87,6 @@ std::vector<double> QuantilePredictionStrategy::compute_variance(
     std::unordered_map<size_t, double> weights_by_sampleID,
     const Data* train_data,
     const Data* data,
-    size_t ci_group_size){
+    size_t ci_group_size) const {
   return { 0.0 };
 }

--- a/core/src/prediction/QuantilePredictionStrategy.h
+++ b/core/src/prediction/QuantilePredictionStrategy.h
@@ -30,12 +30,12 @@ class QuantilePredictionStrategy: public DefaultPredictionStrategy {
 public:
   QuantilePredictionStrategy(std::vector<double> quantiles);
 
-  size_t prediction_length();
+  size_t prediction_length() const;
 
   std::vector<double> predict(size_t prediction_sample,
     const std::unordered_map<size_t, double>& weights_by_sample,
     const Data* train_data,
-    const Data* data);
+    const Data* data) const;
 
   std::vector<double> compute_variance(
       size_t sampleID,
@@ -43,11 +43,11 @@ public:
       std::unordered_map<size_t, double> weights_by_sampleID,
       const Data* train_data,
       const Data* data,
-      size_t ci_group_size);
+      size_t ci_group_size) const;
 
 private:
   std::vector<double> compute_quantile_cutoffs(const std::unordered_map<size_t, double>& weights_by_sample,
-                                               std::vector<std::pair<size_t, double>>& samples_and_values);
+                                               std::vector<std::pair<size_t, double>>& samples_and_values) const;
 
   std::vector<double> quantiles;
 };

--- a/core/src/prediction/RegressionPredictionStrategy.cpp
+++ b/core/src/prediction/RegressionPredictionStrategy.cpp
@@ -21,18 +21,18 @@
 
 const size_t RegressionPredictionStrategy::OUTCOME = 0;
 
-size_t RegressionPredictionStrategy::prediction_length() {
+size_t RegressionPredictionStrategy::prediction_length() const {
     return 1;
 }
 
-std::vector<double> RegressionPredictionStrategy::predict(const std::vector<double>& average) {
+std::vector<double> RegressionPredictionStrategy::predict(const std::vector<double>& average) const {
   return { average.at(OUTCOME) };
 }
 
 std::vector<double> RegressionPredictionStrategy::compute_variance(
     const std::vector<double>& average,
     const PredictionValues& leaf_values,
-    size_t ci_group_size) {
+    size_t ci_group_size) const {
 
   double average_outcome = average.at(OUTCOME);
 
@@ -81,13 +81,13 @@ std::vector<double> RegressionPredictionStrategy::compute_variance(
 }
 
 
-size_t RegressionPredictionStrategy::prediction_value_length() {
+size_t RegressionPredictionStrategy::prediction_value_length() const {
   return 1;
 }
 
 PredictionValues RegressionPredictionStrategy::precompute_prediction_values(
     const std::vector<std::vector<size_t>>& leaf_samples,
-    const Data* data) {
+    const Data* data) const {
   size_t num_leaves = leaf_samples.size();
   std::vector<std::vector<double>> values(num_leaves);
 
@@ -121,7 +121,7 @@ std::vector<std::pair<double, double>>  RegressionPredictionStrategy::compute_er
     size_t sample,
     const std::vector<double>& average,
     const PredictionValues& leaf_values,
-    const Data* data) {
+    const Data* data) const {
   double outcome = data->get_outcome(sample);
 
   double error = average.at(OUTCOME) - outcome;

--- a/core/src/prediction/RegressionPredictionStrategy.h
+++ b/core/src/prediction/RegressionPredictionStrategy.h
@@ -26,25 +26,25 @@
 
 class RegressionPredictionStrategy: public OptimizedPredictionStrategy {
 public:
-  size_t prediction_value_length();
+  size_t prediction_value_length() const;
 
   PredictionValues precompute_prediction_values(const std::vector<std::vector<size_t>>& leaf_samples,
-                                                const Data* data);
+                                                const Data* data) const;
 
-  size_t prediction_length();
+  size_t prediction_length() const;
 
-  std::vector<double> predict(const std::vector<double>& average);
+  std::vector<double> predict(const std::vector<double>& average) const;
 
   std::vector<double> compute_variance(
       const std::vector<double>& average,
       const PredictionValues& leaf_values,
-      size_t ci_group_size);
+      size_t ci_group_size) const;
 
   std::vector<std::pair<double, double>> compute_error(
       size_t sample,
       const std::vector<double>& average,
       const PredictionValues& leaf_values,
-      const Data* data);
+      const Data* data) const;
 
 private:
   static const std::size_t OUTCOME;

--- a/core/src/prediction/collector/DefaultPredictionCollector.cpp
+++ b/core/src/prediction/collector/DefaultPredictionCollector.cpp
@@ -27,7 +27,7 @@ std::vector<Prediction> DefaultPredictionCollector::collect_predictions(
     const std::vector<std::vector<size_t>>& leaf_nodes_by_tree,
     const std::vector<std::vector<bool>>& valid_trees_by_sample,
     bool estimate_variance,
-    bool estimate_error) {
+    bool estimate_error) const {
 
   size_t num_samples = data->get_num_rows();
   std::vector<Prediction> predictions;
@@ -70,7 +70,8 @@ std::vector<Prediction> DefaultPredictionCollector::collect_predictions(
   return predictions;
 }
 
-void DefaultPredictionCollector::validate_prediction(size_t sample, Prediction prediction) {
+void DefaultPredictionCollector::validate_prediction(size_t sample,
+                                                     const Prediction& prediction) const {
   size_t prediction_length = strategy->prediction_length();
   if (prediction.size() != prediction_length) {
     throw std::runtime_error("Prediction for sample " + std::to_string(sample) +

--- a/core/src/prediction/collector/DefaultPredictionCollector.h
+++ b/core/src/prediction/collector/DefaultPredictionCollector.h
@@ -34,10 +34,10 @@ public:
                                               const std::vector<std::vector<size_t>>& leaf_nodes_by_tree,
                                               const std::vector<std::vector<bool>>& valid_trees_by_sample,
                                               bool estimate_variance,
-                                              bool estimate_error);
+                                              bool estimate_error) const;
 
 private:
-  void validate_prediction(size_t sample, Prediction prediction);
+  void validate_prediction(size_t sample, const Prediction& prediction) const;
 
   std::shared_ptr<DefaultPredictionStrategy> strategy;
   SampleWeightComputer weight_computer;

--- a/core/src/prediction/collector/OptimizedPredictionCollector.cpp
+++ b/core/src/prediction/collector/OptimizedPredictionCollector.cpp
@@ -26,7 +26,7 @@ std::vector<Prediction> OptimizedPredictionCollector::collect_predictions(const 
                                                                           const std::vector<std::vector<size_t>>& leaf_nodes_by_tree,
                                                                           const std::vector<std::vector<bool>>& valid_trees_by_sample,
                                                                           bool estimate_variance,
-                                                                          bool estimate_error) {
+                                                                          bool estimate_error) const {
   size_t num_trees = forest.get_trees().size();
   size_t num_samples = data->get_num_rows();
   bool record_leaf_values = estimate_variance || estimate_error;
@@ -100,7 +100,7 @@ std::vector<Prediction> OptimizedPredictionCollector::collect_predictions(const 
 
 void OptimizedPredictionCollector::add_prediction_values(size_t node,
     const PredictionValues& prediction_values,
-    std::vector<double>& combined_average) {
+    std::vector<double>& combined_average) const {
   if (combined_average.empty()) {
     combined_average.resize(prediction_values.get_num_types());
   }
@@ -111,13 +111,14 @@ void OptimizedPredictionCollector::add_prediction_values(size_t node,
 }
 
 void OptimizedPredictionCollector::normalize_prediction_values(size_t num_leaves,
-    std::vector<double>& combined_average) {
+                                                               std::vector<double>& combined_average) const {
   for (double& value : combined_average) {
     value /= num_leaves;
   }
 }
 
-void OptimizedPredictionCollector::validate_prediction(size_t sample, Prediction prediction) {
+void OptimizedPredictionCollector::validate_prediction(size_t sample,
+                                                       const Prediction& prediction) const {
   size_t prediction_length = strategy->prediction_length();
   if (prediction.size() != prediction_length) {
     throw std::runtime_error("Prediction for sample " + std::to_string(sample) +

--- a/core/src/prediction/collector/OptimizedPredictionCollector.h
+++ b/core/src/prediction/collector/OptimizedPredictionCollector.h
@@ -32,17 +32,18 @@ public:
                                               const std::vector<std::vector<size_t>>& leaf_nodes_by_tree,
                                               const std::vector<std::vector<bool>>& valid_trees_by_sample,
                                               bool estimate_variance,
-                                              bool estimate_error);
+                                              bool estimate_error) const;
 
 private:
   void add_prediction_values(size_t node,
                              const PredictionValues& prediction_values,
-                             std::vector<double>& combined_average);
+                             std::vector<double>& combined_average) const;
 
   void normalize_prediction_values(size_t num_leaves,
-                                   std::vector<double>& combined_average);
+                                   std::vector<double>& combined_average) const;
 
-  void validate_prediction(size_t sample, Prediction prediction);
+  void validate_prediction(size_t sample,
+                           const Prediction& prediction) const;
 
   std::shared_ptr<OptimizedPredictionStrategy> strategy;
 };

--- a/core/src/prediction/collector/PredictionCollector.h
+++ b/core/src/prediction/collector/PredictionCollector.h
@@ -28,7 +28,7 @@ public:
                                                       const std::vector<std::vector<size_t>>& leaf_nodes_by_tree,
                                                       const std::vector<std::vector<bool>>& valid_trees_by_sample,
                                                       bool estimate_variance,
-                                                      bool estimate_error) = 0;
+                                                      bool estimate_error) const = 0;
 };
 
 #endif //GRF_PREDICTIONCOLLECTOR_H

--- a/core/src/prediction/collector/TreeTraverser.cpp
+++ b/core/src/prediction/collector/TreeTraverser.cpp
@@ -101,8 +101,8 @@ std::vector<std::vector<size_t>> TreeTraverser::get_leaf_node_batch(
 }
 
 std::vector<bool> TreeTraverser::get_valid_samples(size_t num_samples,
-                                                     std::shared_ptr<Tree> tree,
-                                                     bool oob_prediction) const {
+                                                   const std::shared_ptr<Tree>& tree,
+                                                   bool oob_prediction) const {
   std::vector<bool> valid_samples(num_samples, true);
   if (oob_prediction) {
     for (size_t sample : tree->get_drawn_samples()) {

--- a/core/src/prediction/collector/TreeTraverser.h
+++ b/core/src/prediction/collector/TreeTraverser.h
@@ -42,7 +42,7 @@ private:
       bool oob_prediction) const;
 
   std::vector<bool> get_valid_samples(size_t num_samples,
-                                      std::shared_ptr<Tree> tree,
+                                      const std::shared_ptr<Tree>& tree,
                                       bool oob_prediction) const;
 
   uint num_threads;

--- a/core/src/relabeling/CustomRelabelingStrategy.cpp
+++ b/core/src/relabeling/CustomRelabelingStrategy.cpp
@@ -19,6 +19,6 @@
 
 std::unordered_map<size_t, double> CustomRelabelingStrategy::relabel(
     const std::vector<size_t>& samples,
-    const Data* data) {
+    const Data* data) const {
   return std::unordered_map<size_t, double>();
 }

--- a/core/src/relabeling/CustomRelabelingStrategy.h
+++ b/core/src/relabeling/CustomRelabelingStrategy.h
@@ -25,7 +25,7 @@ class CustomRelabelingStrategy: public RelabelingStrategy {
 public:
   std::unordered_map<size_t, double> relabel(
       const std::vector<size_t>& samples,
-      const Data* data);
+      const Data* data) const;
 };
 
 

--- a/core/src/relabeling/InstrumentalRelabelingStrategy.cpp
+++ b/core/src/relabeling/InstrumentalRelabelingStrategy.cpp
@@ -26,7 +26,7 @@ InstrumentalRelabelingStrategy::InstrumentalRelabelingStrategy(double reduced_fo
 
 std::unordered_map<size_t, double> InstrumentalRelabelingStrategy::relabel(
     const std::vector<size_t>& samples,
-    const Data* data) {
+    const Data* data) const {
 
   // Prepare the relevant averages.
   size_t num_samples = samples.size();

--- a/core/src/relabeling/InstrumentalRelabelingStrategy.h
+++ b/core/src/relabeling/InstrumentalRelabelingStrategy.h
@@ -32,7 +32,7 @@ public:
 
   std::unordered_map<size_t, double> relabel(
       const std::vector<size_t>& samples,
-      const Data* data);
+      const Data* data) const;
 
   DISALLOW_COPY_AND_ASSIGN(InstrumentalRelabelingStrategy);
 

--- a/core/src/relabeling/NoopRelabelingStrategy.cpp
+++ b/core/src/relabeling/NoopRelabelingStrategy.cpp
@@ -19,7 +19,7 @@
 
 std::unordered_map<size_t, double> NoopRelabelingStrategy::relabel(
     const std::vector<size_t>& samples,
-    const Data* data) {
+    const Data* data) const {
 
   std::unordered_map<size_t, double> relabeled_observations;
   for (size_t sample : samples) {

--- a/core/src/relabeling/NoopRelabelingStrategy.h
+++ b/core/src/relabeling/NoopRelabelingStrategy.h
@@ -24,7 +24,7 @@ class NoopRelabelingStrategy: public RelabelingStrategy {
 public:
   std::unordered_map<size_t, double> relabel(
       const std::vector<size_t>& samples,
-      const Data* data);
+      const Data* data) const;
 };
 
 

--- a/core/src/relabeling/QuantileRelabelingStrategy.cpp
+++ b/core/src/relabeling/QuantileRelabelingStrategy.cpp
@@ -25,7 +25,7 @@ QuantileRelabelingStrategy::QuantileRelabelingStrategy(const std::vector<double>
 
 std::unordered_map<size_t, double> QuantileRelabelingStrategy::relabel(
     const std::vector<size_t>& samples,
-    const Data* data) {
+    const Data* data) const {
 
   std::vector<double> sorted_outcomes;
   for (size_t sample : samples) {

--- a/core/src/relabeling/QuantileRelabelingStrategy.h
+++ b/core/src/relabeling/QuantileRelabelingStrategy.h
@@ -27,7 +27,7 @@ public:
   QuantileRelabelingStrategy(const std::vector<double>& quantiles);
   std::unordered_map<size_t, double> relabel(
       const std::vector<size_t>& samples,
-      const Data* data);
+      const Data* data) const;
 private:
   std::vector<double> quantiles;
 };

--- a/core/src/relabeling/RelabelingStrategy.h
+++ b/core/src/relabeling/RelabelingStrategy.h
@@ -37,7 +37,7 @@ class RelabelingStrategy {
 public:
   virtual std::unordered_map<size_t, double> relabel(
       const std::vector<size_t>& samples,
-      const Data* data) = 0;
+      const Data* data) const = 0;
 };
 
 

--- a/core/src/sampling/SamplingOptions.cpp
+++ b/core/src/sampling/SamplingOptions.cpp
@@ -57,6 +57,6 @@ unsigned int SamplingOptions::get_samples_per_cluster() const {
   return num_samples_per_cluster;
 }
 
-const std::vector<std::vector<size_t>>& SamplingOptions::get_clusters() {
+const std::vector<std::vector<size_t>>& SamplingOptions::get_clusters() const {
   return clusters;
 }

--- a/core/src/sampling/SamplingOptions.h
+++ b/core/src/sampling/SamplingOptions.h
@@ -36,7 +36,7 @@ public:
   /**
    * A map from each cluster ID to the set of sample IDs it contains.
    */
-  const std::vector<std::vector<size_t>>& get_clusters();
+  const std::vector<std::vector<size_t>>& get_clusters() const;
 
   /**
    * The number of samples that should be drawn from each cluster when

--- a/core/src/splitting/factory/InstrumentalSplittingRuleFactory.cpp
+++ b/core/src/splitting/factory/InstrumentalSplittingRuleFactory.cpp
@@ -21,7 +21,7 @@
 InstrumentalSplittingRuleFactory::InstrumentalSplittingRuleFactory() {}
 
 std::shared_ptr<SplittingRule> InstrumentalSplittingRuleFactory::create(const Data* data,
-                                                                        const TreeOptions& options) {
+                                                                        const TreeOptions& options) const {
   return std::shared_ptr<SplittingRule>(new InstrumentalSplittingRule(data,
       options.get_min_node_size(),
       options.get_alpha(),

--- a/core/src/splitting/factory/InstrumentalSplittingRuleFactory.h
+++ b/core/src/splitting/factory/InstrumentalSplittingRuleFactory.h
@@ -34,7 +34,7 @@ class InstrumentalSplittingRuleFactory: public SplittingRuleFactory {
 public:
   InstrumentalSplittingRuleFactory();
   std::shared_ptr<SplittingRule> create(const Data* data,
-                                        const TreeOptions& options);
+                                        const TreeOptions& options) const;
 private:
   DISALLOW_COPY_AND_ASSIGN(InstrumentalSplittingRuleFactory);
 };

--- a/core/src/splitting/factory/ProbabilitySplittingRuleFactory.cpp
+++ b/core/src/splitting/factory/ProbabilitySplittingRuleFactory.cpp
@@ -24,7 +24,7 @@ ProbabilitySplittingRuleFactory::ProbabilitySplittingRuleFactory(size_t num_clas
     num_classes(num_classes) {}
 
 std::shared_ptr<SplittingRule> ProbabilitySplittingRuleFactory::create(const Data* data,
-                                                                       const TreeOptions& options) {
+                                                                       const TreeOptions& options) const {
   return std::shared_ptr<SplittingRule>(new ProbabilitySplittingRule(
       data, num_classes, options.get_alpha(), options.get_imbalance_penalty()));
 }

--- a/core/src/splitting/factory/ProbabilitySplittingRuleFactory.h
+++ b/core/src/splitting/factory/ProbabilitySplittingRuleFactory.h
@@ -33,7 +33,7 @@ class ProbabilitySplittingRuleFactory: public SplittingRuleFactory {
 public:
   ProbabilitySplittingRuleFactory(size_t num_classes);
   std::shared_ptr<SplittingRule> create(const Data* data,
-                                        const TreeOptions& options);
+                                        const TreeOptions& options) const;
 
 private:
   size_t num_classes;

--- a/core/src/splitting/factory/RegressionSplittingRuleFactory.cpp
+++ b/core/src/splitting/factory/RegressionSplittingRuleFactory.cpp
@@ -21,7 +21,7 @@
 RegressionSplittingRuleFactory::RegressionSplittingRuleFactory() {}
 
 std::shared_ptr<SplittingRule> RegressionSplittingRuleFactory::create(const Data* data,
-                                                                      const TreeOptions& options) {
+                                                                      const TreeOptions& options) const {
   return std::shared_ptr<SplittingRule>(new RegressionSplittingRule(
       data, options.get_alpha(), options.get_imbalance_penalty()));
 }

--- a/core/src/splitting/factory/RegressionSplittingRuleFactory.h
+++ b/core/src/splitting/factory/RegressionSplittingRuleFactory.h
@@ -31,7 +31,7 @@ class RegressionSplittingRuleFactory: public SplittingRuleFactory {
 public:
   RegressionSplittingRuleFactory();
   std::shared_ptr<SplittingRule> create(const Data* data,
-                                        const TreeOptions& options);
+                                        const TreeOptions& options) const;
 private:
   DISALLOW_COPY_AND_ASSIGN(RegressionSplittingRuleFactory);
 };

--- a/core/src/splitting/factory/SplittingRuleFactory.h
+++ b/core/src/splitting/factory/SplittingRuleFactory.h
@@ -28,7 +28,7 @@
 class SplittingRuleFactory {
 public:
   virtual std::shared_ptr<SplittingRule> create(const Data* data,
-                                                const TreeOptions& options) = 0;
+                                                const TreeOptions& options) const = 0;
 };
 
 #endif //GRF_SPLITTINGRULEFACTORY_H

--- a/core/src/tree/Tree.cpp
+++ b/core/src/tree/Tree.cpp
@@ -36,36 +36,36 @@ Tree::Tree(size_t root_node,
     drawn_samples(drawn_samples),
     prediction_values(prediction_values) {}
 
-size_t Tree::get_root_node() {
+size_t Tree::get_root_node() const {
   return root_node;
 }
 
-const std::vector<std::vector<size_t>>& Tree::get_child_nodes() {
+const std::vector<std::vector<size_t>>& Tree::get_child_nodes() const {
   return child_nodes;
 }
 
-const std::vector<std::vector<size_t>>& Tree::get_leaf_samples() {
+const std::vector<std::vector<size_t>>& Tree::get_leaf_samples() const {
   return leaf_samples;
 }
 
-const std::vector<size_t>& Tree::get_split_vars() {
+const std::vector<size_t>& Tree::get_split_vars() const  {
   return split_vars;
 }
 
-const std::vector<double>& Tree::get_split_values() {
+const std::vector<double>& Tree::get_split_values() const  {
   return split_values;
 }
 
-const std::vector<size_t>& Tree::get_drawn_samples() {
+const std::vector<size_t>& Tree::get_drawn_samples() const  {
   return drawn_samples;
 }
 
-const PredictionValues& Tree::get_prediction_values() {
+const PredictionValues& Tree::get_prediction_values() const  {
   return prediction_values;
 }
 
 std::vector<size_t> Tree::find_leaf_nodes(const Data* data,
-                                          const std::vector<size_t>& samples) {
+                                          const std::vector<size_t>& samples) const  {
   std::vector<size_t> prediction_leaf_nodes;
   prediction_leaf_nodes.resize(data->get_num_rows());
 
@@ -77,7 +77,7 @@ std::vector<size_t> Tree::find_leaf_nodes(const Data* data,
 }
 
 std::vector<size_t> Tree::find_leaf_nodes(const Data* data,
-                                          const std::vector<bool>& valid_samples) {
+                                          const std::vector<bool>& valid_samples) const  {
   size_t num_samples = data->get_num_rows();
 
   std::vector<size_t> prediction_leaf_nodes;
@@ -104,7 +104,7 @@ void Tree::set_prediction_values(const PredictionValues& prediction_values) {
 
 
 size_t Tree::find_leaf_node(const Data* data,
-                            size_t sample) {
+                            size_t sample) const  {
   size_t node = root_node;
   while (true) {
     // Break if terminal node
@@ -166,11 +166,11 @@ void Tree::prune_node(size_t& node) {
   }
 }
 
-bool Tree::is_leaf(size_t node) {
+bool Tree::is_leaf(size_t node) const  {
   return child_nodes[0][node] == 0 && child_nodes[1][node] == 0;
 }
 
-bool Tree::is_empty_leaf(size_t node) {
+bool Tree::is_empty_leaf(size_t node) const  {
   return is_leaf(node) && leaf_samples[node].empty();
 }
 

--- a/core/src/tree/Tree.h
+++ b/core/src/tree/Tree.h
@@ -48,7 +48,7 @@ public:
    * requested sample ID will contain the corresponding node ID. All other values will be 0.
    */
   std::vector<size_t> find_leaf_nodes(const Data* data,
-                                      const std::vector<size_t>& samples);
+                                      const std::vector<size_t>& samples) const;
 
   /**
    * Given test data and a vector indicating which samples to consider, recurses
@@ -63,7 +63,7 @@ public:
    * requested sample ID will contain the corresponding node ID. All other values will be 0.
    */
   std::vector<size_t> find_leaf_nodes(const Data* data,
-                                      const std::vector<bool>& valid_samples);
+                                      const std::vector<bool>& valid_samples) const;
   /**
    * Removes all empty leaf nodes.
    *
@@ -77,49 +77,49 @@ public:
    * The ID of the root node for this tree. Note that this is usually 0, but may not always
    * be as the top of the tree can be pruned.
    */
-  size_t get_root_node();
+  size_t get_root_node() const;
 
   /**
    * A vector containing two vectors: the first gives the ID of the left child for every
    * node, and the second gives the ID of the right child. If a node is a leaf, the entries
    * for both the left and right children will be '0'.
    */
-  const std::vector<std::vector<size_t>>& get_child_nodes();
+  const std::vector<std::vector<size_t>>& get_child_nodes() const;
 
   /**
    * Specifies the samples that each node contains. Note that only leaf nodes will contain
    * a non-empty vector of sample IDs.
    */
-  const std::vector<std::vector<size_t>>& get_leaf_samples();
+  const std::vector<std::vector<size_t>>& get_leaf_samples() const;
 
   /**
    * For each split, the ID of the variable that was chosen to split on.
    */
-  const std::vector<size_t>& get_split_vars();
+  const std::vector<size_t>& get_split_vars() const;
 
   /**
    * For each split, the value of the variable that was chosen to split on.
    */
-  const std::vector<double>& get_split_values();
+  const std::vector<double>& get_split_values() const;
 
   /**
    * The sample IDs that were not drawn in creating this tree. For honest trees,
    * this excludes both samples that went into growing the tree, as well as samples
    * used to repopulate the leaves.
    */
-  const std::vector<size_t>& get_drawn_samples();
+  const std::vector<size_t>& get_drawn_samples() const;
 
   /**
    * Optional summary values about the samples in each leaf. Note that this will only
    * be non-empty if the tree was trained with an 'optimized' prediction strategy.
    */
-  const PredictionValues& get_prediction_values();
+  const PredictionValues& get_prediction_values() const;
 
   /**
    * Given a node ID, returns true if the node represents a leaf in this tree (in
    * particular, the node has no children).
    */
-  bool is_leaf(size_t node);
+  bool is_leaf(size_t node) const;
 
   /**
    * Sets the contents of this tree's leaf nodes. Please see
@@ -141,9 +141,9 @@ public:
 
 private:
   size_t find_leaf_node(const Data* data,
-                        size_t sample);
+                        size_t sample) const;
   void prune_node(size_t& node);
-  bool is_empty_leaf(size_t node);
+  bool is_empty_leaf(size_t node) const;
 
   size_t root_node;
   std::vector<std::vector<size_t>> child_nodes;

--- a/core/src/tree/TreeOptions.cpp
+++ b/core/src/tree/TreeOptions.cpp
@@ -33,11 +33,11 @@ TreeOptions::TreeOptions(uint mtry,
   alpha(alpha),
   imbalance_penalty(imbalance_penalty) {}
 
-uint TreeOptions::get_mtry() const  {
+uint TreeOptions::get_mtry() const {
   return mtry;
 }
 
-uint TreeOptions::get_min_node_size() const  {
+uint TreeOptions::get_min_node_size() const {
   return min_node_size;
 }
 

--- a/core/src/tree/TreeTrainer.cpp
+++ b/core/src/tree/TreeTrainer.cpp
@@ -102,7 +102,7 @@ std::shared_ptr<Tree> TreeTrainer::train(const Data* data,
   return tree;
 }
 
-void TreeTrainer::repopulate_leaf_nodes(std::shared_ptr<Tree> tree,
+void TreeTrainer::repopulate_leaf_nodes(const std::shared_ptr<Tree>& tree,
                                         const Data* data,
                                         const std::vector<size_t>& leaf_samples,
                                         const bool prune_empty_leaves) const {
@@ -139,7 +139,7 @@ void TreeTrainer::create_split_variable_subset(std::vector<size_t>& result,
 
 bool TreeTrainer::split_node(size_t node,
                              const Data* data,
-                             std::shared_ptr<SplittingRule> splitting_rule,
+                             const std::shared_ptr<SplittingRule>& splitting_rule,
                              RandomSampler& sampler,
                              std::vector<std::vector<size_t>>& child_nodes,
                              std::vector<std::vector<size_t>>& samples,
@@ -189,7 +189,7 @@ bool TreeTrainer::split_node(size_t node,
 
 bool TreeTrainer::split_node_internal(size_t node,
                                       const Data* data,
-                                      std::shared_ptr<SplittingRule> splitting_rule,
+                                      const std::shared_ptr<SplittingRule>& splitting_rule,
                                       const std::vector<size_t>& possible_split_vars,
                                       const std::vector<std::vector<size_t>>& samples,
                                       std::vector<size_t>& split_vars,

--- a/core/src/tree/TreeTrainer.h
+++ b/core/src/tree/TreeTrainer.h
@@ -45,7 +45,7 @@ private:
                          std::vector<size_t>& split_vars,
                          std::vector<double>& split_values) const;
 
-  void repopulate_leaf_nodes(std::shared_ptr<Tree> tree,
+  void repopulate_leaf_nodes(const std::shared_ptr<Tree>& tree,
                              const Data* data,
                              const std::vector<size_t> &leaf_samples,
                              const bool prune_empty_leaves) const;
@@ -57,7 +57,7 @@ private:
 
   bool split_node(size_t node,
                   const Data* data,
-                  std::shared_ptr<SplittingRule> splitting_rule,
+                  const std::shared_ptr<SplittingRule>& splitting_rule,
                   RandomSampler& sampler,
                   std::vector<std::vector<size_t>>& child_nodes,
                   std::vector<std::vector<size_t>>& samples,
@@ -67,7 +67,7 @@ private:
 
   bool split_node_internal(size_t node,
                            const Data* data,
-                           std::shared_ptr<SplittingRule> splitting_rule,
+                           const std::shared_ptr<SplittingRule>& splitting_rule,
                            const std::vector<size_t>& possible_split_vars,
                            const std::vector<std::vector<size_t>>& samples,
                            std::vector<size_t>& split_vars,

--- a/core/test/forest/CustomForestTest.cpp
+++ b/core/test/forest/CustomForestTest.cpp
@@ -40,7 +40,7 @@ TEST_CASE("custom forests predict 0 by default", "[custom, forest]") {
 
   // Check the dummy predictions look as expected.
   REQUIRE(predictions.size() == data->get_num_rows());
-  for (Prediction prediction : predictions) {
+  for (const Prediction& prediction : predictions) {
     double value = prediction.get_predictions()[0];
     REQUIRE(equal_doubles(value, 0.0, 1e-10));
   }

--- a/core/test/forest/ForestCharacterizationTest.cpp
+++ b/core/test/forest/ForestCharacterizationTest.cpp
@@ -53,7 +53,8 @@ bool equal_predictions(const std::vector<Prediction>& actual_predictions,
   return true;
 }
 
-void update_predictions_file(const std::string file_name, std::vector<Prediction> predictions) {
+void update_predictions_file(const std::string& file_name,
+                             const std::vector<Prediction>& predictions) {
   std::vector<std::vector<double>> values;
   for (auto& prediction : predictions) {
     values.push_back(prediction.get_predictions());

--- a/core/test/utilities/FileTestUtilities.cpp
+++ b/core/test/utilities/FileTestUtilities.cpp
@@ -18,7 +18,7 @@
 #include <fstream>
 #include "FileTestUtilities.h"
 
-std::vector<std::vector<double>> FileTestUtilities::read_csv_file(std::string file_name) {
+std::vector<std::vector<double>> FileTestUtilities::read_csv_file(const std::string& file_name) {
   std::ifstream file;
   file.open(file_name, std::ios::binary);
 
@@ -49,7 +49,8 @@ std::vector<std::vector<double>> FileTestUtilities::read_csv_file(std::string fi
   return result;
 }
 
-void FileTestUtilities::write_csv_file(std::string file_name, std::vector<std::vector<double>> contents) {
+void FileTestUtilities::write_csv_file(const std::string& file_name,
+                                       const std::vector<std::vector<double>>& contents) {
   std::ofstream file;
   file.open(file_name, std::ios::binary);
 

--- a/core/test/utilities/FileTestUtilities.h
+++ b/core/test/utilities/FileTestUtilities.h
@@ -24,9 +24,9 @@
 
 class FileTestUtilities {
 public:
-  static std::vector<std::vector<double>> read_csv_file(std::string file_name);
-  static void write_csv_file(std::string file_name,
-                             std::vector<std::vector<double>> contents);
+  static std::vector<std::vector<double>> read_csv_file(const std::string& file_name);
+  static void write_csv_file(const std::string& file_name,
+                             const std::vector<std::vector<double>>& contents);
 };
 
 


### PR DESCRIPTION
Many of these missing const statements were found using the 'performance-*'
checks in clang-tidy.

Addresses #186.