### PR TITLE
Add helpful links to grf.Rd.

### DIFF
--- a/r-package/grf/man/grf.Rd
+++ b/r-package/grf/man/grf.Rd
@@ -6,7 +6,13 @@ A pluggable package for forest-based statistical estimation and inference. GRF c
 
 In addition, GRF supports 'honest' estimation (where one subset of the data is used for choosing splits, and another for populating the leaves of the tree), and confidence intervals for least-squares regression and treatment effect estimation.
 
-This package is currently in beta, and we expect to make continual improvements to its performance and usability. For a practical description of the GRF algorithm, including explanations of model parameters and troubleshooting suggestions, please see the [GRF reference](https://github.com/grf-labs/grf/blob/master/REFERENCE.md).
+Some helpful links for getting started:
+
+* The R package documentation contains usage examples and method reference (https://grf-labs.github.io/grf).
+
+* The GRF reference gives a detailed description of the GRF algorithm and includes troubleshooting suggestions: (https://github.com/grf-labs/grf/blob/master/REFERENCE.md).
+
+* For community questions and answers around usage, see Github issues labelled 'question' (https://github.com/grf-labs/grf/issues?q=label\%3Aquestion).
 }
 
 \examples{


### PR DESCRIPTION
The documentation in `grf.Rd` is presented when running `help(grf)` from R. This commit adds some important links to the main description.