### PR TITLE
Address more issues from clang-tidy checks.

### DIFF
--- a/core/src/analysis/SplitFrequencyComputer.cpp
+++ b/core/src/analysis/SplitFrequencyComputer.cpp
@@ -15,8 +15,6 @@
   along with grf. If not, see <http://www.gnu.org/licenses/>.
  #-------------------------------------------------------------------------------*/
 
-#include <math.h>
-
 #include "SplitFrequencyComputer.h"
 
 std::vector<std::vector<size_t>> SplitFrequencyComputer::compute(const Forest& forest,

--- a/core/src/commons/Data.cpp
+++ b/core/src/commons/Data.cpp
@@ -26,7 +26,7 @@ Data::Data() :
     num_rows(0),
     num_cols(0),
     external_data(true),
-    index_data(0),
+    index_data(nullptr),
     max_num_unique_values(0),
     outcome_index(),
     treatment_index(),
@@ -34,7 +34,7 @@ Data::Data() :
     weight_index() {}
 
 Data::~Data() {
-  if (index_data != 0) {
+  if (index_data != nullptr) {
     delete[] index_data;
   }
 }
@@ -65,9 +65,9 @@ bool Data::load_from_file(const std::string& filename) {
   input_file.open(filename);
 
   // Find out if comma, semicolon or whitespace seperated and call appropriate method
-  if (first_line.find(",") != std::string::npos) {
+  if (first_line.find(',') != std::string::npos) {
     result = load_from_other_file(input_file, first_line, ',');
-  } else if (first_line.find(";") != std::string::npos) {
+  } else if (first_line.find(';') != std::string::npos) {
     result = load_from_other_file(input_file, first_line, ';');
   } else {
     result = load_from_whitespace_file(input_file, first_line);
@@ -165,8 +165,8 @@ void Data::set_weight_index(size_t index) {
 
 void Data::get_all_values(std::vector<double>& all_values, const std::vector<size_t>& samples, size_t var) const {
   all_values.reserve(samples.size());
-  for (size_t i = 0; i < samples.size(); ++i) {
-    all_values.push_back(get(samples[i], var));
+  for (size_t sample : samples) {
+    all_values.push_back(get(sample, var));
   }
   std::sort(all_values.begin(), all_values.end());
   all_values.erase(unique(all_values.begin(), all_values.end()), all_values.end());

--- a/core/src/commons/DefaultData.cpp
+++ b/core/src/commons/DefaultData.cpp
@@ -25,7 +25,7 @@
 #include "utility.h"
 
 DefaultData::DefaultData() :
-    DefaultData(NULL, 0, 0) {}
+    DefaultData(nullptr, 0, 0) {}
 
 DefaultData::DefaultData(double* data,
                          size_t num_rows,

--- a/core/src/commons/SparseData.cpp
+++ b/core/src/commons/SparseData.cpp
@@ -22,7 +22,7 @@
 #include "utility.h"
 
 SparseData::SparseData():
-  SparseData(NULL, 0, 0) {}
+  SparseData(nullptr, 0, 0) {}
 
 SparseData::SparseData(Eigen::SparseMatrix<double>* data,
                        size_t num_rows,

--- a/core/src/commons/utility.cpp
+++ b/core/src/commons/utility.cpp
@@ -15,7 +15,6 @@
   along with grf. If not, see <http://www.gnu.org/licenses/>.
  #-------------------------------------------------------------------------------*/
 
-#include <math.h>
 #include <iostream>
 #include <sstream>
 #include <unordered_set>

--- a/core/src/forest/ForestTrainers.cpp
+++ b/core/src/forest/ForestTrainers.cpp
@@ -44,7 +44,7 @@ ForestTrainer ForestTrainers::quantile_trainer(const std::vector<double>& quanti
   std::shared_ptr<SplittingRuleFactory> splitting_rule_factory(
       new ProbabilitySplittingRuleFactory(quantiles.size() + 1));
 
-  return ForestTrainer(relabeling_strategy, splitting_rule_factory, NULL);
+  return ForestTrainer(relabeling_strategy, splitting_rule_factory, nullptr);
 }
 
 ForestTrainer ForestTrainers::regression_trainer() {
@@ -59,5 +59,5 @@ ForestTrainer ForestTrainers::custom_trainer() {
   std::shared_ptr<RelabelingStrategy> relabeling_strategy(new CustomRelabelingStrategy());
   std::shared_ptr<SplittingRuleFactory> splitting_rule_factory(new RegressionSplittingRuleFactory());
 
-  return ForestTrainer(relabeling_strategy, splitting_rule_factory, NULL);
+  return ForestTrainer(relabeling_strategy, splitting_rule_factory, nullptr);
 }

--- a/core/src/prediction/CustomPredictionStrategy.h
+++ b/core/src/prediction/CustomPredictionStrategy.h
@@ -20,7 +20,7 @@
 
 #include "DefaultPredictionStrategy.h"
 
-class CustomPredictionStrategy: public DefaultPredictionStrategy {
+class CustomPredictionStrategy final: public DefaultPredictionStrategy {
 public:
 
   size_t prediction_length() const;

--- a/core/src/prediction/InstrumentalPredictionStrategy.cpp
+++ b/core/src/prediction/InstrumentalPredictionStrategy.cpp
@@ -209,7 +209,6 @@ std::vector<std::pair<double, double>> InstrumentalPredictionStrategy::compute_e
 
   double outcome = data->get_outcome(sample);
   double treatment = data->get_treatment(sample);
-  double instrument = data->get_instrument(sample);
 
   // To justify the squared residual below as an error criterion in the case of CATE estimation
   // with an unconfounded treatment assignment, see Nie and Wager (2017).

--- a/core/src/prediction/InstrumentalPredictionStrategy.h
+++ b/core/src/prediction/InstrumentalPredictionStrategy.h
@@ -27,7 +27,7 @@
 #include "prediction/PredictionValues.h"
 #include "ObjectiveBayesDebiaser.h"
 
-class InstrumentalPredictionStrategy: public OptimizedPredictionStrategy {
+class InstrumentalPredictionStrategy final: public OptimizedPredictionStrategy {
 public:
   static const std::size_t OUTCOME;
   static const std::size_t TREATMENT;

--- a/core/src/prediction/LLCausalPredictionStrategy.cpp
+++ b/core/src/prediction/LLCausalPredictionStrategy.cpp
@@ -113,22 +113,22 @@ std::vector<double> LLCausalPredictionStrategy::predict(
   std::vector<double> predictions(num_lambdas);
   Eigen::MatrixXd M;
 
-  for( size_t i = 0; i < num_lambdas; ++i){
+  for (size_t i = 0; i < num_lambdas; ++i){
     double lambda = lambdas[i];
     M = M_unpenalized;
     if (!weight_penalty) {
       double normalization = M_unpenalized.trace() / dim_X;
 
       // standard ridge penalty
-      for(size_t j = 1; j < dim_X; ++j){
-        if(j != treatment_index){
+      for (size_t j = 1; j < dim_X; ++j){
+        if (j != treatment_index){
           M(j, j) += lambda * normalization;
         }
       }
     } else {
       // covariance ridge penalty
-      for(size_t j = 1; j < dim_X; ++j){
-        if(j != treatment_index){
+      for (size_t j = 1; j < dim_X; ++j){
+        if (j != treatment_index){
           M(j, j) += lambda * M(j, j);
         }
       }
@@ -264,8 +264,8 @@ std::vector<double> LLCausalPredictionStrategy::compute_variance(
     for (size_t j = 0; j < ci_group_size; ++j) {
       size_t b = group * ci_group_size + j;
       double psi_1 = 0;
-      for(size_t k = 0; k < samples_by_tree[b].size(); ++ k){
-        psi_1 += pseudo_residual(sample_index_map[samples_by_tree[b][k]]);
+      for (size_t sample : samples_by_tree[b]) {
+        psi_1 += pseudo_residual(sample_index_map[sample]);
       }
       psi_1 /= samples_by_tree[b].size();
       psi_squared += psi_1 * psi_1;

--- a/core/src/prediction/LLCausalPredictionStrategy.h
+++ b/core/src/prediction/LLCausalPredictionStrategy.h
@@ -25,7 +25,7 @@
 #include "prediction/PredictionValues.h"
 #include "ObjectiveBayesDebiaser.h"
 
-class LLCausalPredictionStrategy: public DefaultPredictionStrategy {
+class LLCausalPredictionStrategy final: public DefaultPredictionStrategy {
 public:
     LLCausalPredictionStrategy(std::vector<double> lambdas,
                                bool weight_penalty,

--- a/core/src/prediction/LocalLinearPredictionStrategy.cpp
+++ b/core/src/prediction/LocalLinearPredictionStrategy.cpp
@@ -120,7 +120,7 @@ std::vector<double> LocalLinearPredictionStrategy::compute_variance(
   Eigen::MatrixXd weights_vec = Eigen::VectorXd::Zero(num_nonzero_weights);
     {
       size_t i = 0;
-      for (auto& it : weights_by_sampleID) {
+      for (const auto& it : weights_by_sampleID) {
         size_t index = it.first;
         double weight = it.second;
         indices[i] = index;
@@ -193,8 +193,8 @@ std::vector<double> LocalLinearPredictionStrategy::compute_variance(
     for (size_t j = 0; j < ci_group_size; ++j) {
       size_t b = group * ci_group_size + j;
       double psi_1 = 0;
-      for(size_t k = 0; k < samples_by_tree[b].size(); ++ k){
-        psi_1 += pseudo_residual(sample_index_map[samples_by_tree[b][k]]);
+      for (size_t sample : samples_by_tree[b]){
+        psi_1 += pseudo_residual(sample_index_map[sample]);
       }
       psi_1 /= samples_by_tree[b].size();
       psi_squared += psi_1 * psi_1;

--- a/core/src/prediction/LocalLinearPredictionStrategy.h
+++ b/core/src/prediction/LocalLinearPredictionStrategy.h
@@ -28,7 +28,7 @@
 #include "prediction/PredictionValues.h"
 #include "ObjectiveBayesDebiaser.h"
 
-class LocalLinearPredictionStrategy: public DefaultPredictionStrategy {
+class LocalLinearPredictionStrategy final: public DefaultPredictionStrategy {
 
 public:
     LocalLinearPredictionStrategy(std::vector<double> lambdas,

--- a/core/src/prediction/ObjectiveBayesDebiaser.cpp
+++ b/core/src/prediction/ObjectiveBayesDebiaser.cpp
@@ -18,10 +18,6 @@
 #include "commons/utility.h"
 #include "ObjectiveBayesDebiaser.h"
 
-#include <algorithm>
-#include <cmath>
-#include <math.h>
-
 double ObjectiveBayesDebiaser::debias(double var_between,
                                       double group_noise,
                                       double num_good_groups) const {

--- a/core/src/prediction/QuantilePredictionStrategy.cpp
+++ b/core/src/prediction/QuantilePredictionStrategy.cpp
@@ -37,10 +37,9 @@ std::vector<double> QuantilePredictionStrategy::predict(
     const Data* train_data,
     const Data* data) const {
   std::vector<std::pair<size_t, double>> samples_and_values;
-  for (auto it = weights_by_sample.begin(); it != weights_by_sample.end(); it++) {
-    size_t sample = it->first;
-    samples_and_values.push_back(std::pair<size_t, double>(
-        sample, train_data->get_outcome(sample)));
+  for (const auto& entry : weights_by_sample) {
+    size_t sample = entry.first;
+    samples_and_values.emplace_back(sample, train_data->get_outcome(sample));
   }
 
   return compute_quantile_cutoffs(weights_by_sample, samples_and_values);
@@ -63,9 +62,9 @@ std::vector<double> QuantilePredictionStrategy::compute_quantile_cutoffs(
   auto quantile_it = quantiles.begin();
   double cumulative_weight = 0.0;
 
-  for (auto it = samples_and_values.begin(); it != samples_and_values.end(); ++it) {
-    size_t sample = it->first;
-    double value = it->second;
+  for (const auto& entry : samples_and_values) {
+    size_t sample = entry.first;
+    double value = entry.second;
 
     cumulative_weight += weights_by_sample.at(sample);
     while (quantile_it != quantiles.end() && cumulative_weight >= *quantile_it) {

--- a/core/src/prediction/QuantilePredictionStrategy.h
+++ b/core/src/prediction/QuantilePredictionStrategy.h
@@ -26,7 +26,7 @@
 #include "prediction/DefaultPredictionStrategy.h"
 #include "prediction/PredictionValues.h"
 
-class QuantilePredictionStrategy: public DefaultPredictionStrategy {
+class QuantilePredictionStrategy final: public DefaultPredictionStrategy {
 public:
   QuantilePredictionStrategy(std::vector<double> quantiles);
 

--- a/core/src/prediction/RegressionPredictionStrategy.h
+++ b/core/src/prediction/RegressionPredictionStrategy.h
@@ -24,7 +24,7 @@
 #include "prediction/PredictionValues.h"
 #include "ObjectiveBayesDebiaser.h"
 
-class RegressionPredictionStrategy: public OptimizedPredictionStrategy {
+class RegressionPredictionStrategy final: public OptimizedPredictionStrategy {
 public:
   size_t prediction_value_length() const;
 

--- a/core/src/prediction/collector/DefaultPredictionCollector.h
+++ b/core/src/prediction/collector/DefaultPredictionCollector.h
@@ -24,7 +24,7 @@
 #include "prediction/collector/SampleWeightComputer.h"
 #include "prediction/DefaultPredictionStrategy.h"
 
-class DefaultPredictionCollector: public PredictionCollector {
+class DefaultPredictionCollector final: public PredictionCollector {
 public:
   DefaultPredictionCollector(std::shared_ptr<DefaultPredictionStrategy> strategy);
 

--- a/core/src/prediction/collector/OptimizedPredictionCollector.h
+++ b/core/src/prediction/collector/OptimizedPredictionCollector.h
@@ -22,7 +22,7 @@
 #include "forest/Forest.h"
 #include "prediction/collector/PredictionCollector.h"
 
-class OptimizedPredictionCollector: public PredictionCollector {
+class OptimizedPredictionCollector final: public PredictionCollector {
 public:
   OptimizedPredictionCollector(std::shared_ptr<OptimizedPredictionStrategy> strategy);
 

--- a/core/src/prediction/collector/SampleWeightComputer.cpp
+++ b/core/src/prediction/collector/SampleWeightComputer.cpp
@@ -56,11 +56,11 @@ void SampleWeightComputer::add_sample_weights(const std::vector<size_t>& samples
 
 void SampleWeightComputer::normalize_sample_weights(std::unordered_map<size_t, double>& weights_by_sample) const {
   double total_weight = 0.0;
-  for (auto it = weights_by_sample.begin(); it != weights_by_sample.end(); ++it) {
-    total_weight += it->second;
+  for (const auto& entry : weights_by_sample) {
+    total_weight += entry.second;
   }
 
-  for (auto it = weights_by_sample.begin(); it != weights_by_sample.end(); ++it) {
-    it->second /= total_weight;
+  for (auto& entry : weights_by_sample) {
+    entry.second/= total_weight;
   }
 }

--- a/core/src/relabeling/CustomRelabelingStrategy.h
+++ b/core/src/relabeling/CustomRelabelingStrategy.h
@@ -21,7 +21,7 @@
 
 #include "RelabelingStrategy.h"
 
-class CustomRelabelingStrategy: public RelabelingStrategy {
+class CustomRelabelingStrategy final: public RelabelingStrategy {
 public:
   std::unordered_map<size_t, double> relabel(
       const std::vector<size_t>& samples,

--- a/core/src/relabeling/InstrumentalRelabelingStrategy.h
+++ b/core/src/relabeling/InstrumentalRelabelingStrategy.h
@@ -24,7 +24,7 @@
 #include "tree/Tree.h"
 #include "relabeling/RelabelingStrategy.h"
 
-class InstrumentalRelabelingStrategy: public RelabelingStrategy {
+class InstrumentalRelabelingStrategy final: public RelabelingStrategy {
 public:
   InstrumentalRelabelingStrategy();
 

--- a/core/src/relabeling/NoopRelabelingStrategy.h
+++ b/core/src/relabeling/NoopRelabelingStrategy.h
@@ -20,7 +20,7 @@
 
 #include "relabeling/RelabelingStrategy.h"
 
-class NoopRelabelingStrategy: public RelabelingStrategy {
+class NoopRelabelingStrategy final: public RelabelingStrategy {
 public:
   std::unordered_map<size_t, double> relabel(
       const std::vector<size_t>& samples,

--- a/core/src/relabeling/QuantileRelabelingStrategy.cpp
+++ b/core/src/relabeling/QuantileRelabelingStrategy.cpp
@@ -28,6 +28,7 @@ std::unordered_map<size_t, double> QuantileRelabelingStrategy::relabel(
     const Data* data) const {
 
   std::vector<double> sorted_outcomes;
+  sorted_outcomes.reserve(samples.size());
   for (size_t sample : samples) {
     sorted_outcomes.push_back(data->get_outcome(sample));
   }

--- a/core/src/relabeling/QuantileRelabelingStrategy.h
+++ b/core/src/relabeling/QuantileRelabelingStrategy.h
@@ -22,7 +22,7 @@
 #include "tree/Tree.h"
 #include "relabeling/RelabelingStrategy.h"
 
-class QuantileRelabelingStrategy: public RelabelingStrategy {
+class QuantileRelabelingStrategy final: public RelabelingStrategy {
 public:
   QuantileRelabelingStrategy(const std::vector<double>& quantiles);
   std::unordered_map<size_t, double> relabel(

--- a/core/src/splitting/InstrumentalSplittingRule.cpp
+++ b/core/src/splitting/InstrumentalSplittingRule.cpp
@@ -16,7 +16,6 @@
  #-------------------------------------------------------------------------------*/
 
 #include <algorithm>
-#include <math.h>
 
 #include "InstrumentalSplittingRule.h"
 
@@ -37,19 +36,19 @@ InstrumentalSplittingRule::InstrumentalSplittingRule(const Data* data,
 }
 
 InstrumentalSplittingRule::~InstrumentalSplittingRule() {
-  if (counter != 0) {
+  if (counter != nullptr) {
     delete[] counter;
   }
-  if (sums != 0) {
+  if (sums != nullptr) {
     delete[] sums;
   }
-  if (sums_z != 0) {
+  if (sums_z != nullptr) {
     delete[] sums_z;
   }
-  if (sums_z_squared != 0) {
+  if (sums_z_squared != nullptr) {
     delete[] sums_z_squared;
   }
-  if (num_small_z != 0) {
+  if (num_small_z != nullptr) {
     delete[] num_small_z;
   }
 }

--- a/core/src/splitting/InstrumentalSplittingRule.h
+++ b/core/src/splitting/InstrumentalSplittingRule.h
@@ -22,7 +22,7 @@
 #include "commons/Data.h"
 #include "splitting/SplittingRule.h"
 
-class InstrumentalSplittingRule: public SplittingRule {
+class InstrumentalSplittingRule final: public SplittingRule {
 public:
   InstrumentalSplittingRule(const Data* data,
                             uint min_node_size,

--- a/core/src/splitting/ProbabilitySplittingRule.cpp
+++ b/core/src/splitting/ProbabilitySplittingRule.cpp
@@ -37,10 +37,10 @@ ProbabilitySplittingRule::ProbabilitySplittingRule(const Data* data,
 }
 
 ProbabilitySplittingRule::~ProbabilitySplittingRule() {
-  if (counter != 0) {
+  if (counter != nullptr) {
     delete[] counter;
   }
-  if (counter_per_class != 0) {
+  if (counter_per_class != nullptr) {
     delete[] counter_per_class;
   }
 }

--- a/core/src/splitting/ProbabilitySplittingRule.h
+++ b/core/src/splitting/ProbabilitySplittingRule.h
@@ -23,7 +23,7 @@
 #include "commons/globals.h"
 #include "splitting/SplittingRule.h"
 
-class ProbabilitySplittingRule: public SplittingRule {
+class ProbabilitySplittingRule final: public SplittingRule {
 public:
   ProbabilitySplittingRule(const Data* data,
                            size_t num_classes,

--- a/core/src/splitting/RegressionSplittingRule.cpp
+++ b/core/src/splitting/RegressionSplittingRule.cpp
@@ -16,7 +16,6 @@
  #-------------------------------------------------------------------------------*/
 
 #include <algorithm>
-#include <math.h>
 
 #include "RegressionSplittingRule.h"
 
@@ -32,10 +31,10 @@ RegressionSplittingRule::RegressionSplittingRule(const Data* data,
 }
 
 RegressionSplittingRule::~RegressionSplittingRule() {
-  if (counter != 0) {
+  if (counter != nullptr) {
     delete[] counter;
   }
-  if (sums != 0) {
+  if (sums != nullptr) {
     delete[] sums;
   }
 }

--- a/core/src/splitting/RegressionSplittingRule.h
+++ b/core/src/splitting/RegressionSplittingRule.h
@@ -23,7 +23,7 @@
 #include <unordered_map>
 #include "commons/DefaultData.h"
 
-class RegressionSplittingRule: public SplittingRule {
+class RegressionSplittingRule final: public SplittingRule {
 public:
   RegressionSplittingRule(const Data* data,
                           double alpha,

--- a/core/src/splitting/factory/InstrumentalSplittingRuleFactory.cpp
+++ b/core/src/splitting/factory/InstrumentalSplittingRuleFactory.cpp
@@ -18,8 +18,6 @@
 #include "splitting/factory/InstrumentalSplittingRuleFactory.h"
 #include "splitting/InstrumentalSplittingRule.h"
 
-InstrumentalSplittingRuleFactory::InstrumentalSplittingRuleFactory() {}
-
 std::shared_ptr<SplittingRule> InstrumentalSplittingRuleFactory::create(const Data* data,
                                                                         const TreeOptions& options) const {
   return std::shared_ptr<SplittingRule>(new InstrumentalSplittingRule(data,

--- a/core/src/splitting/factory/InstrumentalSplittingRuleFactory.h
+++ b/core/src/splitting/factory/InstrumentalSplittingRuleFactory.h
@@ -30,9 +30,9 @@
  * assignment or instrument. The exact penalty used  depends on the value
  * of {@link TreeOptions#get_split_penalty}.
  */
-class InstrumentalSplittingRuleFactory: public SplittingRuleFactory {
+class InstrumentalSplittingRuleFactory final: public SplittingRuleFactory {
 public:
-  InstrumentalSplittingRuleFactory();
+  InstrumentalSplittingRuleFactory() = default;
   std::shared_ptr<SplittingRule> create(const Data* data,
                                         const TreeOptions& options) const;
 private:

--- a/core/src/splitting/factory/ProbabilitySplittingRuleFactory.h
+++ b/core/src/splitting/factory/ProbabilitySplittingRuleFactory.h
@@ -29,7 +29,7 @@
  * In addition to performing standard regression splits, this rule applies
  * a penalty to avoid splits too close to the edge of the node's data.
  */
-class ProbabilitySplittingRuleFactory: public SplittingRuleFactory {
+class ProbabilitySplittingRuleFactory final: public SplittingRuleFactory {
 public:
   ProbabilitySplittingRuleFactory(size_t num_classes);
   std::shared_ptr<SplittingRule> create(const Data* data,

--- a/core/src/splitting/factory/RegressionSplittingRuleFactory.cpp
+++ b/core/src/splitting/factory/RegressionSplittingRuleFactory.cpp
@@ -18,8 +18,6 @@
 #include "splitting/factory/RegressionSplittingRuleFactory.h"
 #include "splitting/RegressionSplittingRule.h"
 
-RegressionSplittingRuleFactory::RegressionSplittingRuleFactory() {}
-
 std::shared_ptr<SplittingRule> RegressionSplittingRuleFactory::create(const Data* data,
                                                                       const TreeOptions& options) const {
   return std::shared_ptr<SplittingRule>(new RegressionSplittingRule(

--- a/core/src/splitting/factory/RegressionSplittingRuleFactory.h
+++ b/core/src/splitting/factory/RegressionSplittingRuleFactory.h
@@ -27,9 +27,9 @@
  * In addition to performing standard regression splits, this rule applies
  * a penalty to avoid splits too close to the edge of the node's data.
  */
-class RegressionSplittingRuleFactory: public SplittingRuleFactory {
+class RegressionSplittingRuleFactory final: public SplittingRuleFactory {
 public:
-  RegressionSplittingRuleFactory();
+  RegressionSplittingRuleFactory() = default;
   std::shared_ptr<SplittingRule> create(const Data* data,
                                         const TreeOptions& options) const;
 private:

--- a/core/src/tree/TreeTrainer.cpp
+++ b/core/src/tree/TreeTrainer.cpp
@@ -37,8 +37,8 @@ std::shared_ptr<Tree> TreeTrainer::train(const Data* data,
   std::vector<size_t> split_vars;
   std::vector<double> split_values;
 
-  child_nodes.push_back(std::vector<size_t>());
-  child_nodes.push_back(std::vector<size_t>());
+  child_nodes.emplace_back();
+  child_nodes.emplace_back();
   create_empty_node(child_nodes, nodes, split_vars, split_values);
 
   std::vector<size_t> new_leaf_samples;
@@ -94,7 +94,7 @@ std::shared_ptr<Tree> TreeTrainer::train(const Data* data,
   }
 
   PredictionValues prediction_values;
-  if (prediction_strategy != NULL) {
+  if (prediction_strategy != nullptr) {
     prediction_values = prediction_strategy->precompute_prediction_values(tree->get_leaf_samples(), data);
   }
   tree->set_prediction_values(prediction_values);
@@ -223,7 +223,7 @@ void TreeTrainer::create_empty_node(std::vector<std::vector<size_t>>& child_node
                                     std::vector<double>& split_values) const {
   child_nodes[0].push_back(0);
   child_nodes[1].push_back(0);
-  samples.push_back(std::vector<size_t>());
+  samples.emplace_back();
   split_vars.push_back(0);
   split_values.push_back(0);
 }

--- a/core/test/forest/ForestCharacterizationTest.cpp
+++ b/core/test/forest/ForestCharacterizationTest.cpp
@@ -56,7 +56,8 @@ bool equal_predictions(const std::vector<Prediction>& actual_predictions,
 void update_predictions_file(const std::string& file_name,
                              const std::vector<Prediction>& predictions) {
   std::vector<std::vector<double>> values;
-  for (auto& prediction : predictions) {
+  values.reserve(predictions.size());
+  for (const auto& prediction : predictions) {
     values.push_back(prediction.get_predictions());
   }
   FileTestUtilities::write_csv_file(file_name, values);

--- a/core/test/forest/LocalLinearForestTest.cpp
+++ b/core/test/forest/LocalLinearForestTest.cpp
@@ -140,8 +140,7 @@ TEST_CASE("local linear forests give reasonable variance estimates", "[regressio
   ForestPredictor predictor = ForestPredictors::ll_regression_predictor(4, lambda, false, linear_correction_variables);
   std::vector<Prediction> predictions = predictor.predict_oob(forest, data, true);
 
-  for (size_t i = 0; i < predictions.size(); i++) {
-    Prediction prediction = predictions[i];
+  for (const Prediction& prediction : predictions) {
     REQUIRE(prediction.contains_variance_estimates());
 
     double variance_estimate = prediction.get_variance_estimates()[0];

--- a/core/test/forest/RegressionForestTest.cpp
+++ b/core/test/forest/RegressionForestTest.cpp
@@ -78,8 +78,7 @@ TEST_CASE("regression forests give reasonable variance estimates", "[regression,
   ForestPredictor predictor = ForestPredictors::regression_predictor(4);
   std::vector<Prediction> predictions = predictor.predict_oob(forest, data, true);
 
-  for (size_t i = 0; i < predictions.size(); i++) {
-    Prediction prediction = predictions[i];
+  for (const Prediction& prediction : predictions) {
     REQUIRE(prediction.contains_variance_estimates());
 
     double variance_estimate = prediction.get_variance_estimates()[0];

--- a/core/test/relabeling/InstrumentalRelabelingStrategyTest.cpp
+++ b/core/test/relabeling/InstrumentalRelabelingStrategyTest.cpp
@@ -44,6 +44,7 @@ std::vector<double> get_relabeled_outcomes(double observations[], size_t num_sam
   }
 
   std::vector<double> relabeled_outcomes;
+  relabeled_outcomes.reserve(samples.size());
   for (auto& sample : samples) {
     relabeled_outcomes.push_back(relabeled_observations.at(sample));
   }

--- a/core/test/sampling/RandomSamplerTest.cpp
+++ b/core/test/sampling/RandomSamplerTest.cpp
@@ -184,7 +184,7 @@ TEST_CASE("Draw without replacement 5", "[drawWithoutReplacement]") {
 
 TEST_CASE("sample multilevel 1", "[sampleMultilevel]") {
   std::random_device random_device;
-  DefaultData data(NULL, 0, 0);
+  DefaultData data(nullptr, 0, 0);
 
   uint samples_per_cluster = 3;
   std::vector<size_t> clusters = {0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 2, 2, 2, 2, 0, 3, 3, 3, 2, 3};


### PR DESCRIPTION
This commit addresses most issues found through the performance-* and
modernize-* checks.

* Use nullptr instead of NULL.
* Mark classes final when appropriate.
* Use default constructors.
* Use foreach syntax when possible.
* Remove references to deprecated headers.