### PR TITLE
Stop wrapping tree objects in shared_ptr.

### DIFF
--- a/core/src/analysis/SplitFrequencyComputer.cpp
+++ b/core/src/analysis/SplitFrequencyComputer.cpp
@@ -25,20 +25,20 @@ std::vector<std::vector<size_t>> SplitFrequencyComputer::compute(const Forest& f
   std::vector<std::vector<size_t>> result(max_depth, std::vector<size_t>(num_variables));
 
   for (const auto& tree : forest.get_trees()) {
-    const std::vector<std::vector<size_t>>& child_nodes = tree->get_child_nodes();
+    const std::vector<std::vector<size_t>>& child_nodes = tree.get_child_nodes();
 
     size_t depth = 0;
-    std::vector<size_t> level = {tree->get_root_node()};
+    std::vector<size_t> level = {tree.get_root_node()};
 
     while (level.size() > 0 && depth < max_depth) {
       std::vector<size_t> next_level;
 
       for (size_t node : level) {
-        if (tree->is_leaf(node)) {
+        if (tree.is_leaf(node)) {
           continue;
         }
 
-        size_t variable = tree->get_split_vars().at(node);
+        size_t variable = tree.get_split_vars().at(node);
         result[depth][variable]++;
 
         next_level.push_back(child_nodes[0][node]);

--- a/core/src/forest/Forest.cpp
+++ b/core/src/forest/Forest.cpp
@@ -20,7 +20,7 @@
 
 namespace grf {
 
-Forest Forest::create(const std::vector<std::shared_ptr<Tree>>& trees,
+Forest Forest::create(const std::vector<Tree>& trees,
                       const ForestOptions& forest_options,
                       const Data* data) {
   size_t num_independent_variables = data->get_num_cols() -
@@ -28,22 +28,23 @@ Forest Forest::create(const std::vector<std::shared_ptr<Tree>>& trees,
   return Forest(trees, num_independent_variables, forest_options.get_ci_group_size());
 }
 
-Forest::Forest(const std::vector<std::shared_ptr<Tree>>& trees,
+Forest::Forest(const std::vector<Tree>& trees,
                size_t num_variables,
                size_t ci_group_size):
-  trees(trees),
+  trees(std::move(trees)),
   num_variables(num_variables),
   ci_group_size(ci_group_size) {}
 
-Forest Forest::merge(const std::vector<Forest>& forests) {
-
-  std::vector<std::shared_ptr<Tree>> all_trees;
+Forest Forest::merge(std::vector<Forest>& forests) {
+  std::vector<Tree> all_trees;
   const size_t num_variables = forests.at(0).get_num_variables();
   const size_t ci_group_size = forests.at(0).get_ci_group_size();
 
-  for (const auto& forest : forests) {
-    auto& trees = forest.get_trees();
-    all_trees.insert(all_trees.end(), trees.begin(), trees.end());
+  for (auto& forest : forests) {
+    auto& trees = forest.get_trees_();
+    all_trees.insert(all_trees.end(),
+                     std::make_move_iterator(trees.begin()),
+                     std::make_move_iterator(trees.end()));
 
     if (forest.get_ci_group_size() != ci_group_size) {
       throw std::runtime_error("All forests being merged must have the same ci_group_size.");
@@ -53,7 +54,11 @@ Forest Forest::merge(const std::vector<Forest>& forests) {
   return Forest(all_trees, num_variables, ci_group_size);
 }
 
-const std::vector<std::shared_ptr<Tree>>& Forest::get_trees() const {
+const std::vector<Tree>& Forest::get_trees() const {
+  return trees;
+}
+
+std::vector<Tree>& Forest::get_trees_() {
   return trees;
 }
 

--- a/core/src/forest/Forest.h
+++ b/core/src/forest/Forest.h
@@ -28,23 +28,36 @@ namespace grf {
 
 class Forest {
 public:
-  static Forest create(const std::vector<std::shared_ptr<Tree>>& trees,
+  static Forest create(const std::vector<Tree>& trees,
                        const ForestOptions& forest_options,
                        const Data* data);
 
-  Forest(const std::vector<std::shared_ptr<Tree>>& trees,
+  Forest(const std::vector<Tree>& trees,
          size_t num_variables,
          size_t ci_group_size);
 
-  const std::vector<std::shared_ptr<Tree>>& get_trees() const;
+  const std::vector<Tree>& get_trees() const;
+
+  /**
+   * A method intended for internal use that allows the list of
+   * trees to be modified.
+   */
+  std::vector<Tree>& get_trees_();
 
   const size_t get_num_variables() const;
   const size_t get_ci_group_size() const;
 
-  static Forest merge(const std::vector<Forest>& forests);
+  /**
+   * Merges the given forests into a single forest. The new forest
+   * will contain all the trees from the smaller forests.
+   *
+   * NOTE: this is a destructive operation -- the original forests cannot
+   * be used after they are merged together.
+   */
+  static Forest merge(std::vector<Forest>& forests);
   
 private:
-  std::vector<std::shared_ptr<Tree>> trees;
+  std::vector<Tree> trees;
   size_t num_variables;
   size_t ci_group_size;
 };

--- a/core/src/forest/ForestTrainer.h
+++ b/core/src/forest/ForestTrainer.h
@@ -43,19 +43,19 @@ public:
 
 private:
 
-  std::vector<std::shared_ptr<Tree>> train_batch(
+  std::vector<Tree> train_batch(
       size_t start,
       size_t num_trees,
       const Data* data,
       const ForestOptions& options) const;
 
-  std::shared_ptr<Tree> train_tree(const Data* data,
+  Tree train_tree(const Data* data,
+                  RandomSampler& sampler,
+                  const ForestOptions& options) const;
+
+  std::vector<Tree> train_ci_group(const Data* data,
                                    RandomSampler& sampler,
                                    const ForestOptions& options) const;
-
-  std::vector<std::shared_ptr<Tree>> train_ci_group(const Data* data,
-                                                    RandomSampler& sampler,
-                                                    const ForestOptions& options) const;
 
   TreeTrainer tree_trainer;
 };

--- a/core/src/prediction/collector/DefaultPredictionCollector.cpp
+++ b/core/src/prediction/collector/DefaultPredictionCollector.cpp
@@ -53,8 +53,8 @@ std::vector<Prediction> DefaultPredictionCollector::collect_predictions(
         const std::vector<size_t>& leaf_nodes = leaf_nodes_by_tree.at(tree_index);
         size_t node = leaf_nodes.at(sample);
 
-        std::shared_ptr<Tree> tree = forest.get_trees()[tree_index];
-        std::vector<std::vector<size_t>> leaf_samples = tree->get_leaf_samples();
+        const Tree& tree = forest.get_trees()[tree_index];
+        std::vector<std::vector<size_t>> leaf_samples = tree.get_leaf_samples();
         samples_by_tree.push_back(leaf_samples.at(node));
       }
     }

--- a/core/src/prediction/collector/OptimizedPredictionCollector.cpp
+++ b/core/src/prediction/collector/OptimizedPredictionCollector.cpp
@@ -53,8 +53,8 @@ std::vector<Prediction> OptimizedPredictionCollector::collect_predictions(const 
       const std::vector<size_t>& leaf_nodes = leaf_nodes_by_tree.at(tree_index);
       size_t node = leaf_nodes.at(sample);
 
-      std::shared_ptr<Tree> tree = forest.get_trees()[tree_index];
-      const PredictionValues& prediction_values = tree->get_prediction_values();
+      const Tree& tree = forest.get_trees()[tree_index];
+      const PredictionValues& prediction_values = tree.get_prediction_values();
 
       if (!prediction_values.empty(node)) {
         num_leaves++;
@@ -69,7 +69,7 @@ std::vector<Prediction> OptimizedPredictionCollector::collect_predictions(const 
     // that this can only occur when honesty is enabled, and is expected to be rare.
     if (num_leaves == 0) {
       std::vector<double> nan(strategy->prediction_length(), NAN);
-      predictions.emplace_back(Prediction(nan, nan, nan, nan));
+      predictions.emplace_back(nan, nan, nan, nan);
       continue;
     }
 

--- a/core/src/prediction/collector/SampleWeightComputer.cpp
+++ b/core/src/prediction/collector/SampleWeightComputer.cpp
@@ -36,8 +36,8 @@ std::unordered_map<size_t, double> SampleWeightComputer::compute_weights(size_t 
     const std::vector<size_t>& leaf_nodes = leaf_nodes_by_tree.at(tree_index);
     size_t node = leaf_nodes.at(sample);
 
-    std::shared_ptr<Tree> tree = forest.get_trees()[tree_index];
-    const std::vector<size_t>& samples = tree->get_leaf_samples()[node];
+    const Tree& tree = forest.get_trees()[tree_index];
+    const std::vector<size_t>& samples = tree.get_leaf_samples()[node];
     if (!samples.empty()) {
       add_sample_weights(samples, weights_by_sample);
     }

--- a/core/src/prediction/collector/TreeTraverser.cpp
+++ b/core/src/prediction/collector/TreeTraverser.cpp
@@ -73,7 +73,7 @@ std::vector<std::vector<bool>> TreeTraverser::get_valid_trees_by_sample(const Fo
   std::vector<std::vector<bool>> result(num_samples, std::vector<bool>(num_trees, true));
   if (oob_prediction) {
     for (size_t tree_idx = 0; tree_idx < num_trees; ++tree_idx) {
-      for (size_t sample : forest.get_trees()[tree_idx]->get_drawn_samples()) {
+      for (size_t sample : forest.get_trees()[tree_idx].get_drawn_samples()) {
         result[sample][tree_idx] = false;
       }
     }
@@ -92,10 +92,10 @@ std::vector<std::vector<size_t>> TreeTraverser::get_leaf_node_batch(
   std::vector<std::vector<size_t>> all_leaf_nodes(num_trees);
 
   for (size_t i = 0; i < num_trees; ++i) {
-    std::shared_ptr<Tree> tree = forest.get_trees()[start + i];
+    const Tree& tree = forest.get_trees()[start + i];
 
     std::vector<bool> valid_samples = get_valid_samples(num_samples, tree, oob_prediction);
-    std::vector<size_t> leaf_nodes = tree->find_leaf_nodes(data, valid_samples);
+    std::vector<size_t> leaf_nodes = tree.find_leaf_nodes(data, valid_samples);
     all_leaf_nodes[i] = leaf_nodes;
   }
 
@@ -103,11 +103,11 @@ std::vector<std::vector<size_t>> TreeTraverser::get_leaf_node_batch(
 }
 
 std::vector<bool> TreeTraverser::get_valid_samples(size_t num_samples,
-                                                   const std::shared_ptr<Tree>& tree,
+                                                   const Tree& tree,
                                                    bool oob_prediction) const {
   std::vector<bool> valid_samples(num_samples, true);
   if (oob_prediction) {
-    for (size_t sample : tree->get_drawn_samples()) {
+    for (size_t sample : tree.get_drawn_samples()) {
       valid_samples[sample] = false;
     }
   }

--- a/core/src/prediction/collector/TreeTraverser.h
+++ b/core/src/prediction/collector/TreeTraverser.h
@@ -44,7 +44,7 @@ private:
       bool oob_prediction) const;
 
   std::vector<bool> get_valid_samples(size_t num_samples,
-                                      const std::shared_ptr<Tree>& tree,
+                                      const Tree& tree,
                                       bool oob_prediction) const;
 
   uint num_threads;

--- a/core/src/tree/TreeTrainer.h
+++ b/core/src/tree/TreeTrainer.h
@@ -36,10 +36,10 @@ public:
               std::unique_ptr<SplittingRuleFactory> splitting_rule_factory,
               std::unique_ptr<OptimizedPredictionStrategy> prediction_strategy);
 
-  std::shared_ptr<Tree> train(const Data* data,
-                              RandomSampler& sampler,
-                              const std::vector<size_t>& clusters,
-                              const TreeOptions& options) const;
+  Tree train(const Data* data,
+             RandomSampler& sampler,
+             const std::vector<size_t>& clusters,
+             const TreeOptions& options) const;
 
 private:
   void create_empty_node(std::vector<std::vector<size_t>>& child_nodes,
@@ -47,7 +47,7 @@ private:
                          std::vector<size_t>& split_vars,
                          std::vector<double>& split_values) const;
 
-  void repopulate_leaf_nodes(const std::shared_ptr<Tree>& tree,
+  void repopulate_leaf_nodes(Tree& tree,
                              const Data* data,
                              const std::vector<size_t>& leaf_samples,
                              const bool prune_empty_leaves) const;

--- a/core/test/analysis/SplitFrequencyUnitTest.cpp
+++ b/core/test/analysis/SplitFrequencyUnitTest.cpp
@@ -54,11 +54,9 @@ TEST_CASE("split frequency computation works as expected", "[analysis, unit]") {
       {0, 0, 0, 2, 1}, // depth 2
       {0, 0, 0, 0, 1}}; // depth 3
 
-  std::vector<std::shared_ptr<Tree>> trees;
-  trees.push_back(std::shared_ptr<Tree>(new Tree(0, first_child_nodes,
-      {{0}}, first_split_vars, {0}, {0}, PredictionValues())));
-  trees.push_back(std::shared_ptr<Tree>(new Tree(0, second_child_nodes,
-      {{1}}, second_split_vars, {1}, {1}, PredictionValues())));
+  std::vector<Tree> trees;
+  trees.push_back(Tree(0, first_child_nodes, {{0}}, first_split_vars, {0}, {0}, PredictionValues()));
+  trees.push_back(Tree(0, second_child_nodes, {{1}}, second_split_vars, {1}, {1}, PredictionValues()));
 
   size_t num_variables = 5;
   size_t ci_group_size = 2;
@@ -91,9 +89,8 @@ TEST_CASE("split frequency computation respects max depth", "[analysis, unit]") 
       {1, 1, 0, 0, 0}, // depth 1
       {0, 0, 0, 2, 1}}; // depth 2
 
-  std::vector<std::shared_ptr<Tree>> trees;
-  trees.push_back(std::shared_ptr<Tree>(new Tree(0, child_nodes,
-      {{0}}, split_vars, {0}, {0}, PredictionValues())));
+  std::vector<Tree> trees;
+  trees.push_back(Tree(0, child_nodes, {{0}}, split_vars, {0}, {0}, PredictionValues()));
 
   size_t num_variables = 5;
   size_t ci_group_size = 2;

--- a/r-package/grf/bindings/AnalysisToolsBindings.cpp
+++ b/r-package/grf/bindings/AnalysisToolsBindings.cpp
@@ -120,15 +120,15 @@ Rcpp::List deserialize_tree(Rcpp::List forest_object,
     throw std::runtime_error("The provided tree index is not valid.");
   }
 
-  std::shared_ptr<Tree> tree = forest.get_trees().at(tree_index);
-  const std::vector<std::vector<size_t>>& child_nodes = tree->get_child_nodes();
-  const std::vector<std::vector<size_t>>& leaf_samples = tree->get_leaf_samples();
+  const Tree& tree = forest.get_trees().at(tree_index);
+  const std::vector<std::vector<size_t>>& child_nodes = tree.get_child_nodes();
+  const std::vector<std::vector<size_t>>& leaf_samples = tree.get_leaf_samples();
 
-  const std::vector<size_t>& split_vars = tree->get_split_vars();
-  const std::vector<double>& split_values = tree->get_split_values();
+  const std::vector<size_t>& split_vars = tree.get_split_vars();
+  const std::vector<double>& split_values = tree.get_split_values();
 
   std::queue<size_t> frontier;
-  frontier.push(tree->get_root_node());
+  frontier.push(tree.get_root_node());
   size_t node_index = 1;
 
   std::vector<Rcpp::List> node_objects;
@@ -138,7 +138,7 @@ Rcpp::List deserialize_tree(Rcpp::List forest_object,
     size_t node = frontier.front();
     Rcpp::List node_object;
 
-    if (tree->is_leaf(node)) {
+    if (tree.is_leaf(node)) {
       node_object.push_back(true, "is_leaf");
 
       std::vector<size_t> samples;
@@ -165,7 +165,7 @@ Rcpp::List deserialize_tree(Rcpp::List forest_object,
     node_objects.push_back(node_object);
   }
 
-  std::vector<size_t> drawn_samples(tree->get_drawn_samples());
+  std::vector<size_t> drawn_samples(tree.get_drawn_samples());
   for (size_t& index : drawn_samples) index += 1; //R is 1-indexed.
 
 


### PR DESCRIPTION
Now, tree objects are stored directly instead of always being wrapped in
`std::shared_ptr`. Ownership of trees is explicitly transferred through
`std::move`.

This design may be changed or partially reverted as part of our work on #187 

Relates to #203.