### PR TITLE
Remove most references to shared_ptr.

### DIFF
--- a/core/src/forest/Forest.cpp
+++ b/core/src/forest/Forest.cpp
@@ -33,17 +33,17 @@ Forest::Forest(const std::vector<std::shared_ptr<Tree>>& trees,
   num_variables(num_variables),
   ci_group_size(ci_group_size) {}
 
-Forest Forest::merge(const std::vector<std::shared_ptr<Forest>>& forests) {
+Forest Forest::merge(const std::vector<Forest>& forests) {
 
   std::vector<std::shared_ptr<Tree>> all_trees;
-  const size_t num_variables = forests[0]->get_num_variables();
-  const size_t ci_group_size = forests[0]->get_ci_group_size();
+  const size_t num_variables = forests.at(0).get_num_variables();
+  const size_t ci_group_size = forests.at(0).get_ci_group_size();
 
-  for (auto& forest : forests) {
-    auto& trees = forest->get_trees();
+  for (const auto& forest : forests) {
+    auto& trees = forest.get_trees();
     all_trees.insert(all_trees.end(), trees.begin(), trees.end());
 
-    if (forest->get_ci_group_size() != ci_group_size) {
+    if (forest.get_ci_group_size() != ci_group_size) {
       throw std::runtime_error("All forests being merged must have the same ci_group_size.");
     }
   }

--- a/core/src/forest/Forest.h
+++ b/core/src/forest/Forest.h
@@ -39,7 +39,7 @@ public:
   const size_t get_num_variables() const;
   const size_t get_ci_group_size() const;
 
-  static Forest merge(const std::vector<std::shared_ptr<Forest>>& forests);
+  static Forest merge(const std::vector<Forest>& forests);
   
 private:
   std::vector<std::shared_ptr<Tree>> trees;

--- a/core/src/forest/ForestPredictor.cpp
+++ b/core/src/forest/ForestPredictor.cpp
@@ -21,17 +21,17 @@
 #include "commons/utility.h"
 
 ForestPredictor::ForestPredictor(uint num_threads,
-                                 std::shared_ptr<DefaultPredictionStrategy> strategy) :
+                                 std::unique_ptr<DefaultPredictionStrategy> strategy) :
     tree_traverser(num_threads) {
-  this->prediction_collector = std::shared_ptr<PredictionCollector>(
-        new DefaultPredictionCollector(strategy));
+  this->prediction_collector = std::unique_ptr<PredictionCollector>(
+        new DefaultPredictionCollector(std::move(strategy)));
 }
 
 ForestPredictor::ForestPredictor(uint num_threads,
-                                 std::shared_ptr<OptimizedPredictionStrategy> strategy) :
+                                 std::unique_ptr<OptimizedPredictionStrategy> strategy) :
     tree_traverser(num_threads) {
-  this->prediction_collector = std::shared_ptr<PredictionCollector>(
-      new OptimizedPredictionCollector(strategy));
+  this->prediction_collector = std::unique_ptr<PredictionCollector>(
+      new OptimizedPredictionCollector(std::move(strategy)));
 }
 
 

--- a/core/src/forest/ForestPredictor.h
+++ b/core/src/forest/ForestPredictor.h
@@ -38,10 +38,10 @@
 class ForestPredictor {
 public:
   ForestPredictor(uint num_threads,
-                  std::shared_ptr<DefaultPredictionStrategy> strategy);
+                  std::unique_ptr<DefaultPredictionStrategy> strategy);
 
   ForestPredictor(uint num_threads,
-                  std::shared_ptr<OptimizedPredictionStrategy> strategy);
+                  std::unique_ptr<OptimizedPredictionStrategy> strategy);
 
   std::vector<Prediction> predict(const Forest& forest,
                                   Data* train_data,
@@ -60,7 +60,7 @@ private:
 
 private:
   TreeTraverser tree_traverser;
-  std::shared_ptr<PredictionCollector> prediction_collector;
+  std::unique_ptr<PredictionCollector> prediction_collector;
 };
 
 

--- a/core/src/forest/ForestPredictors.cpp
+++ b/core/src/forest/ForestPredictors.cpp
@@ -26,27 +26,27 @@
 
 ForestPredictor ForestPredictors::custom_predictor(uint num_threads) {
   num_threads = ForestOptions::validate_num_threads(num_threads);
-  std::shared_ptr<DefaultPredictionStrategy> prediction_strategy(new CustomPredictionStrategy());
-  return ForestPredictor(num_threads, prediction_strategy);
+  std::unique_ptr<DefaultPredictionStrategy> prediction_strategy(new CustomPredictionStrategy());
+  return ForestPredictor(num_threads, std::move(prediction_strategy));
 }
 
 ForestPredictor ForestPredictors::instrumental_predictor(uint num_threads) {
   num_threads = ForestOptions::validate_num_threads(num_threads);
-  std::shared_ptr<OptimizedPredictionStrategy> prediction_strategy(new InstrumentalPredictionStrategy());
-  return ForestPredictor(num_threads, prediction_strategy);
+  std::unique_ptr<OptimizedPredictionStrategy> prediction_strategy(new InstrumentalPredictionStrategy());
+  return ForestPredictor(num_threads, std::move(prediction_strategy));
 }
 
 ForestPredictor ForestPredictors::quantile_predictor(uint num_threads,
                                                      const std::vector<double>& quantiles) {
   num_threads = ForestOptions::validate_num_threads(num_threads);
-  std::shared_ptr<DefaultPredictionStrategy> prediction_strategy(new QuantilePredictionStrategy(quantiles));
-  return ForestPredictor(num_threads, prediction_strategy);
+  std::unique_ptr<DefaultPredictionStrategy> prediction_strategy(new QuantilePredictionStrategy(quantiles));
+  return ForestPredictor(num_threads, std::move(prediction_strategy));
 }
 
 ForestPredictor ForestPredictors::regression_predictor(uint num_threads) {
   num_threads = ForestOptions::validate_num_threads(num_threads);
-  std::shared_ptr<OptimizedPredictionStrategy> prediction_strategy(new RegressionPredictionStrategy());
-  return ForestPredictor(num_threads, prediction_strategy);
+  std::unique_ptr<OptimizedPredictionStrategy> prediction_strategy(new RegressionPredictionStrategy());
+  return ForestPredictor(num_threads, std::move(prediction_strategy));
 }
 
 ForestPredictor ForestPredictors::ll_regression_predictor(uint num_threads,
@@ -54,9 +54,9 @@ ForestPredictor ForestPredictors::ll_regression_predictor(uint num_threads,
                                                          bool weight_penalty,
                                                          std::vector<size_t> linear_correction_variables) {
   num_threads = ForestOptions::validate_num_threads(num_threads);
-  std::shared_ptr<DefaultPredictionStrategy> prediction_strategy(
+  std::unique_ptr<DefaultPredictionStrategy> prediction_strategy(
       new LocalLinearPredictionStrategy(lambdas, weight_penalty, linear_correction_variables));
-  return ForestPredictor(num_threads, prediction_strategy);
+  return ForestPredictor(num_threads, std::move(prediction_strategy));
 }
 
 ForestPredictor ForestPredictors::ll_causal_predictor(uint num_threads,
@@ -64,7 +64,7 @@ ForestPredictor ForestPredictors::ll_causal_predictor(uint num_threads,
                                                           bool weight_penalty,
                                                           std::vector<size_t> linear_correction_variables) {
   num_threads = ForestOptions::validate_num_threads(num_threads);
-  std::shared_ptr<DefaultPredictionStrategy> prediction_strategy(
+  std::unique_ptr<DefaultPredictionStrategy> prediction_strategy(
           new LLCausalPredictionStrategy(lambdas, weight_penalty, linear_correction_variables));
-  return ForestPredictor(num_threads, prediction_strategy);
+  return ForestPredictor(num_threads, std::move(prediction_strategy));
 }

--- a/core/src/forest/ForestTrainer.cpp
+++ b/core/src/forest/ForestTrainer.cpp
@@ -25,12 +25,12 @@
 #include "ForestTrainer.h"
 #include "random/random.hpp"
 
-ForestTrainer::ForestTrainer(std::shared_ptr<RelabelingStrategy> relabeling_strategy,
-                             std::shared_ptr<SplittingRuleFactory> splitting_rule_factory,
-                             std::shared_ptr<OptimizedPredictionStrategy> prediction_strategy) :
-    tree_trainer(relabeling_strategy,
-                 splitting_rule_factory,
-                 prediction_strategy) {}
+ForestTrainer::ForestTrainer(std::unique_ptr<RelabelingStrategy> relabeling_strategy,
+                             std::unique_ptr<SplittingRuleFactory> splitting_rule_factory,
+                             std::unique_ptr<OptimizedPredictionStrategy> prediction_strategy) :
+    tree_trainer(std::move(relabeling_strategy),
+                 std::move(splitting_rule_factory),
+                 std::move(prediction_strategy)) {}
 
 const Forest ForestTrainer::train(const Data* data,
                                   const ForestOptions& options) const {

--- a/core/src/forest/ForestTrainer.h
+++ b/core/src/forest/ForestTrainer.h
@@ -34,9 +34,9 @@
 
 class ForestTrainer {
 public:
-  ForestTrainer(std::shared_ptr<RelabelingStrategy> relabeling_strategy,
-                std::shared_ptr<SplittingRuleFactory> splitting_rule_factory,
-                std::shared_ptr<OptimizedPredictionStrategy> prediction_strategy);
+  ForestTrainer(std::unique_ptr<RelabelingStrategy> relabeling_strategy,
+                std::unique_ptr<SplittingRuleFactory> splitting_rule_factory,
+                std::unique_ptr<OptimizedPredictionStrategy> prediction_strategy);
   const Forest train(const Data* data, const ForestOptions& options) const;
 
 private:

--- a/core/src/forest/ForestTrainers.cpp
+++ b/core/src/forest/ForestTrainers.cpp
@@ -30,34 +30,42 @@
 ForestTrainer ForestTrainers::instrumental_trainer(double reduced_form_weight,
                                                    bool stabilize_splits) {
 
-  std::shared_ptr<RelabelingStrategy> relabeling_strategy(new InstrumentalRelabelingStrategy(reduced_form_weight));
-  std::shared_ptr<SplittingRuleFactory> splitting_rule_factory = stabilize_splits
-          ? std::shared_ptr<SplittingRuleFactory>(new InstrumentalSplittingRuleFactory())
-          : std::shared_ptr<SplittingRuleFactory>(new RegressionSplittingRuleFactory());
-  std::shared_ptr<OptimizedPredictionStrategy> prediction_strategy(new InstrumentalPredictionStrategy());
+  std::unique_ptr<RelabelingStrategy> relabeling_strategy(new InstrumentalRelabelingStrategy(reduced_form_weight));
+  std::unique_ptr<SplittingRuleFactory> splitting_rule_factory = stabilize_splits
+          ? std::unique_ptr<SplittingRuleFactory>(new InstrumentalSplittingRuleFactory())
+          : std::unique_ptr<SplittingRuleFactory>(new RegressionSplittingRuleFactory());
+  std::unique_ptr<OptimizedPredictionStrategy> prediction_strategy(new InstrumentalPredictionStrategy());
 
-  return ForestTrainer(relabeling_strategy, splitting_rule_factory, prediction_strategy);
+  return ForestTrainer(std::move(relabeling_strategy),
+                       std::move(splitting_rule_factory),
+                       std::move(prediction_strategy));
 }
 
 ForestTrainer ForestTrainers::quantile_trainer(const std::vector<double>& quantiles) {
-  std::shared_ptr<RelabelingStrategy> relabeling_strategy(new QuantileRelabelingStrategy(quantiles));
-  std::shared_ptr<SplittingRuleFactory> splitting_rule_factory(
+  std::unique_ptr<RelabelingStrategy> relabeling_strategy(new QuantileRelabelingStrategy(quantiles));
+  std::unique_ptr<SplittingRuleFactory> splitting_rule_factory(
       new ProbabilitySplittingRuleFactory(quantiles.size() + 1));
 
-  return ForestTrainer(relabeling_strategy, splitting_rule_factory, nullptr);
+  return ForestTrainer(std::move(relabeling_strategy),
+                       std::move(splitting_rule_factory),
+                       nullptr);
 }
 
 ForestTrainer ForestTrainers::regression_trainer() {
-  std::shared_ptr<RelabelingStrategy> relabeling_strategy(new NoopRelabelingStrategy());
-  std::shared_ptr<SplittingRuleFactory> splitting_rule_factory(new RegressionSplittingRuleFactory());
-  std::shared_ptr<OptimizedPredictionStrategy> prediction_strategy(new RegressionPredictionStrategy());
+  std::unique_ptr<RelabelingStrategy> relabeling_strategy(new NoopRelabelingStrategy());
+  std::unique_ptr<SplittingRuleFactory> splitting_rule_factory(new RegressionSplittingRuleFactory());
+  std::unique_ptr<OptimizedPredictionStrategy> prediction_strategy(new RegressionPredictionStrategy());
 
-  return ForestTrainer(relabeling_strategy, splitting_rule_factory, prediction_strategy);
+  return ForestTrainer(std::move(relabeling_strategy),
+                       std::move(splitting_rule_factory),
+                       std::move(prediction_strategy));
 }
 
 ForestTrainer ForestTrainers::custom_trainer() {
-  std::shared_ptr<RelabelingStrategy> relabeling_strategy(new CustomRelabelingStrategy());
-  std::shared_ptr<SplittingRuleFactory> splitting_rule_factory(new RegressionSplittingRuleFactory());
+  std::unique_ptr<RelabelingStrategy> relabeling_strategy(new CustomRelabelingStrategy());
+  std::unique_ptr<SplittingRuleFactory> splitting_rule_factory(new RegressionSplittingRuleFactory());
 
-  return ForestTrainer(relabeling_strategy, splitting_rule_factory, nullptr);
+  return ForestTrainer(std::move(relabeling_strategy),
+                       std::move(splitting_rule_factory),
+                       nullptr);
 }

--- a/core/src/prediction/DefaultPredictionStrategy.h
+++ b/core/src/prediction/DefaultPredictionStrategy.h
@@ -36,6 +36,8 @@
 class DefaultPredictionStrategy {
 public:
 
+  virtual ~DefaultPredictionStrategy() = default;
+
   /**
    * The number of values in a prediction, e.g. 1 for regression
    * or the number of quantiles for quantile forests.

--- a/core/src/prediction/LLCausalPredictionStrategy.h
+++ b/core/src/prediction/LLCausalPredictionStrategy.h
@@ -47,8 +47,6 @@ public:
             size_t ci_group_size) const;
 
 private:
-    const Data *train_data;
-    const Data *test_data;
     std::vector<double> lambdas;
     bool weight_penalty;
     std::vector<size_t> linear_correction_variables;

--- a/core/src/prediction/OptimizedPredictionStrategy.h
+++ b/core/src/prediction/OptimizedPredictionStrategy.h
@@ -38,7 +38,9 @@
 class OptimizedPredictionStrategy {
 public:
 
- /**
+  virtual ~OptimizedPredictionStrategy() = default;
+
+  /**
   * The number of values in a prediction, e.g. 1 for regression,
   * or the number of quantiles for quantile forests.
   */

--- a/core/src/prediction/collector/DefaultPredictionCollector.cpp
+++ b/core/src/prediction/collector/DefaultPredictionCollector.cpp
@@ -17,8 +17,8 @@
 
 #include "prediction/collector/DefaultPredictionCollector.h"
 
-DefaultPredictionCollector::DefaultPredictionCollector(std::shared_ptr<DefaultPredictionStrategy> strategy):
-    strategy(strategy) {}
+DefaultPredictionCollector::DefaultPredictionCollector(std::unique_ptr<DefaultPredictionStrategy> strategy):
+    strategy(std::move(strategy)) {}
 
 std::vector<Prediction> DefaultPredictionCollector::collect_predictions(
     const Forest& forest,

--- a/core/src/prediction/collector/DefaultPredictionCollector.h
+++ b/core/src/prediction/collector/DefaultPredictionCollector.h
@@ -26,7 +26,7 @@
 
 class DefaultPredictionCollector final: public PredictionCollector {
 public:
-  DefaultPredictionCollector(std::shared_ptr<DefaultPredictionStrategy> strategy);
+  DefaultPredictionCollector(std::unique_ptr<DefaultPredictionStrategy> strategy);
 
   std::vector<Prediction> collect_predictions(const Forest& forest,
                                               Data* train_data,
@@ -39,7 +39,7 @@ public:
 private:
   void validate_prediction(size_t sample, const Prediction& prediction) const;
 
-  std::shared_ptr<DefaultPredictionStrategy> strategy;
+  std::unique_ptr<DefaultPredictionStrategy> strategy;
   SampleWeightComputer weight_computer;
 };
 

--- a/core/src/prediction/collector/OptimizedPredictionCollector.cpp
+++ b/core/src/prediction/collector/OptimizedPredictionCollector.cpp
@@ -17,8 +17,8 @@
 
 #include "prediction/collector/OptimizedPredictionCollector.h"
 
-OptimizedPredictionCollector::OptimizedPredictionCollector(std::shared_ptr<OptimizedPredictionStrategy> strategy):
-    strategy(strategy) {}
+OptimizedPredictionCollector::OptimizedPredictionCollector(std::unique_ptr<OptimizedPredictionStrategy> strategy):
+    strategy(std::move(strategy)) {}
 
 std::vector<Prediction> OptimizedPredictionCollector::collect_predictions(const Forest& forest,
                                                                           Data* train_data,

--- a/core/src/prediction/collector/OptimizedPredictionCollector.h
+++ b/core/src/prediction/collector/OptimizedPredictionCollector.h
@@ -24,7 +24,7 @@
 
 class OptimizedPredictionCollector final: public PredictionCollector {
 public:
-  OptimizedPredictionCollector(std::shared_ptr<OptimizedPredictionStrategy> strategy);
+  OptimizedPredictionCollector(std::unique_ptr<OptimizedPredictionStrategy> strategy);
 
   std::vector<Prediction> collect_predictions(const Forest& forest,
                                               Data* train_data,
@@ -45,7 +45,7 @@ private:
   void validate_prediction(size_t sample,
                            const Prediction& prediction) const;
 
-  std::shared_ptr<OptimizedPredictionStrategy> strategy;
+  std::unique_ptr<OptimizedPredictionStrategy> strategy;
 };
 
 

--- a/core/src/prediction/collector/PredictionCollector.h
+++ b/core/src/prediction/collector/PredictionCollector.h
@@ -22,6 +22,9 @@
 
 class PredictionCollector {
 public:
+
+  virtual ~PredictionCollector() = default;
+
   virtual std::vector<Prediction> collect_predictions(const Forest& forest,
                                                       Data* train_data,
                                                       Data* data,

--- a/core/src/relabeling/RelabelingStrategy.h
+++ b/core/src/relabeling/RelabelingStrategy.h
@@ -35,6 +35,9 @@
  */
 class RelabelingStrategy {
 public:
+
+  virtual ~RelabelingStrategy() = default;
+
   virtual std::unordered_map<size_t, double> relabel(
       const std::vector<size_t>& samples,
       const Data* data) const = 0;

--- a/core/src/splitting/factory/InstrumentalSplittingRuleFactory.cpp
+++ b/core/src/splitting/factory/InstrumentalSplittingRuleFactory.cpp
@@ -18,9 +18,9 @@
 #include "splitting/factory/InstrumentalSplittingRuleFactory.h"
 #include "splitting/InstrumentalSplittingRule.h"
 
-std::shared_ptr<SplittingRule> InstrumentalSplittingRuleFactory::create(const Data* data,
+std::unique_ptr<SplittingRule> InstrumentalSplittingRuleFactory::create(const Data* data,
                                                                         const TreeOptions& options) const {
-  return std::shared_ptr<SplittingRule>(new InstrumentalSplittingRule(data,
+  return std::unique_ptr<SplittingRule>(new InstrumentalSplittingRule(data,
       options.get_min_node_size(),
       options.get_alpha(),
       options.get_imbalance_penalty()));

--- a/core/src/splitting/factory/InstrumentalSplittingRuleFactory.h
+++ b/core/src/splitting/factory/InstrumentalSplittingRuleFactory.h
@@ -33,7 +33,7 @@
 class InstrumentalSplittingRuleFactory final: public SplittingRuleFactory {
 public:
   InstrumentalSplittingRuleFactory() = default;
-  std::shared_ptr<SplittingRule> create(const Data* data,
+  std::unique_ptr<SplittingRule> create(const Data* data,
                                         const TreeOptions& options) const;
 private:
   DISALLOW_COPY_AND_ASSIGN(InstrumentalSplittingRuleFactory);

--- a/core/src/splitting/factory/ProbabilitySplittingRuleFactory.cpp
+++ b/core/src/splitting/factory/ProbabilitySplittingRuleFactory.cpp
@@ -23,8 +23,8 @@
 ProbabilitySplittingRuleFactory::ProbabilitySplittingRuleFactory(size_t num_classes):
     num_classes(num_classes) {}
 
-std::shared_ptr<SplittingRule> ProbabilitySplittingRuleFactory::create(const Data* data,
+std::unique_ptr<SplittingRule> ProbabilitySplittingRuleFactory::create(const Data* data,
                                                                        const TreeOptions& options) const {
-  return std::shared_ptr<SplittingRule>(new ProbabilitySplittingRule(
+  return std::unique_ptr<SplittingRule>(new ProbabilitySplittingRule(
       data, num_classes, options.get_alpha(), options.get_imbalance_penalty()));
 }

--- a/core/src/splitting/factory/ProbabilitySplittingRuleFactory.h
+++ b/core/src/splitting/factory/ProbabilitySplittingRuleFactory.h
@@ -32,7 +32,7 @@
 class ProbabilitySplittingRuleFactory final: public SplittingRuleFactory {
 public:
   ProbabilitySplittingRuleFactory(size_t num_classes);
-  std::shared_ptr<SplittingRule> create(const Data* data,
+  std::unique_ptr<SplittingRule> create(const Data* data,
                                         const TreeOptions& options) const;
 
 private:

--- a/core/src/splitting/factory/RegressionSplittingRuleFactory.cpp
+++ b/core/src/splitting/factory/RegressionSplittingRuleFactory.cpp
@@ -18,8 +18,8 @@
 #include "splitting/factory/RegressionSplittingRuleFactory.h"
 #include "splitting/RegressionSplittingRule.h"
 
-std::shared_ptr<SplittingRule> RegressionSplittingRuleFactory::create(const Data* data,
+std::unique_ptr<SplittingRule> RegressionSplittingRuleFactory::create(const Data* data,
                                                                       const TreeOptions& options) const {
-  return std::shared_ptr<SplittingRule>(new RegressionSplittingRule(
+  return std::unique_ptr<SplittingRule>(new RegressionSplittingRule(
       data, options.get_alpha(), options.get_imbalance_penalty()));
 }

--- a/core/src/splitting/factory/RegressionSplittingRuleFactory.h
+++ b/core/src/splitting/factory/RegressionSplittingRuleFactory.h
@@ -30,7 +30,7 @@
 class RegressionSplittingRuleFactory final: public SplittingRuleFactory {
 public:
   RegressionSplittingRuleFactory() = default;
-  std::shared_ptr<SplittingRule> create(const Data* data,
+  std::unique_ptr<SplittingRule> create(const Data* data,
                                         const TreeOptions& options) const;
 private:
   DISALLOW_COPY_AND_ASSIGN(RegressionSplittingRuleFactory);

--- a/core/src/splitting/factory/SplittingRuleFactory.h
+++ b/core/src/splitting/factory/SplittingRuleFactory.h
@@ -27,7 +27,7 @@
 
 class SplittingRuleFactory {
 public:
-  virtual std::shared_ptr<SplittingRule> create(const Data* data,
+  virtual std::unique_ptr<SplittingRule> create(const Data* data,
                                                 const TreeOptions& options) const = 0;
 };
 

--- a/core/src/splitting/factory/SplittingRuleFactory.h
+++ b/core/src/splitting/factory/SplittingRuleFactory.h
@@ -27,6 +27,9 @@
 
 class SplittingRuleFactory {
 public:
+
+  virtual ~SplittingRuleFactory() = default;
+
   virtual std::unique_ptr<SplittingRule> create(const Data* data,
                                                 const TreeOptions& options) const = 0;
 };

--- a/core/src/tree/TreeTrainer.cpp
+++ b/core/src/tree/TreeTrainer.cpp
@@ -21,12 +21,12 @@
 #include "commons/DefaultData.h"
 #include "tree/TreeTrainer.h"
 
-TreeTrainer::TreeTrainer(std::shared_ptr<RelabelingStrategy> relabeling_strategy,
-                         std::shared_ptr<SplittingRuleFactory> splitting_rule_factory,
-                         std::shared_ptr<OptimizedPredictionStrategy> prediction_strategy) :
-    relabeling_strategy(relabeling_strategy),
-    splitting_rule_factory(splitting_rule_factory),
-    prediction_strategy(prediction_strategy) {}
+TreeTrainer::TreeTrainer(std::unique_ptr<RelabelingStrategy> relabeling_strategy,
+                         std::unique_ptr<SplittingRuleFactory> splitting_rule_factory,
+                         std::unique_ptr<OptimizedPredictionStrategy> prediction_strategy) :
+    relabeling_strategy(std::move(relabeling_strategy)),
+    splitting_rule_factory(std::move(splitting_rule_factory)),
+    prediction_strategy(std::move(prediction_strategy)) {}
 
 std::shared_ptr<Tree> TreeTrainer::train(const Data* data,
                                          RandomSampler& sampler,
@@ -54,7 +54,7 @@ std::shared_ptr<Tree> TreeTrainer::train(const Data* data,
     sampler.sample_from_clusters(clusters, nodes[0]);
   }
 
-  std::shared_ptr<SplittingRule> splitting_rule = splitting_rule_factory->create(
+  std::unique_ptr<SplittingRule> splitting_rule = splitting_rule_factory->create(
       data, options);
 
   size_t num_open_nodes = 1;
@@ -139,7 +139,7 @@ void TreeTrainer::create_split_variable_subset(std::vector<size_t>& result,
 
 bool TreeTrainer::split_node(size_t node,
                              const Data* data,
-                             const std::shared_ptr<SplittingRule>& splitting_rule,
+                             const std::unique_ptr<SplittingRule>& splitting_rule,
                              RandomSampler& sampler,
                              std::vector<std::vector<size_t>>& child_nodes,
                              std::vector<std::vector<size_t>>& samples,
@@ -189,7 +189,7 @@ bool TreeTrainer::split_node(size_t node,
 
 bool TreeTrainer::split_node_internal(size_t node,
                                       const Data* data,
-                                      const std::shared_ptr<SplittingRule>& splitting_rule,
+                                      const std::unique_ptr<SplittingRule>& splitting_rule,
                                       const std::vector<size_t>& possible_split_vars,
                                       const std::vector<std::vector<size_t>>& samples,
                                       std::vector<size_t>& split_vars,

--- a/core/src/tree/TreeTrainer.h
+++ b/core/src/tree/TreeTrainer.h
@@ -30,9 +30,9 @@
 
 class TreeTrainer {
 public:
-  TreeTrainer(std::shared_ptr<RelabelingStrategy> relabeling_strategy,
-              std::shared_ptr<SplittingRuleFactory> splitting_rule_factory,
-              std::shared_ptr<OptimizedPredictionStrategy> prediction_strategy);
+  TreeTrainer(std::unique_ptr<RelabelingStrategy> relabeling_strategy,
+              std::unique_ptr<SplittingRuleFactory> splitting_rule_factory,
+              std::unique_ptr<OptimizedPredictionStrategy> prediction_strategy);
 
   std::shared_ptr<Tree> train(const Data* data,
                               RandomSampler& sampler,
@@ -57,7 +57,7 @@ private:
 
   bool split_node(size_t node,
                   const Data* data,
-                  const std::shared_ptr<SplittingRule>& splitting_rule,
+                  const std::unique_ptr<SplittingRule>& splitting_rule,
                   RandomSampler& sampler,
                   std::vector<std::vector<size_t>>& child_nodes,
                   std::vector<std::vector<size_t>>& samples,
@@ -67,7 +67,7 @@ private:
 
   bool split_node_internal(size_t node,
                            const Data* data,
-                           const std::shared_ptr<SplittingRule>& splitting_rule,
+                           const std::unique_ptr<SplittingRule>& splitting_rule,
                            const std::vector<size_t>& possible_split_vars,
                            const std::vector<std::vector<size_t>>& samples,
                            std::vector<size_t>& split_vars,
@@ -76,9 +76,9 @@ private:
 
   std::set<size_t> disallowed_split_variables;
 
-  std::shared_ptr<RelabelingStrategy> relabeling_strategy;
-  std::shared_ptr<SplittingRuleFactory> splitting_rule_factory;
-  std::shared_ptr<OptimizedPredictionStrategy> prediction_strategy;
+  std::unique_ptr<RelabelingStrategy> relabeling_strategy;
+  std::unique_ptr<SplittingRuleFactory> splitting_rule_factory;
+  std::unique_ptr<OptimizedPredictionStrategy> prediction_strategy;
 };
 
 #endif //GRF_TREETRAINER_H

--- a/core/test/forest/ForestSmokeTest.cpp
+++ b/core/test/forest/ForestSmokeTest.cpp
@@ -65,11 +65,7 @@ TEST_CASE("basic forest merges work", "[regression, forest]") {
   Forest forest2 = trainer.train(data, options);
   Forest forest3 = trainer.train(data, options);
 
-  std::shared_ptr<Forest> forest_ptr1 = std::make_shared<Forest>(forest1);
-  std::shared_ptr<Forest> forest_ptr2 = std::make_shared<Forest>(forest2);
-  std::shared_ptr<Forest> forest_ptr3 = std::make_shared<Forest>(forest3);
-
-  std::vector<std::shared_ptr<Forest>> forests{ forest_ptr1, forest_ptr2, forest_ptr3 };
+  std::vector<Forest> forests = { forest1, forest2, forest3 };
 
   Forest big_forest = Forest::merge(forests);
 
@@ -99,8 +95,7 @@ TEST_CASE("forests with different ci_group_size cannot be merged", "[regression,
   ForestOptions options_with_ci = ForestTestUtilities::default_options(false, 2);
   Forest forest_with_ci = trainer.train(data, options_with_ci);
 
-  std::vector<std::shared_ptr<Forest>> forests = { std::make_shared<Forest>(forest),
-                                                   std::make_shared<Forest>(forest_with_ci) };
+  std::vector<Forest> forests = { forest, forest_with_ci };
 
   try {
     Forest big_forest = Forest::merge(forests);

--- a/core/test/relabeling/InstrumentalRelabelingStrategyTest.cpp
+++ b/core/test/relabeling/InstrumentalRelabelingStrategyTest.cpp
@@ -36,7 +36,7 @@ std::vector<double> get_relabeled_outcomes(double observations[], size_t num_sam
     samples.push_back(i);
   }
 
-  std::shared_ptr<RelabelingStrategy> relabeling_strategy(new InstrumentalRelabelingStrategy());
+  std::unique_ptr<RelabelingStrategy> relabeling_strategy(new InstrumentalRelabelingStrategy());
   auto relabeled_observations = relabeling_strategy->relabel(samples, &data);
 
   if (relabeled_observations.empty()) {

--- a/r-package/grf/bindings/AnalysisToolsBindings.cpp
+++ b/r-package/grf/bindings/AnalysisToolsBindings.cpp
@@ -176,14 +176,14 @@ Rcpp::List deserialize_tree(Rcpp::List forest_object,
 
 // [[Rcpp::export]]
 Rcpp::List merge(const Rcpp::List forest_objects) {
- std::vector<std::shared_ptr<Forest>> forest_ptrs;
+ std::vector<Forest> forests;
 
  for (auto& forest_obj : forest_objects) {
    Forest deserialized_forest = RcppUtilities::deserialize_forest(forest_obj);
-   forest_ptrs.push_back(std::make_shared<Forest>(deserialized_forest)); 
+   forests.push_back(std::move(deserialized_forest));
  }
 
-  Forest big_forest = Forest::merge(forest_ptrs);
+  Forest big_forest = Forest::merge(forests);
   return RcppUtilities::serialize_forest(big_forest);
 }
  


### PR DESCRIPTION
This commit replaces most uses of `shared_ptr` with `unique_ptr`, invoking
`move` when necessary to transfer ownership.

We still use `shared_ptr` to hold the list of trees -- this will be addressed in
a follow-up.

Relates to #203.