### PR TITLE
Some perf improvements for training.

### DIFF
--- a/core/src/commons/Data.cpp
+++ b/core/src/commons/Data.cpp
@@ -158,9 +158,10 @@ void Data::set_weight_index(size_t index) {
 }
 
 void Data::get_all_values(std::vector<double>& all_values, const std::vector<size_t>& samples, size_t var) const {
-  all_values.reserve(samples.size());
-  for (size_t sample : samples) {
-    all_values.push_back(get(sample, var));
+  all_values.resize(samples.size());
+  for (size_t i = 0; i < samples.size(); i++) {
+    size_t sample = samples[i];
+    all_values[i] = get(sample, var);
   }
   std::sort(all_values.begin(), all_values.end());
   all_values.erase(unique(all_values.begin(), all_values.end()), all_values.end());

--- a/core/src/commons/utility.cpp
+++ b/core/src/commons/utility.cpp
@@ -17,8 +17,6 @@
 
 #include <iostream>
 #include <sstream>
-#include <unordered_set>
-#include <unordered_map>
 
 #include "utility.h"
 #include "DefaultData.h"

--- a/core/src/commons/utility.h
+++ b/core/src/commons/utility.h
@@ -22,8 +22,6 @@
 #include <fstream>
 #include <iostream>
 #include <memory>
-#include <unordered_set>
-#include <unordered_map>
 #include <vector>
 
 #include "Data.h"

--- a/core/src/prediction/ObjectiveBayesDebiaser.cpp
+++ b/core/src/prediction/ObjectiveBayesDebiaser.cpp
@@ -14,6 +14,7 @@
   You should have received a copy of the GNU General Public License
   along with grf. If not, see <http://www.gnu.org/licenses/>.
  #-------------------------------------------------------------------------------*/
+#include <cmath>
 
 #include "commons/utility.h"
 #include "ObjectiveBayesDebiaser.h"

--- a/core/src/relabeling/CustomRelabelingStrategy.cpp
+++ b/core/src/relabeling/CustomRelabelingStrategy.cpp
@@ -19,10 +19,11 @@
 
 namespace grf {
 
-std::vector<double> CustomRelabelingStrategy::relabel(
+bool CustomRelabelingStrategy::relabel(
     const std::vector<size_t>& samples,
-    const Data& data) const {
-  return std::vector<double>();
+    const Data& data,
+    std::vector<double>& responses_by_sample) const {
+  return true;
 }
 
 } // namespace grf

--- a/core/src/relabeling/CustomRelabelingStrategy.cpp
+++ b/core/src/relabeling/CustomRelabelingStrategy.cpp
@@ -19,10 +19,10 @@
 
 namespace grf {
 
-std::unordered_map<size_t, double> CustomRelabelingStrategy::relabel(
+std::vector<double> CustomRelabelingStrategy::relabel(
     const std::vector<size_t>& samples,
     const Data& data) const {
-  return std::unordered_map<size_t, double>();
+  return std::vector<double>();
 }
 
 } // namespace grf

--- a/core/src/relabeling/CustomRelabelingStrategy.h
+++ b/core/src/relabeling/CustomRelabelingStrategy.h
@@ -25,7 +25,7 @@ namespace grf {
 
 class CustomRelabelingStrategy final: public RelabelingStrategy {
 public:
-  std::unordered_map<size_t, double> relabel(
+  std::vector<double> relabel(
       const std::vector<size_t>& samples,
       const Data& data) const;
 };

--- a/core/src/relabeling/CustomRelabelingStrategy.h
+++ b/core/src/relabeling/CustomRelabelingStrategy.h
@@ -25,9 +25,10 @@ namespace grf {
 
 class CustomRelabelingStrategy final: public RelabelingStrategy {
 public:
-  std::vector<double> relabel(
+  bool relabel(
       const std::vector<size_t>& samples,
-      const Data& data) const;
+      const Data& data,
+      std::vector<double>& responses_by_sample) const;
 };
 
 } // namespace grf

--- a/core/src/relabeling/InstrumentalRelabelingStrategy.cpp
+++ b/core/src/relabeling/InstrumentalRelabelingStrategy.cpp
@@ -26,7 +26,7 @@ InstrumentalRelabelingStrategy::InstrumentalRelabelingStrategy():
 InstrumentalRelabelingStrategy::InstrumentalRelabelingStrategy(double reduced_form_weight):
   reduced_form_weight(reduced_form_weight) {}
 
-std::unordered_map<size_t, double> InstrumentalRelabelingStrategy::relabel(
+std::vector<double> InstrumentalRelabelingStrategy::relabel(
     const std::vector<size_t>& samples,
     const Data& data) const {
 
@@ -65,13 +65,13 @@ std::unordered_map<size_t, double> InstrumentalRelabelingStrategy::relabel(
   }
 
   if (equal_doubles(denominator, 0.0, 1.0e-10)) {
-    return std::unordered_map<size_t, double>(); // Signals that we should not perform a split.
+    return std::vector<double>(); // Signals that we should not perform a split.
   }
 
   double local_average_treatment_effect = numerator / denominator;
 
   // Create the new outcomes.
-  std::unordered_map<size_t, double> relabeled_outcomes;
+  std::vector<double> relabeled_outcomes(data.get_num_rows());
 
   for (size_t sample : samples) {
     double response = data.get_outcome(sample);

--- a/core/src/relabeling/InstrumentalRelabelingStrategy.h
+++ b/core/src/relabeling/InstrumentalRelabelingStrategy.h
@@ -18,11 +18,11 @@
 #ifndef GRF_INSTRUMENTALRELABELINGSTRATEGY_H
 #define GRF_INSTRUMENTALRELABELINGSTRATEGY_H
 
-#include <unordered_map>
 #include <vector>
+
 #include "commons/Data.h"
-#include "tree/Tree.h"
 #include "relabeling/RelabelingStrategy.h"
+#include "tree/Tree.h"
 
 namespace grf {
 
@@ -32,7 +32,7 @@ public:
 
   InstrumentalRelabelingStrategy(double reduced_form_weight);
 
-  std::unordered_map<size_t, double> relabel(
+  std::vector<double> relabel(
       const std::vector<size_t>& samples,
       const Data& data) const;
 

--- a/core/src/relabeling/InstrumentalRelabelingStrategy.h
+++ b/core/src/relabeling/InstrumentalRelabelingStrategy.h
@@ -32,9 +32,10 @@ public:
 
   InstrumentalRelabelingStrategy(double reduced_form_weight);
 
-  std::vector<double> relabel(
+  bool relabel(
       const std::vector<size_t>& samples,
-      const Data& data) const;
+      const Data& data,
+      std::vector<double>& responses_by_sample) const;
 
   DISALLOW_COPY_AND_ASSIGN(InstrumentalRelabelingStrategy);
 

--- a/core/src/relabeling/NoopRelabelingStrategy.cpp
+++ b/core/src/relabeling/NoopRelabelingStrategy.cpp
@@ -19,11 +19,11 @@
 
 namespace grf {
 
-std::unordered_map<size_t, double> NoopRelabelingStrategy::relabel(
+std::vector<double> NoopRelabelingStrategy::relabel(
     const std::vector<size_t>& samples,
     const Data& data) const {
 
-  std::unordered_map<size_t, double> relabeled_observations;
+  std::vector<double> relabeled_observations(data.get_num_rows());
   for (size_t sample : samples) {
     double outcome = data.get_outcome(sample);
     relabeled_observations[sample] = outcome;

--- a/core/src/relabeling/NoopRelabelingStrategy.cpp
+++ b/core/src/relabeling/NoopRelabelingStrategy.cpp
@@ -19,16 +19,16 @@
 
 namespace grf {
 
-std::vector<double> NoopRelabelingStrategy::relabel(
+bool NoopRelabelingStrategy::relabel(
     const std::vector<size_t>& samples,
-    const Data& data) const {
+    const Data& data,
+    std::vector<double>& responses_by_sample) const {
 
-  std::vector<double> relabeled_observations(data.get_num_rows());
   for (size_t sample : samples) {
     double outcome = data.get_outcome(sample);
-    relabeled_observations[sample] = outcome;
+    responses_by_sample[sample] = outcome;
   }
-  return relabeled_observations;
+  return false;
 }
 
 } // namespace grf

--- a/core/src/relabeling/NoopRelabelingStrategy.h
+++ b/core/src/relabeling/NoopRelabelingStrategy.h
@@ -24,9 +24,10 @@ namespace grf {
 
 class NoopRelabelingStrategy final: public RelabelingStrategy {
 public:
-  std::vector<double> relabel(
+  bool relabel(
       const std::vector<size_t>& samples,
-      const Data& data) const;
+      const Data& data,
+      std::vector<double>& responses_by_sample) const;
 };
 
 } // namespace grf

--- a/core/src/relabeling/NoopRelabelingStrategy.h
+++ b/core/src/relabeling/NoopRelabelingStrategy.h
@@ -24,7 +24,7 @@ namespace grf {
 
 class NoopRelabelingStrategy final: public RelabelingStrategy {
 public:
-  std::unordered_map<size_t, double> relabel(
+  std::vector<double> relabel(
       const std::vector<size_t>& samples,
       const Data& data) const;
 };

--- a/core/src/relabeling/QuantileRelabelingStrategy.cpp
+++ b/core/src/relabeling/QuantileRelabelingStrategy.cpp
@@ -23,9 +23,10 @@ namespace grf {
 QuantileRelabelingStrategy::QuantileRelabelingStrategy(const std::vector<double>& quantiles) :
     quantiles(quantiles) {}
 
-std::vector<double> QuantileRelabelingStrategy::relabel(
+bool QuantileRelabelingStrategy::relabel(
     const std::vector<size_t>& samples,
-    const Data& data) const {
+    const Data& data,
+    std::vector<double>& responses_by_sample) const {
 
   std::vector<double> sorted_outcomes;
   sorted_outcomes.reserve(samples.size());
@@ -48,16 +49,15 @@ std::vector<double> QuantileRelabelingStrategy::relabel(
                          quantile_cutoffs.end());
 
   // Assign a class to each response based on what quantile it belongs to.
-  std::vector<double> relabeled_observations(data.get_num_rows());
   for (size_t sample : samples) {
     double outcome = data.get_outcome(sample);
     auto quantile = std::lower_bound(quantile_cutoffs.begin(),
                                      quantile_cutoffs.end(),
                                      outcome);
     long quantile_index = quantile - quantile_cutoffs.begin();
-    relabeled_observations[sample] = (uint) quantile_index;
+    responses_by_sample[sample] = (uint) quantile_index;
   }
-  return relabeled_observations;
+  return false;
 }
 
 } // namespace grf

--- a/core/src/relabeling/QuantileRelabelingStrategy.cpp
+++ b/core/src/relabeling/QuantileRelabelingStrategy.cpp
@@ -28,10 +28,10 @@ bool QuantileRelabelingStrategy::relabel(
     const Data& data,
     std::vector<double>& responses_by_sample) const {
 
-  std::vector<double> sorted_outcomes;
-  sorted_outcomes.reserve(samples.size());
-  for (size_t sample : samples) {
-    sorted_outcomes.push_back(data.get_outcome(sample));
+  std::vector<double> sorted_outcomes(samples.size());
+  for (size_t i = 0; i < samples.size(); i++) {
+    size_t sample = samples[i];
+    sorted_outcomes[i] = data.get_outcome(sample);
   }
   std::sort(sorted_outcomes.begin(), sorted_outcomes.end());
 

--- a/core/src/relabeling/QuantileRelabelingStrategy.cpp
+++ b/core/src/relabeling/QuantileRelabelingStrategy.cpp
@@ -41,7 +41,7 @@ bool QuantileRelabelingStrategy::relabel(
   // Calculate the outcome value cutoffs for each quantile.
   for (double quantile : quantiles) {
     size_t outcome_index = (size_t) std::ceil(num_samples * quantile) - 1;
-    quantile_cutoffs.push_back(sorted_outcomes.at(outcome_index));
+    quantile_cutoffs.push_back(sorted_outcomes[outcome_index]);
   }
 
   // Remove duplicate cutoffs.

--- a/core/src/relabeling/QuantileRelabelingStrategy.cpp
+++ b/core/src/relabeling/QuantileRelabelingStrategy.cpp
@@ -16,8 +16,6 @@
  #-------------------------------------------------------------------------------*/
 
 #include <algorithm>
-#include <unordered_map>
-
 #include "relabeling/QuantileRelabelingStrategy.h"
 
 namespace grf {
@@ -25,7 +23,7 @@ namespace grf {
 QuantileRelabelingStrategy::QuantileRelabelingStrategy(const std::vector<double>& quantiles) :
     quantiles(quantiles) {}
 
-std::unordered_map<size_t, double> QuantileRelabelingStrategy::relabel(
+std::vector<double> QuantileRelabelingStrategy::relabel(
     const std::vector<size_t>& samples,
     const Data& data) const {
 
@@ -50,7 +48,7 @@ std::unordered_map<size_t, double> QuantileRelabelingStrategy::relabel(
                          quantile_cutoffs.end());
 
   // Assign a class to each response based on what quantile it belongs to.
-  std::unordered_map<size_t, double> relabeled_observations;
+  std::vector<double> relabeled_observations(data.get_num_rows());
   for (size_t sample : samples) {
     double outcome = data.get_outcome(sample);
     auto quantile = std::lower_bound(quantile_cutoffs.begin(),

--- a/core/src/relabeling/QuantileRelabelingStrategy.h
+++ b/core/src/relabeling/QuantileRelabelingStrategy.h
@@ -27,7 +27,7 @@ namespace grf {
 class QuantileRelabelingStrategy final: public RelabelingStrategy {
 public:
   QuantileRelabelingStrategy(const std::vector<double>& quantiles);
-  std::unordered_map<size_t, double> relabel(
+  std::vector<double> relabel(
       const std::vector<size_t>& samples,
       const Data& data) const;
 private:

--- a/core/src/relabeling/QuantileRelabelingStrategy.h
+++ b/core/src/relabeling/QuantileRelabelingStrategy.h
@@ -27,9 +27,10 @@ namespace grf {
 class QuantileRelabelingStrategy final: public RelabelingStrategy {
 public:
   QuantileRelabelingStrategy(const std::vector<double>& quantiles);
-  std::vector<double> relabel(
+  bool relabel(
       const std::vector<size_t>& samples,
-      const Data& data) const;
+      const Data& data,
+      std::vector<double>& responses_by_sample) const;
 private:
   std::vector<double> quantiles;
 };

--- a/core/src/relabeling/RelabelingStrategy.h
+++ b/core/src/relabeling/RelabelingStrategy.h
@@ -28,20 +28,22 @@ namespace grf {
 /**
  * Produces a relabelled set of outcomes for a set of training samples. These outcomes
  * will then be used in calculating a standard regression (or classification) split.
- *
- * samples: the subset of samples to relabel.
- * data: the training data matrix.
- *
- * returns: a map from sample ID to a relabelled outcome.
  */
 class RelabelingStrategy {
 public:
 
   virtual ~RelabelingStrategy() = default;
 
-  virtual std::vector<double> relabel(
-      const std::vector<size_t>& samples,
-      const Data& data) const = 0;
+ /**
+   * samples: the subset of samples to relabel.
+   * data: the training data matrix.
+   * responses_by_sample: the output of the method, containing a map from sample ID to relabelled response.
+   *
+   * returns: a boolean that will be 'true' if splitting should stop early.
+   */
+  virtual bool relabel(const std::vector<size_t>& samples,
+                       const Data& data,
+                       std::vector<double>& responses_by_sample) const = 0;
 };
 
 } // namespace grf

--- a/core/src/relabeling/RelabelingStrategy.h
+++ b/core/src/relabeling/RelabelingStrategy.h
@@ -21,7 +21,6 @@
 
 #include "commons/DefaultData.h"
 #include "commons/Data.h"
-#include <unordered_map>
 #include <vector>
 
 namespace grf {
@@ -40,7 +39,7 @@ public:
 
   virtual ~RelabelingStrategy() = default;
 
-  virtual std::unordered_map<size_t, double> relabel(
+  virtual std::vector<double> relabel(
       const std::vector<size_t>& samples,
       const Data& data) const = 0;
 };

--- a/core/src/sampling/RandomSampler.cpp
+++ b/core/src/sampling/RandomSampler.cpp
@@ -101,7 +101,7 @@ void RandomSampler::sample_from_clusters(const std::vector<size_t>& clusters,
   } else {
     const std::vector<std::vector<size_t>>& samples_by_cluster = options.get_clusters();
     for (size_t cluster : clusters) {
-      const std::vector<size_t>& cluster_samples = samples_by_cluster.at(cluster);
+      const std::vector<size_t>& cluster_samples = samples_by_cluster[cluster];
 
       // Draw samples_per_cluster observations from each cluster. If the cluster is
       // smaller than the samples_per_cluster parameter, just use the whole cluster.
@@ -122,7 +122,7 @@ void RandomSampler::get_samples_in_clusters(const std::vector<size_t>& clusters,
     samples = clusters;
   } else {
     for (size_t cluster : clusters) {
-      const std::vector<size_t>& cluster_samples = options.get_clusters().at(cluster);
+      const std::vector<size_t>& cluster_samples = options.get_clusters()[cluster];
       samples.insert(samples.end(), cluster_samples.begin(), cluster_samples.end());
     }
   }

--- a/core/src/sampling/RandomSampler.cpp
+++ b/core/src/sampling/RandomSampler.cpp
@@ -155,7 +155,7 @@ void RandomSampler::draw_simple(std::vector<size_t>& result,
                                 size_t max,
                                 const std::set<size_t>& skip,
                                 size_t num_samples) {
-  result.reserve(num_samples);
+  result.resize(num_samples);
 
   // Set all to not selected
   std::vector<bool> temp;
@@ -173,7 +173,7 @@ void RandomSampler::draw_simple(std::vector<size_t>& result,
       }
     } while (temp[draw]);
     temp[draw] = true;
-    result.push_back(draw);
+    result[i] = draw;
   }
 }
 
@@ -206,7 +206,7 @@ void RandomSampler::draw_weighted(std::vector<size_t>& result,
                                   size_t max,
                                   size_t num_samples,
                                   const std::vector<double>& weights) {
-  result.reserve(num_samples);
+  result.resize(num_samples);
 
   // Set all to not selected
   std::vector<bool> temp;
@@ -219,7 +219,7 @@ void RandomSampler::draw_weighted(std::vector<size_t>& result,
       draw = weighted_dist(random_number_generator);
     } while (temp[draw]);
     temp[draw] = true;
-    result.push_back(draw);
+    result[i] = draw;
   }
 }
 

--- a/core/src/sampling/RandomSampler.cpp
+++ b/core/src/sampling/RandomSampler.cpp
@@ -13,7 +13,6 @@
  #-------------------------------------------------------------------------------*/
 
 #include <algorithm>
-#include <unordered_map>
 #include <random>
 
 #include "RandomSampler.h"

--- a/core/src/sampling/RandomSampler.h
+++ b/core/src/sampling/RandomSampler.h
@@ -29,7 +29,6 @@
 #include <random>
 #include <set>
 #include <vector>
-#include <unordered_map>
 
 namespace grf {
 

--- a/core/src/sampling/SamplingOptions.cpp
+++ b/core/src/sampling/SamplingOptions.cpp
@@ -16,8 +16,7 @@
  #-------------------------------------------------------------------------------*/
 
 #include "SamplingOptions.h"
-
-#include <unordered_set>
+#include <unordered_map>
 #include "commons/globals.h"
 
 namespace grf {

--- a/core/src/sampling/SamplingOptions.h
+++ b/core/src/sampling/SamplingOptions.h
@@ -20,7 +20,6 @@
 
 
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 #include "commons/globals.h"

--- a/core/src/splitting/InstrumentalSplittingRule.cpp
+++ b/core/src/splitting/InstrumentalSplittingRule.cpp
@@ -56,7 +56,7 @@ InstrumentalSplittingRule::~InstrumentalSplittingRule() {
 bool InstrumentalSplittingRule::find_best_split(const Data& data,
                                                 size_t node,
                                                 const std::vector<size_t>& possible_split_vars,
-                                                const std::unordered_map<size_t, double>& labels_by_sample,
+                                                const std::vector<double>& responses_by_sample,
                                                 const std::vector<std::vector<size_t>>& samples,
                                                 std::vector<size_t>& split_vars,
                                                 std::vector<double>& split_values) {
@@ -67,7 +67,7 @@ bool InstrumentalSplittingRule::find_best_split(const Data& data,
   double sum_node_z = 0.0;
   double sum_node_z_squared = 0.0;
   for (auto& sample : samples[node]) {
-    sum_node += labels_by_sample.at(sample);
+    sum_node += responses_by_sample.at(sample);
 
     double z = data.get_instrument(sample);
     sum_node_z += z;
@@ -97,11 +97,11 @@ bool InstrumentalSplittingRule::find_best_split(const Data& data,
     if (q < Q_THRESHOLD) {
       find_best_split_value_small_q(data, node, var, num_samples, sum_node, mean_z_node, num_node_small_z,
                                     sum_node_z, sum_node_z_squared, min_child_size, best_value,
-                                    best_var, best_decrease, labels_by_sample, samples);
+                                    best_var, best_decrease, responses_by_sample, samples);
     } else {
       find_best_split_value_large_q(data, node, var, num_samples, sum_node, mean_z_node, num_node_small_z,
                                     sum_node_z, sum_node_z_squared, min_child_size, best_value,
-                                    best_var, best_decrease, labels_by_sample, samples);
+                                    best_var, best_decrease, responses_by_sample, samples);
     }
   }
 
@@ -128,7 +128,7 @@ void InstrumentalSplittingRule::find_best_split_value_small_q(const Data& data,
                                                               double& best_value,
                                                               size_t& best_var,
                                                               double& best_decrease,
-                                                              const std::unordered_map<size_t, double>& labels_by_sample,
+                                                              const std::vector<double>& responses_by_sample,
                                                               const std::vector<std::vector<size_t>>& samples) {
   std::vector<double> possible_split_values;
   data.get_all_values(possible_split_values, samples.at(node), var);
@@ -155,7 +155,7 @@ void InstrumentalSplittingRule::find_best_split_value_small_q(const Data& data,
   // Sum in right child and possible split
   for (auto& sample : samples[node]) {
     double value = data.get(sample, var);
-    double label = labels_by_sample.at(sample);
+    double label = responses_by_sample.at(sample);
     double z = data.get_instrument(sample);
 
     // Count samples until split_value reached
@@ -242,7 +242,7 @@ void InstrumentalSplittingRule::find_best_split_value_large_q(const Data& data,
                                                               double& best_value,
                                                               size_t& best_var,
                                                               double& best_decrease,
-                                                              const std::unordered_map<size_t, double>& responses_by_sample,
+                                                              const std::vector<double>& responses_by_sample,
                                                               const std::vector<std::vector<size_t>>& samples) {
   // Set counters to 0
   size_t num_unique = data.get_num_unique_data_values(var);

--- a/core/src/splitting/InstrumentalSplittingRule.cpp
+++ b/core/src/splitting/InstrumentalSplittingRule.cpp
@@ -67,7 +67,7 @@ bool InstrumentalSplittingRule::find_best_split(const Data& data,
   double sum_node_z = 0.0;
   double sum_node_z_squared = 0.0;
   for (auto& sample : samples[node]) {
-    sum_node += responses_by_sample.at(sample);
+    sum_node += responses_by_sample[sample];
 
     double z = data.get_instrument(sample);
     sum_node_z += z;
@@ -131,7 +131,7 @@ void InstrumentalSplittingRule::find_best_split_value_small_q(const Data& data,
                                                               const std::vector<double>& responses_by_sample,
                                                               const std::vector<std::vector<size_t>>& samples) {
   std::vector<double> possible_split_values;
-  data.get_all_values(possible_split_values, samples.at(node), var);
+  data.get_all_values(possible_split_values, samples[node], var);
 
   // Try next variable if all equal for this
   if (possible_split_values.size() < 2) {
@@ -155,7 +155,7 @@ void InstrumentalSplittingRule::find_best_split_value_small_q(const Data& data,
   // Sum in right child and possible split
   for (auto& sample : samples[node]) {
     double value = data.get(sample, var);
-    double label = responses_by_sample.at(sample);
+    double label = responses_by_sample[sample];
     double z = data.get_instrument(sample);
 
     // Count samples until split_value reached
@@ -256,7 +256,7 @@ void InstrumentalSplittingRule::find_best_split_value_large_q(const Data& data,
     size_t i = data.get_index(sample, var);
     double z = data.get_instrument(sample);
 
-    sums[i] += responses_by_sample.at(sample);
+    sums[i] += responses_by_sample[sample];
     ++counter[i];
 
     sums_z[i] += z;

--- a/core/src/splitting/InstrumentalSplittingRule.h
+++ b/core/src/splitting/InstrumentalSplittingRule.h
@@ -35,7 +35,7 @@ public:
   bool find_best_split(const Data& data,
                        size_t node,
                        const std::vector<size_t>& possible_split_vars,
-                       const std::unordered_map<size_t, double>& labels_by_sample,
+                       const std::vector<double>& responses_by_sample,
                        const std::vector<std::vector<size_t>>& samples,
                        std::vector<size_t>& split_vars,
                        std::vector<double>& split_values);
@@ -54,7 +54,7 @@ private:
                                      double& best_value,
                                      size_t& best_var,
                                      double& best_decrease,
-                                     const std::unordered_map<size_t, double>& responses_by_sample,
+                                     const std::vector<double>& responses_by_sample,
                                      const std::vector<std::vector<size_t>>& samples);
   void find_best_split_value_large_q(const Data& data,
                                      size_t node,
@@ -69,7 +69,7 @@ private:
                                      double& best_value,
                                      size_t& best_var,
                                      double& best_decrease,
-                                     const std::unordered_map<size_t, double>& responses_by_sample,
+                                     const std::vector<double>& responses_by_sample,
                                      const std::vector<std::vector<size_t>>& samples);
 
   size_t* counter;

--- a/core/src/splitting/ProbabilitySplittingRule.cpp
+++ b/core/src/splitting/ProbabilitySplittingRule.cpp
@@ -17,7 +17,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <unordered_map>
 
 #include "ProbabilitySplittingRule.h"
 
@@ -48,7 +47,7 @@ ProbabilitySplittingRule::~ProbabilitySplittingRule() {
 bool ProbabilitySplittingRule::find_best_split(const Data& data,
                                                size_t node,
                                                const std::vector<size_t>& possible_split_vars,
-                                               const std::unordered_map<size_t, double>& labels_by_sample,
+                                               const std::vector<double>& responses_by_sample,
                                                const std::vector<std::vector<size_t>>& samples,
                                                std::vector<size_t>& split_vars,
                                                std::vector<double>& split_values) {
@@ -58,7 +57,7 @@ bool ProbabilitySplittingRule::find_best_split(const Data& data,
   size_t* class_counts = new size_t[num_classes]();
   for (size_t i = 0; i < size_node; ++i) {
     size_t sample = samples[node][i];
-    uint sample_class = (uint) std::round(labels_by_sample.at(sample));
+    uint sample_class = (uint) std::round(responses_by_sample.at(sample));
     ++class_counts[sample_class];
   }
 
@@ -73,10 +72,10 @@ bool ProbabilitySplittingRule::find_best_split(const Data& data,
     double q = (double) size_node / (double) data.get_num_unique_data_values(var);
     if (q < Q_THRESHOLD) {
       find_best_split_value_small_q(data, node, var, num_classes, class_counts, size_node, min_child_size,
-                                    best_value, best_var, best_decrease, labels_by_sample, samples);
+                                    best_value, best_var, best_decrease, responses_by_sample, samples);
     } else {
       find_best_split_value_large_q(data, node, var, num_classes, class_counts, size_node, min_child_size,
-                                    best_value, best_var, best_decrease, labels_by_sample, samples);
+                                    best_value, best_var, best_decrease, responses_by_sample, samples);
     }
   }
 
@@ -103,7 +102,7 @@ void ProbabilitySplittingRule::find_best_split_value_small_q(const Data& data,
                                                              double& best_value,
                                                              size_t& best_var,
                                                              double& best_decrease,
-                                                             const std::unordered_map<size_t, double>& labels_by_sample,
+                                                             const std::vector<double>& responses_by_sample,
                                                              const std::vector<std::vector<size_t>>& samples) {
 
   // Create possible split values
@@ -129,7 +128,7 @@ void ProbabilitySplittingRule::find_best_split_value_small_q(const Data& data,
   // Count samples in right child per class and possbile split
   for (auto& sample : samples[node]) {
     double value = data.get(sample, var);
-    uint sample_class = labels_by_sample.at(sample);
+    uint sample_class = responses_by_sample.at(sample);
 
     // Count samples until split_value reached
     for (size_t i = 0; i < num_splits; ++i) {
@@ -192,7 +191,7 @@ void ProbabilitySplittingRule::find_best_split_value_large_q(const Data& data,
                                                              double& best_value,
                                                              size_t& best_var,
                                                              double& best_decrease,
-                                                             const std::unordered_map<size_t, double>& responses_by_sample,
+                                                             const std::vector<double>& responses_by_sample,
                                                              const std::vector<std::vector<size_t>>& samples) {
   // Set counters to 0
   size_t num_unique = data.get_num_unique_data_values(var);

--- a/core/src/splitting/ProbabilitySplittingRule.cpp
+++ b/core/src/splitting/ProbabilitySplittingRule.cpp
@@ -57,7 +57,7 @@ bool ProbabilitySplittingRule::find_best_split(const Data& data,
   size_t* class_counts = new size_t[num_classes]();
   for (size_t i = 0; i < size_node; ++i) {
     size_t sample = samples[node][i];
-    uint sample_class = (uint) std::round(responses_by_sample.at(sample));
+    uint sample_class = (uint) std::round(responses_by_sample[sample]);
     ++class_counts[sample_class];
   }
 
@@ -128,7 +128,7 @@ void ProbabilitySplittingRule::find_best_split_value_small_q(const Data& data,
   // Count samples in right child per class and possbile split
   for (auto& sample : samples[node]) {
     double value = data.get(sample, var);
-    uint sample_class = responses_by_sample.at(sample);
+    uint sample_class = responses_by_sample[sample];
 
     // Count samples until split_value reached
     for (size_t i = 0; i < num_splits; ++i) {
@@ -201,7 +201,7 @@ void ProbabilitySplittingRule::find_best_split_value_large_q(const Data& data,
   // Count values
   for (auto& sample : samples[node]) {
     size_t index = data.get_index(sample, var);
-    size_t sample_class = responses_by_sample.at(sample);
+    size_t sample_class = responses_by_sample[sample];
 
     ++counter[index];
     ++counter_per_class[index * num_classes + sample_class];

--- a/core/src/splitting/ProbabilitySplittingRule.h
+++ b/core/src/splitting/ProbabilitySplittingRule.h
@@ -36,7 +36,7 @@ public:
   bool find_best_split(const Data& data,
                        size_t node,
                        const std::vector<size_t>& possible_split_vars,
-                       const std::unordered_map<size_t, double>& labels_by_sample,
+                       const std::vector<double>& responses_by_sample,
                        const std::vector<std::vector<size_t>>& samples,
                        std::vector<size_t>& split_vars,
                        std::vector<double>& split_values);
@@ -49,7 +49,7 @@ private:
                                      double& best_value,
                                      size_t& best_var,
                                      double& best_decrease,
-                                     const std::unordered_map<size_t, double>& labels_by_sample,
+                                     const std::vector<double>& responses_by_sample,
                                      const std::vector<std::vector<size_t>>& samples);
 
   void find_best_split_value_large_q(const Data& data,
@@ -59,7 +59,7 @@ private:
                                      double& best_value,
                                      size_t& best_var,
                                      double& best_decrease,
-                                     const std::unordered_map<size_t, double>& labels_by_sample,
+                                     const std::vector<double>& responses_by_sample,
                                      const std::vector<std::vector<size_t>>& samples);
 
   size_t num_classes;

--- a/core/src/splitting/RegressionSplittingRule.cpp
+++ b/core/src/splitting/RegressionSplittingRule.cpp
@@ -53,7 +53,7 @@ bool RegressionSplittingRule::find_best_split(const Data& data,
   // Precompute the sum of outcomes in this node.
   double sum_node = 0.0;
   for (auto& sample : samples[node]) {
-    sum_node += responses_by_sample.at(sample);
+    sum_node += responses_by_sample[sample];
   }
 
   // Initialize the variables to track the best split variable.
@@ -95,7 +95,7 @@ void RegressionSplittingRule::find_best_split_value_small_q(const Data& data,
                                                             const std::vector<double>& responses_by_sample,
                                                             const std::vector<std::vector<size_t>>& samples) {
   std::vector<double> possible_split_values;
-  data.get_all_values(possible_split_values, samples.at(node), var);
+  data.get_all_values(possible_split_values, samples[node], var);
 
   // Try next variable if all equal for this
   if (possible_split_values.size() < 2) {
@@ -117,7 +117,7 @@ void RegressionSplittingRule::find_best_split_value_small_q(const Data& data,
   // Sum in right child and possible split
   for (auto& sample : samples[node]) {
     double value = data.get(sample, var);
-    double response = responses_by_sample.at(sample);
+    double response = responses_by_sample[sample];
 
     // Count samples until split_value reached
     for (size_t i = 0; i < num_splits; ++i) {
@@ -181,7 +181,7 @@ void RegressionSplittingRule::find_best_split_value_large_q(const Data& data,
   for (auto& sample : samples[node]) {
     size_t index = data.get_index(sample, var);
 
-    sums[index] += responses_by_sample.at(sample);
+    sums[index] += responses_by_sample[sample];
     ++counter[index];
   }
 

--- a/core/src/splitting/RegressionSplittingRule.cpp
+++ b/core/src/splitting/RegressionSplittingRule.cpp
@@ -42,7 +42,7 @@ RegressionSplittingRule::~RegressionSplittingRule() {
 bool RegressionSplittingRule::find_best_split(const Data& data,
                                               size_t node,
                                               const std::vector<size_t>& possible_split_vars,
-                                              const std::unordered_map<size_t, double>& labels_by_sample,
+                                              const std::vector<double>& responses_by_sample,
                                               const std::vector<std::vector<size_t>>& samples,
                                               std::vector<size_t>& split_vars,
                                               std::vector<double>& split_values) {
@@ -53,7 +53,7 @@ bool RegressionSplittingRule::find_best_split(const Data& data,
   // Precompute the sum of outcomes in this node.
   double sum_node = 0.0;
   for (auto& sample : samples[node]) {
-    sum_node += labels_by_sample.at(sample);
+    sum_node += responses_by_sample.at(sample);
   }
 
   // Initialize the variables to track the best split variable.
@@ -67,10 +67,10 @@ bool RegressionSplittingRule::find_best_split(const Data& data,
     double q = (double) size_node / (double) data.get_num_unique_data_values(var);
     if (q < Q_THRESHOLD) {
       find_best_split_value_small_q(data, node, var, sum_node, size_node, min_child_size,
-                                    best_value, best_var, best_decrease, labels_by_sample, samples);
+                                    best_value, best_var, best_decrease, responses_by_sample, samples);
     } else {
       find_best_split_value_large_q(data, node, var, sum_node, size_node, min_child_size,
-                                    best_value, best_var, best_decrease, labels_by_sample, samples);
+                                    best_value, best_var, best_decrease, responses_by_sample, samples);
     }
   }
 
@@ -92,7 +92,7 @@ void RegressionSplittingRule::find_best_split_value_small_q(const Data& data,
                                                             size_t min_child_size,
                                                             double& best_value, size_t& best_var,
                                                             double& best_decrease,
-                                                            const std::unordered_map<size_t, double>& labels_by_sample,
+                                                            const std::vector<double>& responses_by_sample,
                                                             const std::vector<std::vector<size_t>>& samples) {
   std::vector<double> possible_split_values;
   data.get_all_values(possible_split_values, samples.at(node), var);
@@ -117,7 +117,7 @@ void RegressionSplittingRule::find_best_split_value_small_q(const Data& data,
   // Sum in right child and possible split
   for (auto& sample : samples[node]) {
     double value = data.get(sample, var);
-    double response = labels_by_sample.at(sample);
+    double response = responses_by_sample.at(sample);
 
     // Count samples until split_value reached
     for (size_t i = 0; i < num_splits; ++i) {
@@ -171,7 +171,7 @@ void RegressionSplittingRule::find_best_split_value_large_q(const Data& data,
                                                             double& best_value,
                                                             size_t& best_var,
                                                             double& best_decrease,
-                                                            const std::unordered_map<size_t, double>& responses_by_sample,
+                                                            const std::vector<double>& responses_by_sample,
                                                             const std::vector<std::vector<size_t>>& samples) {
   // Set counters to 0
   size_t num_unique = data.get_num_unique_data_values(var);

--- a/core/src/splitting/RegressionSplittingRule.h
+++ b/core/src/splitting/RegressionSplittingRule.h
@@ -18,10 +18,9 @@
 #ifndef GRF_REGRESSIONSPLITTINGRULE_H
 #define GRF_REGRESSIONSPLITTINGRULE_H
 
-#include "tree/Tree.h"
-#include "splitting/SplittingRule.h"
-#include <unordered_map>
 #include "commons/DefaultData.h"
+#include "splitting/SplittingRule.h"
+#include "tree/Tree.h"
 
 namespace grf {
 
@@ -36,7 +35,7 @@ public:
   bool find_best_split(const Data& data,
                        size_t node,
                        const std::vector<size_t>& possible_split_vars,
-                       const std::unordered_map<size_t, double>& labels_by_sample,
+                       const std::vector<double>& responses_by_sample,
                        const std::vector<std::vector<size_t>>& samples,
                        std::vector<size_t>& split_vars,
                        std::vector<double>& split_values);
@@ -51,7 +50,7 @@ private:
                                      double& best_value,
                                      size_t& best_var,
                                      double& best_decrease,
-                                     const std::unordered_map<size_t, double>& labels_by_sample,
+                                     const std::vector<double>& responses_by_sample,
                                      const std::vector<std::vector<size_t>>& samples);
   void find_best_split_value_large_q(const Data& data,
                                      size_t node,
@@ -62,7 +61,7 @@ private:
                                      double& best_value,
                                      size_t& best_var,
                                      double& best_decrease,
-                                     const std::unordered_map<size_t, double>& responses_by_sample,
+                                     const std::vector<double>& responses_by_sample,
                                      const std::vector<std::vector<size_t>>& samples);
 
   size_t* counter;

--- a/core/src/splitting/SplittingRule.h
+++ b/core/src/splitting/SplittingRule.h
@@ -18,7 +18,6 @@
 #ifndef GRF_SPLITTINGRULE_H
 #define GRF_SPLITTINGRULE_H
 
-#include <unordered_map>
 #include <vector>
 
 #include "commons/Data.h"
@@ -31,7 +30,7 @@ public:
   virtual bool find_best_split(const Data& data,
                                size_t node,
                                const std::vector<size_t>& possible_split_vars,
-                               const std::unordered_map<size_t, double>& labels_by_sample,
+                               const std::vector<double>& responses_by_sample,
                                const std::vector<std::vector<size_t>>& samples,
                                std::vector<size_t>& split_vars,
                                std::vector<double>& split_values) = 0;

--- a/core/src/splitting/factory/ProbabilitySplittingRuleFactory.cpp
+++ b/core/src/splitting/factory/ProbabilitySplittingRuleFactory.cpp
@@ -15,7 +15,6 @@
   along with grf. If not, see <http://www.gnu.org/licenses/>.
  #-------------------------------------------------------------------------------*/
 
-#include <unordered_map>
 #include "splitting/SplittingRule.h"
 #include "splitting/factory/ProbabilitySplittingRuleFactory.h"
 #include "splitting/ProbabilitySplittingRule.h"

--- a/core/src/tree/TreeTrainer.cpp
+++ b/core/src/tree/TreeTrainer.cpp
@@ -61,6 +61,7 @@ Tree TreeTrainer::train(const Data& data,
 
   size_t num_open_nodes = 1;
   size_t i = 0;
+  std::vector<double> responses_by_sample(data.get_num_rows());
   while (num_open_nodes > 0) {
     bool is_leaf_node = split_node(i,
                                    data,
@@ -70,6 +71,7 @@ Tree TreeTrainer::train(const Data& data,
                                    nodes,
                                    split_vars,
                                    split_values,
+                                   responses_by_sample,
                                    options);
     if (is_leaf_node) {
       --num_open_nodes;
@@ -141,6 +143,7 @@ bool TreeTrainer::split_node(size_t node,
                              std::vector<std::vector<size_t>>& samples,
                              std::vector<size_t>& split_vars,
                              std::vector<double>& split_values,
+                             std::vector<double>& responses_by_sample,
                              const TreeOptions& options) const {
 
   std::vector<size_t> possible_split_vars;
@@ -153,6 +156,7 @@ bool TreeTrainer::split_node(size_t node,
                                   samples,
                                   split_vars,
                                   split_values,
+                                  responses_by_sample,
                                   options.get_min_node_size());
   if (stop) {
     return true;
@@ -190,6 +194,7 @@ bool TreeTrainer::split_node_internal(size_t node,
                                       const std::vector<std::vector<size_t>>& samples,
                                       std::vector<size_t>& split_vars,
                                       std::vector<double>& split_values,
+                                      std::vector<double>& responses_by_sample,
                                       uint min_node_size) const {
   // Check node size, stop if maximum reached
   if (samples[node].size() <= min_node_size) {
@@ -197,15 +202,16 @@ bool TreeTrainer::split_node_internal(size_t node,
     return true;
   }
 
-  std::vector<double> responses_by_sample = relabeling_strategy->relabel(samples[node], data);
+  std::fill(responses_by_sample.begin(), responses_by_sample.end(), 0.0);
+  bool stop = relabeling_strategy->relabel(samples[node], data, responses_by_sample);
 
-  if (responses_by_sample.empty() || splitting_rule->find_best_split(data,
-                                                                     node,
-                                                                     possible_split_vars,
-                                                                     responses_by_sample,
-                                                                     samples,
-                                                                     split_vars,
-                                                                     split_values)) {
+  if (stop || splitting_rule->find_best_split(data,
+                                              node,
+                                              possible_split_vars,
+                                              responses_by_sample,
+                                              samples,
+                                              split_vars,
+                                              split_values)) {
     split_values[node] = -1.0;
     return true;
   }

--- a/core/src/tree/TreeTrainer.cpp
+++ b/core/src/tree/TreeTrainer.cpp
@@ -110,8 +110,8 @@ void TreeTrainer::repopulate_leaf_nodes(Tree& tree,
   std::vector<size_t> leaf_nodes = tree.find_leaf_nodes(data, leaf_samples);
 
   for (auto& sample : leaf_samples) {
-    size_t leaf_node = leaf_nodes.at(sample);
-    new_leaf_nodes.at(leaf_node).push_back(sample);
+    size_t leaf_node = leaf_nodes[sample];
+    new_leaf_nodes[leaf_node].push_back(sample);
   }
   tree.set_leaf_samples(new_leaf_nodes);
   if (prune_empty_leaves) {

--- a/core/src/tree/TreeTrainer.cpp
+++ b/core/src/tree/TreeTrainer.cpp
@@ -197,8 +197,7 @@ bool TreeTrainer::split_node_internal(size_t node,
     return true;
   }
 
-  std::unordered_map<size_t, double> responses_by_sample = relabeling_strategy->relabel(
-      samples[node], data);
+  std::vector<double> responses_by_sample = relabeling_strategy->relabel(samples[node], data);
 
   if (responses_by_sample.empty() || splitting_rule->find_best_split(data,
                                                                      node,

--- a/core/src/tree/TreeTrainer.h
+++ b/core/src/tree/TreeTrainer.h
@@ -65,6 +65,7 @@ private:
                   std::vector<std::vector<size_t>>& samples,
                   std::vector<size_t>& split_vars,
                   std::vector<double>& split_values,
+                  std::vector<double>& responses_by_sample,
                   const TreeOptions& tree_options) const;
 
   bool split_node_internal(size_t node,
@@ -74,6 +75,7 @@ private:
                            const std::vector<std::vector<size_t>>& samples,
                            std::vector<size_t>& split_vars,
                            std::vector<double>& split_values,
+                           std::vector<double>& responses_by_sample,
                            uint min_node_size) const ;
 
   std::set<size_t> disallowed_split_variables;

--- a/core/test/relabeling/InstrumentalRelabelingStrategyTest.cpp
+++ b/core/test/relabeling/InstrumentalRelabelingStrategyTest.cpp
@@ -39,9 +39,10 @@ std::vector<double> get_relabeled_outcomes(std::vector<double> observations, siz
   }
 
   std::unique_ptr<RelabelingStrategy> relabeling_strategy(new InstrumentalRelabelingStrategy());
-  auto relabeled_observations = relabeling_strategy->relabel(samples, data);
 
-  if (relabeled_observations.empty()) {
+  std::vector<double> relabeled_observations(num_samples);
+  bool stop = relabeling_strategy->relabel(samples, data, relabeled_observations);
+  if (stop) {
     return std::vector<double>();
   }
 

--- a/core/test/relabeling/QuantileRelabelingStrategyTest.cpp
+++ b/core/test/relabeling/QuantileRelabelingStrategyTest.cpp
@@ -41,7 +41,6 @@ TEST_CASE("simple quantile relabeling", "[quantile, relabeling]") {
 
   std::vector<double> relabeled_outcomes;
   for (auto& sample : samples) {
-    REQUIRE(relabeled_observations.count(sample));
     relabeled_outcomes.push_back(relabeled_observations.at(sample));
   }
 
@@ -62,7 +61,6 @@ TEST_CASE("quantile relabeling subset of observations", "[quantile, relabeling]"
 
   std::vector<double> relabeled_outcomes;
   for (auto& sample : samples) {
-    REQUIRE(relabeled_observations.count(sample));
     relabeled_outcomes.push_back(relabeled_observations.at(sample));
   }
 

--- a/core/test/relabeling/QuantileRelabelingStrategyTest.cpp
+++ b/core/test/relabeling/QuantileRelabelingStrategyTest.cpp
@@ -37,7 +37,10 @@ TEST_CASE("simple quantile relabeling", "[quantile, relabeling]") {
   }
 
   QuantileRelabelingStrategy relabeling_strategy({0.25, 0.5, 0.75});
-  auto relabeled_observations = relabeling_strategy.relabel(samples, data);
+
+  std::vector<double> relabeled_observations(data.get_num_rows());
+  bool stop = relabeling_strategy.relabel(samples, data, relabeled_observations);
+  REQUIRE(stop == false);
 
   std::vector<double> relabeled_outcomes;
   for (auto& sample : samples) {
@@ -57,7 +60,10 @@ TEST_CASE("quantile relabeling subset of observations", "[quantile, relabeling]"
   std::vector<size_t> samples = {1, 3, 5, 7, 9};
 
   QuantileRelabelingStrategy relabeling_strategy({0.5, 0.75});
-  auto relabeled_observations = relabeling_strategy.relabel(samples, data);
+
+  std::vector<double> relabeled_observations(data.get_num_rows());
+  bool stop = relabeling_strategy.relabel(samples, data, relabeled_observations);
+  REQUIRE(stop == false);
 
   std::vector<double> relabeled_outcomes;
   for (auto& sample : samples) {


### PR DESCRIPTION
This PR performs some light optimizations discovered through profiling.

First, it improves memory access during the relabeling procedure:
- Use `vector` instead of `unordered_map` for relabeled responses.
- Re-use a single vector to hold relabeled responses.

It also updates the vector allocation and access strategy for code on the hot path:
- When populating vectors, use `resize` and `operator[]` instead of `reserve` and `push_back`.
- Prefer `operator[]` instead of `at` for vector element access.

For the following code snippet (that uses the recently-added `dgps.R`), this change brings the time from **133 to 113 sec**.

```
data <- gen_data(10000, 10, dgp = "simple")
num.trees <- 2000

system.time(forest.Y <- regression_forest(data$X, data$Y, num.trees = num.trees,
    compute.oob.predictions=FALSE, num.threads=1))
``` 

Thanks @halflearned for performing the investigations that led to this change!

Addresses #483.