### PR TITLE
Remove deserialize_tree and perform tree construction in R

### DIFF
--- a/r-package/grf/R/RcppExports.R
+++ b/r-package/grf/R/RcppExports.R
@@ -13,10 +13,6 @@ compute_weights_oob <- function(forest_object, test_matrix, sparse_test_matrix, 
     .Call('_grf_compute_weights_oob', PACKAGE = 'grf', forest_object, test_matrix, sparse_test_matrix, num_threads)
 }
 
-deserialize_tree <- function(forest_object, tree_index) {
-    .Call('_grf_deserialize_tree', PACKAGE = 'grf', forest_object, tree_index)
-}
-
 merge <- function(forest_objects) {
     .Call('_grf_merge', PACKAGE = 'grf', forest_objects)
 }

--- a/r-package/grf/R/analysis_tools.R
+++ b/r-package/grf/R/analysis_tools.R
@@ -38,7 +38,46 @@ get_tree <- function(forest, index) {
     stop(paste("The provided index,", index, "is not valid."))
   }
 
-  tree <- deserialize_tree(forest, index)
+  # Convert internal grf representation to adjacency list.
+  # +1 from C++ to R index.
+  root <- forest$`_root_nodes`[[index]] + 1
+  left <- forest$`_child_nodes`[[index]][[1]]
+  right <- forest$`_child_nodes`[[index]][[2]]
+  split_vars <- forest$`_split_vars`[[index]]
+  split_values <- forest$`_split_values`[[index]]
+  leaf_samples <- forest$`_leaf_samples`[[index]]
+  drawn_samples <- forest$`_drawn_samples`[[index]] + 1
+
+  nodes <- list()
+  frontier <- root
+  i <- 0
+  node.index <- 1
+  while (length(frontier) > 0) {
+    node <- frontier[1]
+    frontier <- frontier[-1]
+    i <- i + 1
+    if (left[[node]] == 0 && right[[node]] == 0) {
+      nodes[[i]] <- list(
+        is_leaf = TRUE,
+        samples = leaf_samples[[node]] + 1
+      )
+    } else {
+      nodes[[i]] <- list(
+        is_leaf = FALSE,
+        split_variable = split_vars[node] + 1,
+        split_value = split_values[node],
+        left_child = node.index + 1,
+        right_child = node.index + 2
+      )
+      node.index <- node.index + 2
+      frontier <- c(left[node] + 1, right[node] + 1, frontier)
+    }
+  }
+
+  tree <- list()
+  tree$num_samples <- length(drawn_samples)
+  tree$drawn_samples <- drawn_samples
+  tree$nodes <- nodes
   class(tree) <- "grf_tree"
 
   columns <- colnames(forest$X.orig)

--- a/r-package/grf/R/analysis_tools.R
+++ b/r-package/grf/R/analysis_tools.R
@@ -78,7 +78,6 @@ get_tree <- function(forest, index) {
   tree$num_samples <- length(drawn_samples)
   tree$drawn_samples <- drawn_samples
   tree$nodes <- nodes
-  class(tree) <- "grf_tree"
 
   columns <- colnames(forest$X.orig)
   indices <- 1:ncol(forest$X.orig)
@@ -98,6 +97,7 @@ get_tree <- function(forest, index) {
     node
   })
 
+  class(tree) <- "grf_tree"
   tree
 }
 

--- a/r-package/grf/R/analysis_tools.R
+++ b/r-package/grf/R/analysis_tools.R
@@ -98,7 +98,6 @@ get_tree <- function(forest, index) {
     node
   })
 
-
   tree
 }
 

--- a/r-package/grf/R/analysis_tools.R
+++ b/r-package/grf/R/analysis_tools.R
@@ -40,13 +40,13 @@ get_tree <- function(forest, index) {
 
   # Convert internal grf representation to adjacency list.
   # +1 from C++ to R index.
-  root <- forest$`_root_nodes`[[index]] + 1
-  left <- forest$`_child_nodes`[[index]][[1]]
-  right <- forest$`_child_nodes`[[index]][[2]]
-  split_vars <- forest$`_split_vars`[[index]]
-  split_values <- forest$`_split_values`[[index]]
-  leaf_samples <- forest$`_leaf_samples`[[index]]
-  drawn_samples <- forest$`_drawn_samples`[[index]] + 1
+  root <- forest[["_root_nodes"]][[index]] + 1
+  left <- forest[["_child_nodes"]][[index]][[1]]
+  right <- forest[["_child_nodes"]][[index]][[2]]
+  split_vars <- forest[["_split_vars"]][[index]]
+  split_values <- forest[["_split_values"]][[index]]
+  leaf_samples <- forest[["_leaf_samples"]][[index]]
+  drawn_samples <- forest[["_drawn_samples"]][[index]] + 1
 
   nodes <- list()
   frontier <- root

--- a/r-package/grf/bindings/AnalysisToolsBindings.cpp
+++ b/r-package/grf/bindings/AnalysisToolsBindings.cpp
@@ -107,73 +107,6 @@ Eigen::SparseMatrix<double> compute_weights_oob(Rcpp::List forest_object,
 }
 
 // [[Rcpp::export]]
-Rcpp::List deserialize_tree(Rcpp::List forest_object,
-                            size_t tree_index) {
-  Forest forest = RcppUtilities::deserialize_forest(forest_object);
-
-  tree_index--; // Decrement since R is one-indexed.
-  size_t num_trees = forest.get_trees().size();
-  if (tree_index >= num_trees) {
-    throw std::runtime_error("The provided tree index is not valid.");
-  }
-
-  const std::unique_ptr<Tree>& tree = forest.get_trees().at(tree_index);
-  const std::vector<std::vector<size_t>>& child_nodes = tree->get_child_nodes();
-  const std::vector<std::vector<size_t>>& leaf_samples = tree->get_leaf_samples();
-
-  const std::vector<size_t>& split_vars = tree->get_split_vars();
-  const std::vector<double>& split_values = tree->get_split_values();
-
-  std::queue<size_t> frontier;
-  frontier.push(tree->get_root_node());
-  size_t node_index = 1;
-
-  std::vector<Rcpp::List> node_objects;
-
-  // Note that since R is 1-indexed, we add '1' below to array indices.
-  while (frontier.size() > 0) {
-    size_t node = frontier.front();
-    Rcpp::List node_object;
-
-    if (tree->is_leaf(node)) {
-      node_object.push_back(true, "is_leaf");
-
-      std::vector<size_t> samples;
-      samples.reserve(leaf_samples.at(node).size());
-      for (size_t index : leaf_samples.at(node)) {
-        samples.push_back(index + 1); // R is 1-indexed.
-      }
-      node_object.push_back(samples, "samples");
-    } else {
-      node_object.push_back(false, "is_leaf");
-      node_object.push_back(split_vars.at(node) + 1, "split_variable"); // R is 1-indexed.
-      node_object.push_back(split_values.at(node), "split_value");
-
-      node_object.push_back(node_index + 1, "left_child");
-      frontier.push(child_nodes[0][node]);
-      node_index++;
-
-      node_object.push_back(node_index + 1, "right_child");
-      frontier.push(child_nodes[1][node]);
-      node_index++;
-    }
-
-    frontier.pop();
-    node_objects.push_back(node_object);
-  }
-
-  std::vector<size_t> drawn_samples(tree->get_drawn_samples());
-  for (size_t& index : drawn_samples) index += 1; //R is 1-indexed.
-
-
-  Rcpp::List result;
-  result.push_back(drawn_samples.size(), "num_samples");
-  result.push_back(drawn_samples, "drawn_samples");
-  result.push_back(node_objects, "nodes");
-  return result;
-}
-
-// [[Rcpp::export]]
 Rcpp::List merge(const Rcpp::List forest_objects) {
  std::vector<Forest> forests;
 
@@ -185,4 +118,3 @@ Rcpp::List merge(const Rcpp::List forest_objects) {
   Forest big_forest = Forest::merge(forests);
   return RcppUtilities::serialize_forest(big_forest);
 }
- 

--- a/r-package/grf/src/RcppExports.cpp
+++ b/r-package/grf/src/RcppExports.cpp
@@ -48,18 +48,6 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// deserialize_tree
-Rcpp::List deserialize_tree(Rcpp::List forest_object, size_t tree_index);
-RcppExport SEXP _grf_deserialize_tree(SEXP forest_objectSEXP, SEXP tree_indexSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< Rcpp::List >::type forest_object(forest_objectSEXP);
-    Rcpp::traits::input_parameter< size_t >::type tree_index(tree_indexSEXP);
-    rcpp_result_gen = Rcpp::wrap(deserialize_tree(forest_object, tree_index));
-    return rcpp_result_gen;
-END_RCPP
-}
 // merge
 Rcpp::List merge(const Rcpp::List forest_objects);
 RcppExport SEXP _grf_merge(SEXP forest_objectsSEXP) {
@@ -486,7 +474,6 @@ static const R_CallMethodDef CallEntries[] = {
     {"_grf_compute_split_frequencies", (DL_FUNC) &_grf_compute_split_frequencies, 2},
     {"_grf_compute_weights", (DL_FUNC) &_grf_compute_weights, 6},
     {"_grf_compute_weights_oob", (DL_FUNC) &_grf_compute_weights_oob, 4},
-    {"_grf_deserialize_tree", (DL_FUNC) &_grf_deserialize_tree, 2},
     {"_grf_merge", (DL_FUNC) &_grf_merge, 1},
     {"_grf_causal_train", (DL_FUNC) &_grf_causal_train, 23},
     {"_grf_causal_predict", (DL_FUNC) &_grf_causal_predict, 9},


### PR DESCRIPTION
Addressing #187 [next to last bullet point](https://github.com/grf-labs/grf/issues/187#issuecomment-527217557): all tree information is now saved in an R forest object and `get_tree` does not have to call into C++. Simplify by removing `deserialize_tree` and do tree construction directly inside `get_tree`.