### PR TITLE
Add vignettes to .Rbuildignore

### DIFF
--- a/r-package/grf/.Rbuildignore
+++ b/r-package/grf/.Rbuildignore
@@ -1,7 +1,7 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^bindings$
-
+^vignettes
 ^tests/benchmarks
 ^_pkgdown\.yml$
 ^docs$


### PR DESCRIPTION
Vignettes are only built on CI for online documentation, including them in the package.tar will cause R CMD check to fail:

![Screen Shot 2019-09-02 at 15 30 11](https://user-images.githubusercontent.com/7185264/64134997-f32c4a80-cd98-11e9-900f-8fe09fb1dbee.png)
