### PR TITLE
Use unique_ptr to hold trees.

### DIFF
--- a/core/src/analysis/SplitFrequencyComputer.cpp
+++ b/core/src/analysis/SplitFrequencyComputer.cpp
@@ -25,20 +25,20 @@ std::vector<std::vector<size_t>> SplitFrequencyComputer::compute(const Forest& f
   std::vector<std::vector<size_t>> result(max_depth, std::vector<size_t>(num_variables));
 
   for (const auto& tree : forest.get_trees()) {
-    const std::vector<std::vector<size_t>>& child_nodes = tree.get_child_nodes();
+    const std::vector<std::vector<size_t>>& child_nodes = tree->get_child_nodes();
 
     size_t depth = 0;
-    std::vector<size_t> level = {tree.get_root_node()};
+    std::vector<size_t> level = {tree->get_root_node()};
 
     while (level.size() > 0 && depth < max_depth) {
       std::vector<size_t> next_level;
 
       for (size_t node : level) {
-        if (tree.is_leaf(node)) {
+        if (tree->is_leaf(node)) {
           continue;
         }
 
-        size_t variable = tree.get_split_vars().at(node);
+        size_t variable = tree->get_split_vars().at(node);
         result[depth][variable]++;
 
         next_level.push_back(child_nodes[0][node]);

--- a/core/src/forest/Forest.cpp
+++ b/core/src/forest/Forest.cpp
@@ -21,16 +21,6 @@
 namespace grf {
 
 Forest::Forest(std::vector<std::unique_ptr<Tree>>& trees,
-              const ForestOptions& forest_options,
-               const Data& data) {
-  this->trees.insert(this->trees.end(),
-                     std::make_move_iterator(trees.begin()),
-                     std::make_move_iterator(trees.end()));
-  this->num_variables = data.get_num_cols() - data.get_disallowed_split_variables().size();
-  this->ci_group_size = forest_options.get_ci_group_size();
-}
-
-Forest::Forest(std::vector<std::unique_ptr<Tree>>& trees,
                size_t num_variables,
                size_t ci_group_size) {
   this->trees.insert(this->trees.end(),
@@ -38,6 +28,14 @@ Forest::Forest(std::vector<std::unique_ptr<Tree>>& trees,
                      std::make_move_iterator(trees.end()));
   this->num_variables = num_variables;
   this->ci_group_size = ci_group_size;
+}
+
+Forest::Forest(Forest&& forest) {
+  this->trees.insert(this->trees.end(),
+                     std::make_move_iterator(forest.trees.begin()),
+                     std::make_move_iterator(forest.trees.end()));
+  this->num_variables = forest.num_variables;
+  this->ci_group_size = forest.ci_group_size;
 }
 
 Forest Forest::merge(std::vector<Forest>& forests) {

--- a/core/src/forest/Forest.cpp
+++ b/core/src/forest/Forest.cpp
@@ -20,23 +20,28 @@
 
 namespace grf {
 
-Forest Forest::create(const std::vector<Tree>& trees,
-                      const ForestOptions& forest_options,
-                      const Data& data) {
-  size_t num_independent_variables = data.get_num_cols() -
-      data.get_disallowed_split_variables().size();
-  return Forest(trees, num_independent_variables, forest_options.get_ci_group_size());
+Forest::Forest(std::vector<std::unique_ptr<Tree>>& trees,
+              const ForestOptions& forest_options,
+               const Data& data) {
+  this->trees.insert(this->trees.end(),
+                     std::make_move_iterator(trees.begin()),
+                     std::make_move_iterator(trees.end()));
+  this->num_variables = data.get_num_cols() - data.get_disallowed_split_variables().size();
+  this->ci_group_size = forest_options.get_ci_group_size();
 }
 
-Forest::Forest(const std::vector<Tree>& trees,
+Forest::Forest(std::vector<std::unique_ptr<Tree>>& trees,
                size_t num_variables,
-               size_t ci_group_size):
-  trees(std::move(trees)),
-  num_variables(num_variables),
-  ci_group_size(ci_group_size) {}
+               size_t ci_group_size) {
+  this->trees.insert(this->trees.end(),
+                     std::make_move_iterator(trees.begin()),
+                     std::make_move_iterator(trees.end()));
+  this->num_variables = num_variables;
+  this->ci_group_size = ci_group_size;
+}
 
 Forest Forest::merge(std::vector<Forest>& forests) {
-  std::vector<Tree> all_trees;
+  std::vector<std::unique_ptr<Tree>> all_trees;
   const size_t num_variables = forests.at(0).get_num_variables();
   const size_t ci_group_size = forests.at(0).get_ci_group_size();
 
@@ -54,11 +59,11 @@ Forest Forest::merge(std::vector<Forest>& forests) {
   return Forest(all_trees, num_variables, ci_group_size);
 }
 
-const std::vector<Tree>& Forest::get_trees() const {
+const std::vector<std::unique_ptr<Tree>>& Forest::get_trees() const {
   return trees;
 }
 
-std::vector<Tree>& Forest::get_trees_() {
+std::vector<std::unique_ptr<Tree>>& Forest::get_trees_() {
   return trees;
 }
 

--- a/core/src/forest/Forest.h
+++ b/core/src/forest/Forest.h
@@ -28,21 +28,21 @@ namespace grf {
 
 class Forest {
 public:
-  static Forest create(const std::vector<Tree>& trees,
-                       const ForestOptions& forest_options,
-                       const Data& data);
+  Forest(std::vector<std::unique_ptr<Tree>>& trees,
+         const ForestOptions& forest_options,
+         const Data& data);
 
-  Forest(const std::vector<Tree>& trees,
+  Forest(std::vector<std::unique_ptr<Tree>>& trees,
          size_t num_variables,
          size_t ci_group_size);
 
-  const std::vector<Tree>& get_trees() const;
+  const std::vector<std::unique_ptr<Tree>>& get_trees() const;
 
   /**
    * A method intended for internal use that allows the list of
    * trees to be modified.
    */
-  std::vector<Tree>& get_trees_();
+  std::vector<std::unique_ptr<Tree>>& get_trees_();
 
   const size_t get_num_variables() const;
   const size_t get_ci_group_size() const;
@@ -57,9 +57,10 @@ public:
   static Forest merge(std::vector<Forest>& forests);
   
 private:
-  std::vector<Tree> trees;
+  std::vector<std::unique_ptr<Tree>> trees;
   size_t num_variables;
   size_t ci_group_size;
+  //DISALLOW_COPY_AND_ASSIGN(Forest);
 };
 
 } // namespace grf

--- a/core/src/forest/Forest.h
+++ b/core/src/forest/Forest.h
@@ -29,12 +29,10 @@ namespace grf {
 class Forest {
 public:
   Forest(std::vector<std::unique_ptr<Tree>>& trees,
-         const ForestOptions& forest_options,
-         const Data& data);
-
-  Forest(std::vector<std::unique_ptr<Tree>>& trees,
          size_t num_variables,
          size_t ci_group_size);
+
+  Forest(Forest&& forest);
 
   const std::vector<std::unique_ptr<Tree>>& get_trees() const;
 
@@ -60,7 +58,7 @@ private:
   std::vector<std::unique_ptr<Tree>> trees;
   size_t num_variables;
   size_t ci_group_size;
-  //DISALLOW_COPY_AND_ASSIGN(Forest);
+  DISALLOW_COPY_AND_ASSIGN(Forest);
 };
 
 } // namespace grf

--- a/core/src/forest/ForestTrainer.cpp
+++ b/core/src/forest/ForestTrainer.cpp
@@ -37,7 +37,10 @@ ForestTrainer::ForestTrainer(std::unique_ptr<RelabelingStrategy> relabeling_stra
 
 Forest ForestTrainer::train(const Data& data, const ForestOptions& options) const {
   std::vector<std::unique_ptr<Tree>> trees = train_trees(data, options);
-  return Forest(trees, options, data);
+
+  size_t num_variables = data.get_num_cols() - data.get_disallowed_split_variables().size();
+  size_t ci_group_size = options.get_ci_group_size();
+  return Forest(trees, num_variables, ci_group_size);
 }
 
 std::vector<std::unique_ptr<Tree>> ForestTrainer::train_trees(const Data& data,

--- a/core/src/forest/ForestTrainer.cpp
+++ b/core/src/forest/ForestTrainer.cpp
@@ -35,8 +35,13 @@ ForestTrainer::ForestTrainer(std::unique_ptr<RelabelingStrategy> relabeling_stra
                  std::move(splitting_rule_factory),
                  std::move(prediction_strategy)) {}
 
-const Forest ForestTrainer::train(const Data& data,
-                                  const ForestOptions& options) const {
+Forest ForestTrainer::train(const Data& data, const ForestOptions& options) const {
+  std::vector<std::unique_ptr<Tree>> trees = train_trees(data, options);
+  return Forest(trees, options, data);
+}
+
+std::vector<std::unique_ptr<Tree>> ForestTrainer::train_trees(const Data& data,
+                                                              const ForestOptions& options) const {
   size_t num_samples = data.get_num_rows();
   uint num_trees = options.get_num_trees();
 
@@ -56,10 +61,10 @@ const Forest ForestTrainer::train(const Data& data,
   std::vector<uint> thread_ranges;
   split_sequence(thread_ranges, 0, num_groups - 1, options.get_num_threads());
 
-  std::vector<std::future<std::vector<Tree>>> futures;
+  std::vector<std::future<std::vector<std::unique_ptr<Tree>>>> futures;
   futures.reserve(thread_ranges.size());
 
-  std::vector<Tree> trees;
+  std::vector<std::unique_ptr<Tree>> trees;
   trees.reserve(num_trees);
 
   for (uint i = 0; i < thread_ranges.size() - 1; ++i) {
@@ -76,14 +81,16 @@ const Forest ForestTrainer::train(const Data& data,
   }
 
   for (auto& future : futures) {
-    std::vector<Tree> thread_trees = future.get();
-    trees.insert(trees.end(), thread_trees.begin(), thread_trees.end());
+    std::vector<std::unique_ptr<Tree>> thread_trees = future.get();
+    trees.insert(trees.end(),
+                 std::make_move_iterator(thread_trees.begin()),
+                 std::make_move_iterator(thread_trees.end()));
   }
 
-  return Forest::create(trees, options, data);
+  return trees;
 }
 
-std::vector<Tree> ForestTrainer::train_batch(
+std::vector<std::unique_ptr<Tree>> ForestTrainer::train_batch(
     size_t start,
     size_t num_trees,
     const Data& data,
@@ -92,7 +99,7 @@ std::vector<Tree> ForestTrainer::train_batch(
 
   std::mt19937_64 random_number_generator(options.get_random_seed() + start);
   nonstd::uniform_int_distribution<uint> udist;
-  std::vector<Tree> trees;
+  std::vector<std::unique_ptr<Tree>> trees;
 
   if (ci_group_size == 1) {
     trees.reserve(num_trees);
@@ -105,30 +112,29 @@ std::vector<Tree> ForestTrainer::train_batch(
     RandomSampler sampler(tree_seed, options.get_sampling_options());
 
     if (ci_group_size == 1) {
-      Tree tree = train_tree(data, sampler, options);
+      std::unique_ptr<Tree> tree = train_tree(data, sampler, options);
       trees.push_back(std::move(tree));
     } else {
-      std::vector<Tree> group = train_ci_group(data, sampler, options);
+      std::vector<std::unique_ptr<Tree>> group = train_ci_group(data, sampler, options);
       trees.insert(trees.end(),
-                   std::make_move_iterator(group.begin()),
-                   std::make_move_iterator(group.end()));
+          std::make_move_iterator(group.begin()),
+          std::make_move_iterator(group.end()));
     }
   }
   return trees;
 }
-
-Tree ForestTrainer::train_tree(const Data& data,
-                               RandomSampler& sampler,
-                               const ForestOptions& options) const {
+std::unique_ptr<Tree> ForestTrainer::train_tree(const Data& data,
+                                                RandomSampler& sampler,
+                                                const ForestOptions& options) const {
   std::vector<size_t> clusters;
   sampler.sample_clusters(data.get_num_rows(), options.get_sample_fraction(), clusters);
   return tree_trainer.train(data, sampler, clusters, options.get_tree_options());
 }
 
-std::vector<Tree> ForestTrainer::train_ci_group(const Data& data,
-                                                RandomSampler& sampler,
-                                                const ForestOptions& options) const {
-  std::vector<Tree> trees;
+std::vector<std::unique_ptr<Tree>> ForestTrainer::train_ci_group(const Data& data,
+                                                                 RandomSampler& sampler,
+                                                                 const ForestOptions& options) const {
+  std::vector<std::unique_ptr<Tree>> trees;
 
   std::vector<size_t> clusters;
   sampler.sample_clusters(data.get_num_rows(), 0.5, clusters);
@@ -138,7 +144,7 @@ std::vector<Tree> ForestTrainer::train_ci_group(const Data& data,
     std::vector<size_t> cluster_subsample;
     sampler.subsample(clusters, sample_fraction * 2, cluster_subsample);
 
-    Tree tree = tree_trainer.train(data, sampler, cluster_subsample, options.get_tree_options());
+    std::unique_ptr<Tree> tree = tree_trainer.train(data, sampler, cluster_subsample, options.get_tree_options());
     trees.push_back(std::move(tree));
   }
   return trees;

--- a/core/src/forest/ForestTrainer.h
+++ b/core/src/forest/ForestTrainer.h
@@ -39,24 +39,27 @@ public:
   ForestTrainer(std::unique_ptr<RelabelingStrategy> relabeling_strategy,
                 std::unique_ptr<SplittingRuleFactory> splitting_rule_factory,
                 std::unique_ptr<OptimizedPredictionStrategy> prediction_strategy);
-  const Forest train(const Data& data,
-                     const ForestOptions& options) const;
+
+  Forest train(const Data& data, const ForestOptions& options) const;
 
 private:
 
-  std::vector<Tree> train_batch(
+  std::vector<std::unique_ptr<Tree>> train_trees(const Data& data,
+                                                 const ForestOptions& options) const;
+
+  std::vector<std::unique_ptr<Tree>> train_batch(
       size_t start,
       size_t num_trees,
       const Data& data,
       const ForestOptions& options) const;
 
-  Tree train_tree(const Data& data,
-                  RandomSampler& sampler,
-                  const ForestOptions& options) const;
-
-  std::vector<Tree> train_ci_group(const Data& data,
+  std::unique_ptr<Tree> train_tree(const Data& data,
                                    RandomSampler& sampler,
                                    const ForestOptions& options) const;
+
+  std::vector<std::unique_ptr<Tree>> train_ci_group(const Data& data,
+                                                    RandomSampler& sampler,
+                                                    const ForestOptions& options) const;
 
   TreeTrainer tree_trainer;
 };

--- a/core/src/prediction/CustomPredictionStrategy.cpp
+++ b/core/src/prediction/CustomPredictionStrategy.cpp
@@ -32,8 +32,8 @@ std::vector<double> CustomPredictionStrategy::predict(size_t sample,
 
 std::vector<double> CustomPredictionStrategy::compute_variance(
     size_t sample,
-    std::vector<std::vector<size_t>> samples_by_tree,
-    std::unordered_map<size_t, double> weights_by_sampleID,
+    const std::vector<std::vector<size_t>>& samples_by_tree,
+    const std::unordered_map<size_t, double>& weights_by_sampleID,
     const Data& train_data,
     const Data& data,
     size_t ci_group_size) const {

--- a/core/src/prediction/CustomPredictionStrategy.h
+++ b/core/src/prediction/CustomPredictionStrategy.h
@@ -34,8 +34,8 @@ public:
 
   std::vector<double> compute_variance(
       size_t sampleD,
-      std::vector<std::vector<size_t>> samples_by_tree,
-      std::unordered_map<size_t, double> weights_by_sampleID,
+      const std::vector<std::vector<size_t>>& samples_by_tree,
+      const std::unordered_map<size_t, double>& weights_by_sampleID,
       const Data& train_data,
       const Data& data,
       size_t ci_group_size) const;

--- a/core/src/prediction/DefaultPredictionStrategy.h
+++ b/core/src/prediction/DefaultPredictionStrategy.h
@@ -79,8 +79,8 @@ public:
    */
   virtual std::vector<double> compute_variance(
       size_t sample,
-      std::vector<std::vector<size_t>> samples_by_tree,
-      std::unordered_map<size_t, double> weights_by_sampleID,
+      const std::vector<std::vector<size_t>>& samples_by_tree,
+      const std::unordered_map<size_t, double>& weights_by_sampleID,
       const Data& train_data,
       const Data& data,
       size_t ci_group_size) const = 0;

--- a/core/src/prediction/LLCausalPredictionStrategy.cpp
+++ b/core/src/prediction/LLCausalPredictionStrategy.cpp
@@ -147,8 +147,8 @@ std::vector<double> LLCausalPredictionStrategy::predict(
 
 std::vector<double> LLCausalPredictionStrategy::compute_variance(
         size_t sampleID,
-        std::vector<std::vector<size_t>> samples_by_tree,
-        std::unordered_map<size_t, double> weights_by_sampleID,
+        const std::vector<std::vector<size_t>>& samples_by_tree,
+        const std::unordered_map<size_t, double>& weights_by_sampleID,
         const Data& train_data,
         const Data& test_data,
         size_t ci_group_size) const {

--- a/core/src/prediction/LLCausalPredictionStrategy.h
+++ b/core/src/prediction/LLCausalPredictionStrategy.h
@@ -42,8 +42,8 @@ public:
 
     std::vector<double> compute_variance(
             size_t sampleID,
-            std::vector<std::vector<size_t>> samples_by_tree,
-            std::unordered_map<size_t, double> weights_by_sampleID,
+            const std::vector<std::vector<size_t>>& samples_by_tree,
+            const std::unordered_map<size_t, double>& weights_by_sampleID,
             const Data& train_data,
             const Data& data,
             size_t ci_group_size) const;

--- a/core/src/prediction/LocalLinearPredictionStrategy.cpp
+++ b/core/src/prediction/LocalLinearPredictionStrategy.cpp
@@ -105,8 +105,8 @@ std::vector<double> LocalLinearPredictionStrategy::predict(
 
 std::vector<double> LocalLinearPredictionStrategy::compute_variance(
     size_t sampleID,
-    std::vector<std::vector<size_t>> samples_by_tree,
-    std::unordered_map<size_t, double> weights_by_sampleID,
+    const std::vector<std::vector<size_t>>& samples_by_tree,
+    const std::unordered_map<size_t, double>& weights_by_sampleID,
     const Data& train_data,
     const Data& data,
     size_t ci_group_size) const {

--- a/core/src/prediction/LocalLinearPredictionStrategy.h
+++ b/core/src/prediction/LocalLinearPredictionStrategy.h
@@ -52,8 +52,8 @@ public:
 
     std::vector<double> compute_variance(
         size_t sampleID,
-        std::vector<std::vector<size_t>> samples_by_tree,
-        std::unordered_map<size_t, double> weights_by_sampleID,
+        const std::vector<std::vector<size_t>>& samples_by_tree,
+        const std::unordered_map<size_t, double>& weights_by_sampleID,
         const Data& train_data,
         const Data& data,
         size_t ci_group_size) const;

--- a/core/src/prediction/QuantilePredictionStrategy.cpp
+++ b/core/src/prediction/QuantilePredictionStrategy.cpp
@@ -84,8 +84,8 @@ std::vector<double> QuantilePredictionStrategy::compute_quantile_cutoffs(
 
 std::vector<double> QuantilePredictionStrategy::compute_variance(
     size_t sampleID,
-    std::vector<std::vector<size_t>> samples_by_tree,
-    std::unordered_map<size_t, double> weights_by_sampleID,
+    const std::vector<std::vector<size_t>>& samples_by_tree,
+    const std::unordered_map<size_t, double>& weights_by_sampleID,
     const Data& train_data,
     const Data& data,
     size_t ci_group_size) const {

--- a/core/src/prediction/QuantilePredictionStrategy.h
+++ b/core/src/prediction/QuantilePredictionStrategy.h
@@ -41,8 +41,8 @@ public:
 
   std::vector<double> compute_variance(
       size_t sampleID,
-      std::vector<std::vector<size_t>> samples_by_tree,
-      std::unordered_map<size_t, double> weights_by_sampleID,
+      const std::vector<std::vector<size_t>>& samples_by_tree,
+      const std::unordered_map<size_t, double>& weights_by_sampleID,
       const Data& train_data,
       const Data& data,
       size_t ci_group_size) const;

--- a/core/src/prediction/collector/DefaultPredictionCollector.cpp
+++ b/core/src/prediction/collector/DefaultPredictionCollector.cpp
@@ -53,8 +53,8 @@ std::vector<Prediction> DefaultPredictionCollector::collect_predictions(
         const std::vector<size_t>& leaf_nodes = leaf_nodes_by_tree.at(tree_index);
         size_t node = leaf_nodes.at(sample);
 
-        const Tree& tree = forest.get_trees()[tree_index];
-        std::vector<std::vector<size_t>> leaf_samples = tree.get_leaf_samples();
+        const std::unique_ptr<Tree>& tree = forest.get_trees()[tree_index];
+        std::vector<std::vector<size_t>> leaf_samples = tree->get_leaf_samples();
         samples_by_tree.push_back(leaf_samples.at(node));
       }
     }

--- a/core/src/prediction/collector/OptimizedPredictionCollector.cpp
+++ b/core/src/prediction/collector/OptimizedPredictionCollector.cpp
@@ -53,8 +53,8 @@ std::vector<Prediction> OptimizedPredictionCollector::collect_predictions(const 
       const std::vector<size_t>& leaf_nodes = leaf_nodes_by_tree.at(tree_index);
       size_t node = leaf_nodes.at(sample);
 
-      const Tree& tree = forest.get_trees()[tree_index];
-      const PredictionValues& prediction_values = tree.get_prediction_values();
+      const std::unique_ptr<Tree>& tree = forest.get_trees()[tree_index];
+      const PredictionValues& prediction_values = tree->get_prediction_values();
 
       if (!prediction_values.empty(node)) {
         num_leaves++;

--- a/core/src/prediction/collector/SampleWeightComputer.cpp
+++ b/core/src/prediction/collector/SampleWeightComputer.cpp
@@ -36,8 +36,8 @@ std::unordered_map<size_t, double> SampleWeightComputer::compute_weights(size_t 
     const std::vector<size_t>& leaf_nodes = leaf_nodes_by_tree.at(tree_index);
     size_t node = leaf_nodes.at(sample);
 
-    const Tree& tree = forest.get_trees()[tree_index];
-    const std::vector<size_t>& samples = tree.get_leaf_samples()[node];
+    const std::unique_ptr<Tree>& tree = forest.get_trees()[tree_index];
+    const std::vector<size_t>& samples = tree->get_leaf_samples()[node];
     if (!samples.empty()) {
       add_sample_weights(samples, weights_by_sample);
     }

--- a/core/src/prediction/collector/TreeTraverser.cpp
+++ b/core/src/prediction/collector/TreeTraverser.cpp
@@ -49,7 +49,7 @@ std::vector<std::vector<size_t>> TreeTraverser::get_leaf_nodes(
                                  this,
                                  start_index,
                                  num_trees_batch,
-                                 forest,
+                                 std::ref(forest),
                                  std::ref(data),
                                  oob_prediction));
   }
@@ -73,7 +73,7 @@ std::vector<std::vector<bool>> TreeTraverser::get_valid_trees_by_sample(const Fo
   std::vector<std::vector<bool>> result(num_samples, std::vector<bool>(num_trees, true));
   if (oob_prediction) {
     for (size_t tree_idx = 0; tree_idx < num_trees; ++tree_idx) {
-      for (size_t sample : forest.get_trees()[tree_idx].get_drawn_samples()) {
+      for (size_t sample : forest.get_trees()[tree_idx]->get_drawn_samples()) {
         result[sample][tree_idx] = false;
       }
     }
@@ -92,10 +92,10 @@ std::vector<std::vector<size_t>> TreeTraverser::get_leaf_node_batch(
   std::vector<std::vector<size_t>> all_leaf_nodes(num_trees);
 
   for (size_t i = 0; i < num_trees; ++i) {
-    const Tree& tree = forest.get_trees()[start + i];
+    const std::unique_ptr<Tree>& tree = forest.get_trees()[start + i];
 
     std::vector<bool> valid_samples = get_valid_samples(num_samples, tree, oob_prediction);
-    std::vector<size_t> leaf_nodes = tree.find_leaf_nodes(data, valid_samples);
+    std::vector<size_t> leaf_nodes = tree->find_leaf_nodes(data, valid_samples);
     all_leaf_nodes[i] = leaf_nodes;
   }
 
@@ -103,11 +103,11 @@ std::vector<std::vector<size_t>> TreeTraverser::get_leaf_node_batch(
 }
 
 std::vector<bool> TreeTraverser::get_valid_samples(size_t num_samples,
-                                                   const Tree& tree,
+                                                   const std::unique_ptr<Tree>& tree,
                                                    bool oob_prediction) const {
   std::vector<bool> valid_samples(num_samples, true);
   if (oob_prediction) {
-    for (size_t sample : tree.get_drawn_samples()) {
+    for (size_t sample : tree->get_drawn_samples()) {
       valid_samples[sample] = false;
     }
   }

--- a/core/src/prediction/collector/TreeTraverser.h
+++ b/core/src/prediction/collector/TreeTraverser.h
@@ -44,7 +44,7 @@ private:
       bool oob_prediction) const;
 
   std::vector<bool> get_valid_samples(size_t num_samples,
-                                      const Tree& tree,
+                                      const std::unique_ptr<Tree>& tree,
                                       bool oob_prediction) const;
 
   uint num_threads;

--- a/core/src/tree/Tree.cpp
+++ b/core/src/tree/Tree.cpp
@@ -176,14 +176,4 @@ bool Tree::is_empty_leaf(size_t node) const  {
   return is_leaf(node) && leaf_samples[node].empty();
 }
 
-void Tree::clear() {
-  root_node = 0;
-  child_nodes.clear();
-  leaf_samples.clear();
-  split_vars.clear();
-  split_values.clear();
-  drawn_samples.clear();
-  prediction_values.clear();
-}
-
 } // namespace grf

--- a/core/src/tree/Tree.h
+++ b/core/src/tree/Tree.h
@@ -135,12 +135,6 @@ public:
    */
   void set_prediction_values(const PredictionValues& prediction_values);
 
-  /**
-   * Empties out all internal data in this tree. Used to reduce memory
-   * usage when destructively iterating through a {@link Forest} object.
-   */
-  void clear();
-
 private:
   size_t find_leaf_node(const Data& data,
                         size_t sample) const;

--- a/core/src/tree/TreeTrainer.cpp
+++ b/core/src/tree/TreeTrainer.cpp
@@ -30,10 +30,10 @@ TreeTrainer::TreeTrainer(std::unique_ptr<RelabelingStrategy> relabeling_strategy
     splitting_rule_factory(std::move(splitting_rule_factory)),
     prediction_strategy(std::move(prediction_strategy)) {}
 
-Tree TreeTrainer::train(const Data& data,
-                        RandomSampler& sampler,
-                        const std::vector<size_t>& clusters,
-                        const TreeOptions& options) const {
+std::unique_ptr<Tree> TreeTrainer::train(const Data& data,
+                                         RandomSampler& sampler,
+                                         const std::vector<size_t>& clusters,
+                                         const TreeOptions& options) const {
   std::vector<std::vector<size_t>> child_nodes;
   std::vector<std::vector<size_t>> nodes;
   std::vector<size_t> split_vars;
@@ -85,7 +85,8 @@ Tree TreeTrainer::train(const Data& data,
   std::vector<size_t> drawn_samples;
   sampler.get_samples_in_clusters(clusters, drawn_samples);
 
-  Tree tree(0, child_nodes, nodes, split_vars, split_values, drawn_samples, PredictionValues());
+  std::unique_ptr<Tree> tree(new Tree(0, child_nodes, nodes,
+      split_vars, split_values, drawn_samples, PredictionValues()));
 
   if (!new_leaf_samples.empty()) {
     repopulate_leaf_nodes(tree, data, new_leaf_samples, options.get_prune_empty_leaves());
@@ -93,29 +94,29 @@ Tree TreeTrainer::train(const Data& data,
 
   PredictionValues prediction_values;
   if (prediction_strategy != nullptr) {
-    prediction_values = prediction_strategy->precompute_prediction_values(tree.get_leaf_samples(), data);
+    prediction_values = prediction_strategy->precompute_prediction_values(tree->get_leaf_samples(), data);
   }
-  tree.set_prediction_values(prediction_values);
+  tree->set_prediction_values(prediction_values);
 
   return tree;
 }
 
-void TreeTrainer::repopulate_leaf_nodes(Tree& tree,
+void TreeTrainer::repopulate_leaf_nodes(const std::unique_ptr<Tree>& tree,
                                         const Data& data,
                                         const std::vector<size_t>& leaf_samples,
                                         const bool prune_empty_leaves) const {
-  size_t num_nodes = tree.get_leaf_samples().size();
+  size_t num_nodes = tree->get_leaf_samples().size();
   std::vector<std::vector<size_t>> new_leaf_nodes(num_nodes);
 
-  std::vector<size_t> leaf_nodes = tree.find_leaf_nodes(data, leaf_samples);
+  std::vector<size_t> leaf_nodes = tree->find_leaf_nodes(data, leaf_samples);
 
   for (auto& sample : leaf_samples) {
     size_t leaf_node = leaf_nodes[sample];
     new_leaf_nodes[leaf_node].push_back(sample);
   }
-  tree.set_leaf_samples(new_leaf_nodes);
+  tree->set_leaf_samples(new_leaf_nodes);
   if (prune_empty_leaves) {
-    tree.prune_empty_leaves();
+    tree->prune_empty_leaves();
   }
 }
 

--- a/core/src/tree/TreeTrainer.h
+++ b/core/src/tree/TreeTrainer.h
@@ -36,10 +36,10 @@ public:
               std::unique_ptr<SplittingRuleFactory> splitting_rule_factory,
               std::unique_ptr<OptimizedPredictionStrategy> prediction_strategy);
 
-  Tree train(const Data& data,
-             RandomSampler& sampler,
-             const std::vector<size_t>& clusters,
-             const TreeOptions& options) const;
+  std::unique_ptr<Tree> train(const Data& data,
+                              RandomSampler& sampler,
+                              const std::vector<size_t>& clusters,
+                              const TreeOptions& options) const;
 
 private:
   void create_empty_node(std::vector<std::vector<size_t>>& child_nodes,
@@ -47,7 +47,7 @@ private:
                          std::vector<size_t>& split_vars,
                          std::vector<double>& split_values) const;
 
-  void repopulate_leaf_nodes(Tree& tree,
+  void repopulate_leaf_nodes(const std::unique_ptr<Tree>& tree,
                              const Data& data,
                              const std::vector<size_t>& leaf_samples,
                              const bool prune_empty_leaves) const;

--- a/core/test/analysis/SplitFrequencyUnitTest.cpp
+++ b/core/test/analysis/SplitFrequencyUnitTest.cpp
@@ -54,9 +54,9 @@ TEST_CASE("split frequency computation works as expected", "[analysis, unit]") {
       {0, 0, 0, 2, 1}, // depth 2
       {0, 0, 0, 0, 1}}; // depth 3
 
-  std::vector<Tree> trees;
-  trees.push_back(Tree(0, first_child_nodes, {{0}}, first_split_vars, {0}, {0}, PredictionValues()));
-  trees.push_back(Tree(0, second_child_nodes, {{1}}, second_split_vars, {1}, {1}, PredictionValues()));
+  std::vector<std::unique_ptr<Tree>> trees;
+  trees.emplace_back(new Tree(0, first_child_nodes, {{0}}, first_split_vars, {0}, {0}, PredictionValues()));
+  trees.emplace_back(new Tree(0, second_child_nodes, {{1}}, second_split_vars, {1}, {1}, PredictionValues()));
 
   size_t num_variables = 5;
   size_t ci_group_size = 2;
@@ -89,8 +89,8 @@ TEST_CASE("split frequency computation respects max depth", "[analysis, unit]") 
       {1, 1, 0, 0, 0}, // depth 1
       {0, 0, 0, 2, 1}}; // depth 2
 
-  std::vector<Tree> trees;
-  trees.push_back(Tree(0, child_nodes, {{0}}, split_vars, {0}, {0}, PredictionValues()));
+  std::vector<std::unique_ptr<Tree>> trees;
+  trees.emplace_back(new Tree(0, child_nodes, {{0}}, split_vars, {0}, {0}, PredictionValues()));
 
   size_t num_variables = 5;
   size_t ci_group_size = 2;

--- a/r-package/grf/bindings/AnalysisToolsBindings.cpp
+++ b/r-package/grf/bindings/AnalysisToolsBindings.cpp
@@ -117,15 +117,15 @@ Rcpp::List deserialize_tree(Rcpp::List forest_object,
     throw std::runtime_error("The provided tree index is not valid.");
   }
 
-  const Tree& tree = forest.get_trees().at(tree_index);
-  const std::vector<std::vector<size_t>>& child_nodes = tree.get_child_nodes();
-  const std::vector<std::vector<size_t>>& leaf_samples = tree.get_leaf_samples();
+  const std::unique_ptr<Tree>& tree = forest.get_trees().at(tree_index);
+  const std::vector<std::vector<size_t>>& child_nodes = tree->get_child_nodes();
+  const std::vector<std::vector<size_t>>& leaf_samples = tree->get_leaf_samples();
 
-  const std::vector<size_t>& split_vars = tree.get_split_vars();
-  const std::vector<double>& split_values = tree.get_split_values();
+  const std::vector<size_t>& split_vars = tree->get_split_vars();
+  const std::vector<double>& split_values = tree->get_split_values();
 
   std::queue<size_t> frontier;
-  frontier.push(tree.get_root_node());
+  frontier.push(tree->get_root_node());
   size_t node_index = 1;
 
   std::vector<Rcpp::List> node_objects;
@@ -135,7 +135,7 @@ Rcpp::List deserialize_tree(Rcpp::List forest_object,
     size_t node = frontier.front();
     Rcpp::List node_object;
 
-    if (tree.is_leaf(node)) {
+    if (tree->is_leaf(node)) {
       node_object.push_back(true, "is_leaf");
 
       std::vector<size_t> samples;
@@ -162,7 +162,7 @@ Rcpp::List deserialize_tree(Rcpp::List forest_object,
     node_objects.push_back(node_object);
   }
 
-  std::vector<size_t> drawn_samples(tree.get_drawn_samples());
+  std::vector<size_t> drawn_samples(tree->get_drawn_samples());
   for (size_t& index : drawn_samples) index += 1; //R is 1-indexed.
 
 

--- a/r-package/grf/tests/testthat/test_cran_smoke_test.R
+++ b/r-package/grf/tests/testthat/test_cran_smoke_test.R
@@ -1,17 +1,6 @@
 library(grf)
 set.seed(1234)
 
-test_that("regression forest split frequencies are reasonable", {
-  n <- 100
-  p <- 6
-  X <- matrix(rnorm(n * p), n, p)
-  Y <- 1000 * (X[, 1]) + rnorm(n)
-  rrr <- regression_forest(X, Y, mtry = p)
-  freq <- split_frequencies(rrr, 4)
-  expect_true(freq[1, 1] / sum(freq[1, ]) > 1 / 2)
-})
-
-test_that("causal forests give reasonable estimates", {
   p <- 6
   n <- 1000
 
@@ -33,16 +22,4 @@ test_that("causal forests give reasonable estimates", {
   preds.causal.oob <- predict(forest.causal, estimate.variance = TRUE)
   preds.causal <- predict(forest.causal, X.test, estimate.variance = TRUE)
 
-  expect_true(all(preds.causal$variance.estimate > 0))
-  expect_true(all(preds.causal.oob$variance.estimate > 0))
-
-  error <- preds.causal$predictions - truth
-  expect_true(mean(error^2) < 0.5)
-
-  truth.oob <- 2 * (X[, 1] > 0)
-  error.oob <- preds.causal.oob$predictions - truth.oob
-  expect_true(mean(error.oob^2) < 0.5)
-
-  Z.oob <- error.oob / sqrt(preds.causal.oob$variance.estimate)
-  expect_true(mean(abs(Z.oob) > 1) < 0.5)
-})
+  preds.causal2 <- predict(forest.causal, X, estimate.variance = TRUE)


### PR DESCRIPTION
This fixes a regression introduced in #512 where memory usage would spike 2x
during training. Wrapping all trees with unique_ptr makes it much easier to
guarantee that their contents are not copied unintentionally.

This commit also makes sure parameters are passed by const reference in
DefaultPredictionStrategy#compute_variance, addressing another case of
unnecessary copying.