### PR TITLE
create_data_matrices: handle outcome indices

### DIFF
--- a/r-package/grf/R/analysis_tools.R
+++ b/r-package/grf/R/analysis_tools.R
@@ -198,11 +198,11 @@ get_sample_weights <- function(forest, newdata = NULL, num.threads = NULL) {
   if (!is.null(newdata)) {
     data <- create_data_matrices(newdata)
     compute_weights(
-      forest.short, train.data$train_matrix, train.data$sparse_train_matrix,
-      data$train_matrix, data$sparse_train_matrix, num.threads
+      forest.short, train.data$train.matrix, train.data$sparse.train.matrix,
+      data$train.matrix, data$sparse.train.matrix, num.threads
     )
   } else {
-    compute_weights_oob(forest.short, train.data$train_matrix, train.data$sparse_train_matrix, num.threads)
+    compute_weights_oob(forest.short, train.data$train.matrix, train.data$sparse.train.matrix, num.threads)
   }
 }
 

--- a/r-package/grf/R/analysis_tools.R
+++ b/r-package/grf/R/analysis_tools.R
@@ -198,11 +198,11 @@ get_sample_weights <- function(forest, newdata = NULL, num.threads = NULL) {
   if (!is.null(newdata)) {
     data <- create_data_matrices(newdata)
     compute_weights(
-      forest.short, train.data$default, train.data$sparse,
-      data$default, data$sparse, num.threads
+      forest.short, train.data$train_matrix, train.data$sparse_train_matrix,
+      data$train_matrix, data$sparse_train_matrix, num.threads
     )
   } else {
-    compute_weights_oob(forest.short, train.data$default, train.data$sparse, num.threads)
+    compute_weights_oob(forest.short, train.data$train_matrix, train.data$sparse_train_matrix, num.threads)
   }
 }
 

--- a/r-package/grf/R/causal_forest.R
+++ b/r-package/grf/R/causal_forest.R
@@ -258,9 +258,9 @@ causal_forest <- function(X, Y, W,
 
   data <- create_data_matrices(X, outcome = Y.centered, treatment = W.centered, sample.weights = sample.weights)
   forest <- causal_train(
-    data$train_matrix, data$sparse_train_matrix,
-    data$outcome_index, data$treatment_index, data$sample_weight_index,
-    data$use_sample_weights,
+    data$train.matrix, data$sparse.train.matrix,
+    data$outcome.index, data$treatment.index, data$sample.weight.index,
+    data$use.sample.weights,
     as.numeric(tunable.params["mtry"]),
     num.trees,
     as.numeric(tunable.params["min.node.size"]),
@@ -407,21 +407,21 @@ predict.causal_forest <- function(object, newdata = NULL,
        validate_newdata(newdata, object$X.orig)
        data <- create_data_matrices(newdata)
        if (!local.linear) {
-           ret <- causal_predict(forest.short, train.data$train_matrix, train.data$sparse_train_matrix,
-                   train.data$outcome_index, train.data$treatment_index, data$train_matrix,
-                   data$sparse_train_matrix, num.threads, estimate.variance)
+           ret <- causal_predict(forest.short, train.data$train.matrix, train.data$sparse.train.matrix,
+                   train.data$outcome.index, train.data$treatment.index, data$train.matrix,
+                   data$sparse.train.matrix, num.threads, estimate.variance)
        } else {
-           ret <- ll_causal_predict(forest.short, data$train_matrix, train.data$train_matrix, data$sparse_train_matrix,
-                   train.data$sparse_train_matrix, train.data$outcome_index, train.data$treatment_index,
+           ret <- ll_causal_predict(forest.short, data$train.matrix, train.data$train.matrix, data$sparse.train.matrix,
+                   train.data$sparse.train.matrix, train.data$outcome.index, train.data$treatment.index,
                    ll.lambda, ll.weight.penalty, linear.correction.variables, num.threads, estimate.variance)
        }
    } else {
        if (!local.linear) {
-           ret <- causal_predict_oob(forest.short, train.data$train_matrix, train.data$sparse_train_matrix,
-                   train.data$outcome_index, train.data$treatment_index, num.threads, estimate.variance)
+           ret <- causal_predict_oob(forest.short, train.data$train.matrix, train.data$sparse.train.matrix,
+                   train.data$outcome.index, train.data$treatment.index, num.threads, estimate.variance)
        } else {
-           ret <- ll_causal_predict_oob(forest.short, train.data$train_matrix, train.data$sparse_train_matrix,
-                   train.data$outcome_index, train.data$treatment_index, ll.lambda, ll.weight.penalty,
+           ret <- ll_causal_predict_oob(forest.short, train.data$train.matrix, train.data$sparse.train.matrix,
+                   train.data$outcome.index, train.data$treatment.index, ll.lambda, ll.weight.penalty,
                    linear.correction.variables, num.threads, estimate.variance)
        }
   }

--- a/r-package/grf/R/causal_tuning.R
+++ b/r-package/grf/R/causal_tuning.R
@@ -117,9 +117,6 @@ tune_causal_forest <- function(X, Y, W, Y.hat, W.hat,
   reduced.form.weight <- 0
 
   data <- create_data_matrices(X, Y - Y.hat, W - W.hat, sample.weights = sample.weights)
-  outcome.index <- ncol(X) + 1
-  treatment.index <- ncol(X) + 2
-  sample.weight.index <- ncol(X) + 3
 
   # Separate out the tuning parameters with supplied values, and those that were
   # left as 'NULL'. We will only tune those parameters that the user didn't supply.
@@ -151,9 +148,9 @@ tune_causal_forest <- function(X, Y, W, Y.hat, W.hat,
   small.forest.errors <- apply(fit.draws, 1, function(draw) {
     params <- c(fixed.params, get_params_from_draw(X, draw))
     small.forest <- causal_train(
-      data$default, data$sparse,
-      outcome.index, treatment.index, sample.weight.index,
-      !is.null(sample.weights),
+      data$train_matrix, data$sparse_train_matrix,
+      data$outcome_index, data$treatment_index, data$sample_weight_index,
+      data$use_sample_weights,
       as.numeric(params["mtry"]),
       num.fit.trees,
       as.numeric(params["min.node.size"]),
@@ -173,8 +170,8 @@ tune_causal_forest <- function(X, Y, W, Y.hat, W.hat,
       seed
     )
     prediction <- causal_predict_oob(
-      small.forest, data$default, data$sparse,
-      outcome.index, treatment.index, num.threads, FALSE
+      small.forest, data$train_matrix, data$sparse_train_matrix,
+      data$outcome_index, data$treatment_index, num.threads, FALSE
     )
     mean(prediction$debiased.error, na.rm = TRUE)
   })
@@ -239,9 +236,9 @@ tune_causal_forest <- function(X, Y, W, Y.hat, W.hat,
   retrained.forest.params <- c(fixed.params, grid[small.forest.optimal.draw, -1])
   retrained.forest.num.trees <- num.fit.trees * 4
   retrained.forest <- causal_train(
-    data$default, data$sparse,
-    outcome.index, treatment.index, sample.weight.index,
-    !is.null(sample.weights),
+    data$train_matrix, data$sparse_train_matrix,
+    data$outcome_index, data$treatment_index, data$sample_weight_index,
+    data$use_sample_weights,
     retrained.forest.params["mtry"],
     retrained.forest.num.trees,
     retrained.forest.params["min.node.size"],
@@ -262,8 +259,8 @@ tune_causal_forest <- function(X, Y, W, Y.hat, W.hat,
   )
 
   retrained.forest.prediction <- causal_predict_oob(
-    retrained.forest, data$default, data$sparse,
-    outcome.index, treatment.index, num.threads, FALSE
+    retrained.forest, data$train_matrix, data$sparse_train_matrix,
+    data$outcome_index, data$treatment_index, num.threads, FALSE
   )
 
   retrained.forest.error <- mean(retrained.forest.prediction$debiased.error, na.rm = TRUE)
@@ -274,9 +271,9 @@ tune_causal_forest <- function(X, Y, W, Y.hat, W.hat,
   num.default.forest.trees <- num.fit.trees * 4
 
   default.forest <- causal_train(
-    data$default, data$sparse,
-    outcome.index, treatment.index, sample.weight.index,
-    !is.null(sample.weights),
+    data$train_matrix, data$sparse_train_matrix,
+    data$outcome_index, data$treatment_index, data$sample_weight_index,
+    data$use_sample_weights,
     default.params["mtry"],
     num.default.forest.trees,
     default.params["min.node.size"],
@@ -297,8 +294,8 @@ tune_causal_forest <- function(X, Y, W, Y.hat, W.hat,
   )
 
   default.forest.prediction <- causal_predict_oob(
-    default.forest, data$default, data$sparse,
-    outcome.index, treatment.index, num.threads, FALSE
+    default.forest, data$train_matrix, data$sparse_train_matrix,
+    data$outcome_index, data$treatment_index, num.threads, FALSE
   )
 
   default.forest.error <- mean(default.forest.prediction$debiased.error, na.rm = TRUE)

--- a/r-package/grf/R/causal_tuning.R
+++ b/r-package/grf/R/causal_tuning.R
@@ -148,9 +148,9 @@ tune_causal_forest <- function(X, Y, W, Y.hat, W.hat,
   small.forest.errors <- apply(fit.draws, 1, function(draw) {
     params <- c(fixed.params, get_params_from_draw(X, draw))
     small.forest <- causal_train(
-      data$train_matrix, data$sparse_train_matrix,
-      data$outcome_index, data$treatment_index, data$sample_weight_index,
-      data$use_sample_weights,
+      data$train.matrix, data$sparse.train.matrix,
+      data$outcome.index, data$treatment.index, data$sample.weight.index,
+      data$use.sample.weights,
       as.numeric(params["mtry"]),
       num.fit.trees,
       as.numeric(params["min.node.size"]),
@@ -170,8 +170,8 @@ tune_causal_forest <- function(X, Y, W, Y.hat, W.hat,
       seed
     )
     prediction <- causal_predict_oob(
-      small.forest, data$train_matrix, data$sparse_train_matrix,
-      data$outcome_index, data$treatment_index, num.threads, FALSE
+      small.forest, data$train.matrix, data$sparse.train.matrix,
+      data$outcome.index, data$treatment.index, num.threads, FALSE
     )
     mean(prediction$debiased.error, na.rm = TRUE)
   })
@@ -236,9 +236,9 @@ tune_causal_forest <- function(X, Y, W, Y.hat, W.hat,
   retrained.forest.params <- c(fixed.params, grid[small.forest.optimal.draw, -1])
   retrained.forest.num.trees <- num.fit.trees * 4
   retrained.forest <- causal_train(
-    data$train_matrix, data$sparse_train_matrix,
-    data$outcome_index, data$treatment_index, data$sample_weight_index,
-    data$use_sample_weights,
+    data$train.matrix, data$sparse.train.matrix,
+    data$outcome.index, data$treatment.index, data$sample.weight.index,
+    data$use.sample.weights,
     retrained.forest.params["mtry"],
     retrained.forest.num.trees,
     retrained.forest.params["min.node.size"],
@@ -259,8 +259,8 @@ tune_causal_forest <- function(X, Y, W, Y.hat, W.hat,
   )
 
   retrained.forest.prediction <- causal_predict_oob(
-    retrained.forest, data$train_matrix, data$sparse_train_matrix,
-    data$outcome_index, data$treatment_index, num.threads, FALSE
+    retrained.forest, data$train.matrix, data$sparse.train.matrix,
+    data$outcome.index, data$treatment.index, num.threads, FALSE
   )
 
   retrained.forest.error <- mean(retrained.forest.prediction$debiased.error, na.rm = TRUE)
@@ -271,9 +271,9 @@ tune_causal_forest <- function(X, Y, W, Y.hat, W.hat,
   num.default.forest.trees <- num.fit.trees * 4
 
   default.forest <- causal_train(
-    data$train_matrix, data$sparse_train_matrix,
-    data$outcome_index, data$treatment_index, data$sample_weight_index,
-    data$use_sample_weights,
+    data$train.matrix, data$sparse.train.matrix,
+    data$outcome.index, data$treatment.index, data$sample.weight.index,
+    data$use.sample.weights,
     default.params["mtry"],
     num.default.forest.trees,
     default.params["min.node.size"],
@@ -294,8 +294,8 @@ tune_causal_forest <- function(X, Y, W, Y.hat, W.hat,
   )
 
   default.forest.prediction <- causal_predict_oob(
-    default.forest, data$train_matrix, data$sparse_train_matrix,
-    data$outcome_index, data$treatment_index, num.threads, FALSE
+    default.forest, data$train.matrix, data$sparse.train.matrix,
+    data$outcome.index, data$treatment.index, num.threads, FALSE
   )
 
   default.forest.error <- mean(default.forest.prediction$debiased.error, na.rm = TRUE)

--- a/r-package/grf/R/custom_forest.R
+++ b/r-package/grf/R/custom_forest.R
@@ -92,12 +92,11 @@ custom_forest <- function(X, Y,
 
   no.split.variables <- numeric(0)
 
-  data <- create_data_matrices(X, Y)
-  outcome.index <- ncol(X) + 1
+  data <- create_data_matrices(X, outcome = Y)
   ci.group.size <- 1
 
   forest <- custom_train(
-    data$default, data$sparse, outcome.index, mtry, num.trees, min.node.size,
+    data$train_matrix, data$sparse_train_matrix, data$outcome_index, mtry, num.trees, min.node.size,
     sample.fraction, honesty, honesty.fraction, honesty.prune.leaves, ci.group.size, alpha,
     imbalance.penalty, clusters, samples.per.cluster, num.threads, compute.oob.predictions, seed
   )
@@ -144,7 +143,6 @@ predict.custom_forest <- function(object, newdata = NULL, num.threads = NULL, ..
 
   X <- object[["X.orig"]]
   train.data <- create_data_matrices(X, object[["Y.orig"]])
-  outcome.index <- ncol(X) + 1
 
   num.threads <- validate_num_threads(num.threads)
 
@@ -152,10 +150,10 @@ predict.custom_forest <- function(object, newdata = NULL, num.threads = NULL, ..
     validate_newdata(newdata, X)
     data <- create_data_matrices(newdata)
     custom_predict(
-      forest.short, train.data$default, train.data$sparse, outcome.index,
-      data$default, data$sparse, num.threads
+      forest.short, train.data$train_matrix, train.data$sparse_train_matrix, train.data$outcome_index,
+      data$train_matrix, data$sparse_train_matrix, num.threads
     )
   } else {
-    custom_predict_oob(forest.short, train.data$default, train.data$sparse, outcome.index, num.threads)
+    custom_predict_oob(forest.short, train.data$train_matrix, train.data$sparse_train_matrix, train.data$outcome_index, num.threads)
   }
 }

--- a/r-package/grf/R/custom_forest.R
+++ b/r-package/grf/R/custom_forest.R
@@ -96,7 +96,7 @@ custom_forest <- function(X, Y,
   ci.group.size <- 1
 
   forest <- custom_train(
-    data$train_matrix, data$sparse_train_matrix, data$outcome_index, mtry, num.trees, min.node.size,
+    data$train.matrix, data$sparse.train.matrix, data$outcome.index, mtry, num.trees, min.node.size,
     sample.fraction, honesty, honesty.fraction, honesty.prune.leaves, ci.group.size, alpha,
     imbalance.penalty, clusters, samples.per.cluster, num.threads, compute.oob.predictions, seed
   )
@@ -150,10 +150,10 @@ predict.custom_forest <- function(object, newdata = NULL, num.threads = NULL, ..
     validate_newdata(newdata, X)
     data <- create_data_matrices(newdata)
     custom_predict(
-      forest.short, train.data$train_matrix, train.data$sparse_train_matrix, train.data$outcome_index,
-      data$train_matrix, data$sparse_train_matrix, num.threads
+      forest.short, train.data$train.matrix, train.data$sparse.train.matrix, train.data$outcome.index,
+      data$train.matrix, data$sparse.train.matrix, num.threads
     )
   } else {
-    custom_predict_oob(forest.short, train.data$train_matrix, train.data$sparse_train_matrix, train.data$outcome_index, num.threads)
+    custom_predict_oob(forest.short, train.data$train.matrix, train.data$sparse.train.matrix, train.data$outcome.index, num.threads)
   }
 }

--- a/r-package/grf/R/input_utilities.R
+++ b/r-package/grf/R/input_utilities.R
@@ -227,23 +227,23 @@ create_data_matrices <- function(X, outcome = NULL, treatment = NULL,
   out <- list()
   i <- 1
   if (!is.null(outcome)) {
-    out[["outcome_index"]] <- ncol(X) + i
+    out[["outcome.index"]] <- ncol(X) + i
   }
   if (!is.null(treatment)) {
     i <- i + 1
-    out[["treatment_index"]] <- ncol(X) + i
+    out[["treatment.index"]] <- ncol(X) + i
   }
   if (!is.null(instrument)) {
     i <- i + 1
-    out[["instrument_index"]] <- ncol(X) + i
+    out[["instrument.index"]] <- ncol(X) + i
   }
   if (!isFALSE(sample.weights)) {
     i <- i + 1
-    out[["sample_weight_index"]] <- ncol(X) + i
+    out[["sample.weight.index"]] <- ncol(X) + i
     if (is.null(sample.weights)) {
-      out[["use_sample_weights"]] <- FALSE
+      out[["use.sample.weights"]] <- FALSE
     } else {
-      out[["use_sample_weights"]] <- TRUE
+      out[["use.sample.weights"]] <- TRUE
     }
   } else {
     sample.weights = NULL
@@ -255,8 +255,8 @@ create_data_matrices <- function(X, outcome = NULL, treatment = NULL,
     X <- as.matrix(X)
     default.data <- as.matrix(cbind(X, outcome, treatment, instrument, sample.weights))
   }
-  out[["train_matrix"]] <- default.data
-  out[["sparse_train_matrix"]] <- sparse.data
+  out[["train.matrix"]] <- default.data
+  out[["sparse.train.matrix"]] <- sparse.data
 
   out
 }

--- a/r-package/grf/R/instrumental_forest.R
+++ b/r-package/grf/R/instrumental_forest.R
@@ -154,16 +154,12 @@ instrumental_forest <- function(X, Y, W, Z,
     stop("Z.hat has incorrect length.")
   }
 
-  data <- create_data_matrices(X, Y - Y.hat, W - W.hat, Z - Z.hat, sample.weights = sample.weights)
-
-  outcome.index <- ncol(X) + 1
-  treatment.index <- ncol(X) + 2
-  instrument.index <- ncol(X) + 3
-  sample.weight.index <- ncol(X) + 4
-
+  data <- create_data_matrices(X, outcome = Y - Y.hat, treatment = W - W.hat,
+                               instrument = Z - Z.hat, sample.weights = sample.weights)
   forest <- instrumental_train(
-    data$default, data$sparse,
-    outcome.index, treatment.index, instrument.index, sample.weight.index, !is.null(sample.weights),
+    data$train_matrix, data$sparse_train_matrix,
+    data$outcome_index, data$treatment_index, data$instrument_index, data$sample_weight_index,
+    data$use_sample_weights,
     mtry, num.trees, min.node.size, sample.fraction, honesty, honesty.fraction,
     honesty.prune.leaves, ci.group.size, reduced.form.weight, alpha, imbalance.penalty, stabilize.splits, clusters,
     samples.per.cluster, compute.oob.predictions, num.threads, seed
@@ -224,24 +220,20 @@ predict.instrumental_forest <- function(object, newdata = NULL,
   W.centered <- object[["W.orig"]] - object[["W.hat"]]
   Z.centered <- object[["Z.orig"]] - object[["Z.hat"]]
 
-  train.data <- create_data_matrices(X, Y.centered, W.centered, Z.centered)
-
-  outcome.index <- ncol(X) + 1
-  treatment.index <- ncol(X) + 2
-  instrument.index <- ncol(X) + 3
+  train.data <- create_data_matrices(X, outcome = Y.centered, treatment = W.centered, instrument = Z.centered)
 
   if (!is.null(newdata)) {
     validate_newdata(newdata, object$X.orig)
     data <- create_data_matrices(newdata)
     ret <- instrumental_predict(
-      forest.short, train.data$default, train.data$sparse,
-      outcome.index, treatment.index, instrument.index,
-      data$default, data$sparse, num.threads, estimate.variance
+      forest.short, train.data$train_matrix, train.data$sparse_train_matrix,
+      train.data$outcome_index, train.data$treatment_index, train.data$instrument_index,
+      data$train_matrix, data$sparse_train_matrix, num.threads, estimate.variance
     )
   } else {
     ret <- instrumental_predict_oob(
-      forest.short, train.data$default, train.data$sparse,
-      outcome.index, treatment.index, instrument.index,
+      forest.short, train.data$train_matrix, train.data$sparse_train_matrix,
+      train.data$outcome_index, train.data$treatment_index, train.data$instrument_index,
       num.threads, estimate.variance
     )
   }

--- a/r-package/grf/R/instrumental_forest.R
+++ b/r-package/grf/R/instrumental_forest.R
@@ -157,9 +157,9 @@ instrumental_forest <- function(X, Y, W, Z,
   data <- create_data_matrices(X, outcome = Y - Y.hat, treatment = W - W.hat,
                                instrument = Z - Z.hat, sample.weights = sample.weights)
   forest <- instrumental_train(
-    data$train_matrix, data$sparse_train_matrix,
-    data$outcome_index, data$treatment_index, data$instrument_index, data$sample_weight_index,
-    data$use_sample_weights,
+    data$train.matrix, data$sparse.train.matrix,
+    data$outcome.index, data$treatment.index, data$instrument.index, data$sample.weight.index,
+    data$use.sample.weights,
     mtry, num.trees, min.node.size, sample.fraction, honesty, honesty.fraction,
     honesty.prune.leaves, ci.group.size, reduced.form.weight, alpha, imbalance.penalty, stabilize.splits, clusters,
     samples.per.cluster, compute.oob.predictions, num.threads, seed
@@ -226,14 +226,14 @@ predict.instrumental_forest <- function(object, newdata = NULL,
     validate_newdata(newdata, object$X.orig)
     data <- create_data_matrices(newdata)
     ret <- instrumental_predict(
-      forest.short, train.data$train_matrix, train.data$sparse_train_matrix,
-      train.data$outcome_index, train.data$treatment_index, train.data$instrument_index,
-      data$train_matrix, data$sparse_train_matrix, num.threads, estimate.variance
+      forest.short, train.data$train.matrix, train.data$sparse.train.matrix,
+      train.data$outcome.index, train.data$treatment.index, train.data$instrument.index,
+      data$train.matrix, data$sparse.train.matrix, num.threads, estimate.variance
     )
   } else {
     ret <- instrumental_predict_oob(
-      forest.short, train.data$train_matrix, train.data$sparse_train_matrix,
-      train.data$outcome_index, train.data$treatment_index, train.data$instrument_index,
+      forest.short, train.data$train.matrix, train.data$sparse.train.matrix,
+      train.data$outcome.index, train.data$treatment.index, train.data$instrument.index,
       num.threads, estimate.variance
     )
   }

--- a/r-package/grf/R/local_linear_causal_tuning.R
+++ b/r-package/grf/R/local_linear_causal_tuning.R
@@ -56,8 +56,8 @@ tune_ll_causal_forest <- function(forest,
   linear.correction.variables <- linear.correction.variables - 1
 
   # Find sequence of predictions by lambda
-  prediction.object <- ll_causal_predict_oob(forest.short, data$train_matrix, data$sparse_train_matrix,
-      data$outcome_index, data$treatment_index, lambda.path, ll.weight.penalty, linear.correction.variables, num.threads, FALSE)
+  prediction.object <- ll_causal_predict_oob(forest.short, data$train.matrix, data$sparse.train.matrix,
+      data$outcome.index, data$treatment.index, lambda.path, ll.weight.penalty, linear.correction.variables, num.threads, FALSE)
   predictions <- prediction.object$predictions
 
   errors <- apply(predictions, MARGIN = 2, FUN = function(row) {

--- a/r-package/grf/R/local_linear_causal_tuning.R
+++ b/r-package/grf/R/local_linear_causal_tuning.R
@@ -47,9 +47,6 @@ tune_ll_causal_forest <- function(forest,
 
   data <- create_data_matrices(X, Y.centered, W.centered)
 
-  outcome.index <- ncol(X) + 1
-  treatment.index <- ncol(X) + 2
-
   # Validate variables
   num.threads <- validate_num_threads(num.threads)
   linear.correction.variables <- validate_ll_vars(linear.correction.variables, ncol(X))
@@ -59,8 +56,8 @@ tune_ll_causal_forest <- function(forest,
   linear.correction.variables <- linear.correction.variables - 1
 
   # Find sequence of predictions by lambda
-  prediction.object <- ll_causal_predict_oob(forest.short, data$default, data$sparse, outcome.index,
-      treatment.index, lambda.path, ll.weight.penalty, linear.correction.variables, num.threads, FALSE)
+  prediction.object <- ll_causal_predict_oob(forest.short, data$train_matrix, data$sparse_train_matrix,
+      data$outcome_index, data$treatment_index, lambda.path, ll.weight.penalty, linear.correction.variables, num.threads, FALSE)
   predictions <- prediction.object$predictions
 
   errors <- apply(predictions, MARGIN = 2, FUN = function(row) {

--- a/r-package/grf/R/local_linear_forest.R
+++ b/r-package/grf/R/local_linear_forest.R
@@ -124,14 +124,13 @@ ll_regression_forest <- function(X, Y,
     )
   }
 
-  data <- create_data_matrices(X, Y)
-  outcome.index <- ncol(X) + 1
-  sample.weight.index <- ncol(X) + 2
+  data <- create_data_matrices(X, Y, sample.weights = NULL)
   compute.oob.predictions <- FALSE
 
   forest <- regression_train(
-    data$default, data$sparse, outcome.index, sample.weight.index,
-    FALSE,
+    data$train_matrix, data$sparse_train_matrix,
+    data$outcome_index, data$sample_weight_index,
+    data$use_sample_weights,
     as.numeric(tunable.params["mtry"]),
     num.trees,
     as.numeric(tunable.params["min.node.size"]),
@@ -234,20 +233,19 @@ predict.ll_regression_forest <- function(object, newdata = NULL,
   # Subtract 1 to account for C++ indexing
   linear.correction.variables <- linear.correction.variables - 1
 
-  train.data <- create_data_matrices(X, object[["Y.orig"]])
-  outcome.index <- ncol(X) + 1
+  train.data <- create_data_matrices(X, outcome = object[["Y.orig"]])
 
   if (!is.null(newdata)) {
     validate_newdata(newdata, X)
     data <- create_data_matrices(newdata)
     ret <- ll_regression_predict(
-      forest.short, train.data$default, train.data$sparse, outcome.index,
-      data$default, data$sparse,
+      forest.short, train.data$train_matrix, train.data$sparse_train_matrix, train.data$outcome_index,
+      data$train_matrix, data$sparse_train_matrix,
       ll.lambda, ll.weight.penalty, linear.correction.variables, num.threads, estimate.variance
     )
   } else {
     ret <- ll_regression_predict_oob(
-      forest.short, train.data$default, train.data$sparse, outcome.index,
+      forest.short, train.data$train_matrix, train.data$sparse_train_matrix, train.data$outcome_index,
       ll.lambda, ll.weight.penalty, linear.correction.variables, num.threads, estimate.variance
     )
   }

--- a/r-package/grf/R/local_linear_forest.R
+++ b/r-package/grf/R/local_linear_forest.R
@@ -128,9 +128,9 @@ ll_regression_forest <- function(X, Y,
   compute.oob.predictions <- FALSE
 
   forest <- regression_train(
-    data$train_matrix, data$sparse_train_matrix,
-    data$outcome_index, data$sample_weight_index,
-    data$use_sample_weights,
+    data$train.matrix, data$sparse.train.matrix,
+    data$outcome.index, data$sample.weight.index,
+    data$use.sample.weights,
     as.numeric(tunable.params["mtry"]),
     num.trees,
     as.numeric(tunable.params["min.node.size"]),
@@ -239,13 +239,13 @@ predict.ll_regression_forest <- function(object, newdata = NULL,
     validate_newdata(newdata, X)
     data <- create_data_matrices(newdata)
     ret <- ll_regression_predict(
-      forest.short, train.data$train_matrix, train.data$sparse_train_matrix, train.data$outcome_index,
-      data$train_matrix, data$sparse_train_matrix,
+      forest.short, train.data$train.matrix, train.data$sparse.train.matrix, train.data$outcome.index,
+      data$train.matrix, data$sparse.train.matrix,
       ll.lambda, ll.weight.penalty, linear.correction.variables, num.threads, estimate.variance
     )
   } else {
     ret <- ll_regression_predict_oob(
-      forest.short, train.data$train_matrix, train.data$sparse_train_matrix, train.data$outcome_index,
+      forest.short, train.data$train.matrix, train.data$sparse.train.matrix, train.data$outcome.index,
       ll.lambda, ll.weight.penalty, linear.correction.variables, num.threads, estimate.variance
     )
   }

--- a/r-package/grf/R/local_linear_tuning.R
+++ b/r-package/grf/R/local_linear_tuning.R
@@ -49,7 +49,7 @@ tune_ll_regression_forest <- function(forest,
   # Enforce no variance estimates in tuning
   estimate.variance <- FALSE
   prediction.object <- ll_regression_predict_oob(
-    forest.short, data$train_matrix, data$sparse_train_matrix, data$outcome_index,
+    forest.short, data$train.matrix, data$sparse.train.matrix, data$outcome.index,
     lambda.path, ll.weight.penalty, linear.correction.variables, num.threads, estimate.variance
   )
 

--- a/r-package/grf/R/local_linear_tuning.R
+++ b/r-package/grf/R/local_linear_tuning.R
@@ -36,8 +36,7 @@ tune_ll_regression_forest <- function(forest,
 
   X <- forest[["X.orig"]]
   Y <- forest[["Y.orig"]]
-  data <- create_data_matrices(X, Y)
-  outcome.index <- ncol(X) + 1
+  data <- create_data_matrices(X, outcome = Y)
 
   # Validate variables
   num.threads <- validate_num_threads(num.threads)
@@ -50,7 +49,7 @@ tune_ll_regression_forest <- function(forest,
   # Enforce no variance estimates in tuning
   estimate.variance <- FALSE
   prediction.object <- ll_regression_predict_oob(
-    forest.short, data$default, data$sparse, outcome.index,
+    forest.short, data$train_matrix, data$sparse_train_matrix, data$outcome_index,
     lambda.path, ll.weight.penalty, linear.correction.variables, num.threads, estimate.variance
   )
 

--- a/r-package/grf/R/quantile_forest.R
+++ b/r-package/grf/R/quantile_forest.R
@@ -118,7 +118,7 @@ quantile_forest <- function(X, Y,
   ci.group.size <- 1
 
   forest <- quantile_train(
-    quantiles, regression.splitting, data$train_matrix, data$sparse_train_matrix, data$outcome_index, mtry,
+    quantiles, regression.splitting, data$train.matrix, data$sparse.train.matrix, data$outcome.index, mtry,
     num.trees, min.node.size, sample.fraction, honesty, honesty.fraction, honesty.prune.leaves,
     ci.group.size, alpha, imbalance.penalty, clusters, samples.per.cluster, num.threads, seed
   )
@@ -188,13 +188,13 @@ predict.quantile_forest <- function(object,
     validate_newdata(newdata, object$X.orig)
     data <- create_data_matrices(newdata)
     quantile_predict(
-      forest.short, quantiles, train.data$train_matrix, train.data$sparse_train_matrix,
-      train.data$outcome_index, data$train_matrix, data$sparse_train_matrix, num.threads
+      forest.short, quantiles, train.data$train.matrix, train.data$sparse.train.matrix,
+      train.data$outcome.index, data$train.matrix, data$sparse.train.matrix, num.threads
     )
   } else {
     quantile_predict_oob(
-      forest.short, quantiles, train.data$train_matrix, train.data$sparse_train_matrix,
-      train.data$outcome_index, num.threads
+      forest.short, quantiles, train.data$train.matrix, train.data$sparse.train.matrix,
+      train.data$outcome.index, num.threads
     )
   }
 }

--- a/r-package/grf/R/quantile_forest.R
+++ b/r-package/grf/R/quantile_forest.R
@@ -114,13 +114,11 @@ quantile_forest <- function(X, Y,
   honesty.fraction <- validate_honesty_fraction(honesty.fraction, honesty)
   honesty.prune.leaves <- validate_honesty_prune_leaves(honesty.prune.leaves)
 
-  data <- create_data_matrices(X, Y)
-  outcome.index <- ncol(X) + 1
-
+  data <- create_data_matrices(X, outcome = Y)
   ci.group.size <- 1
 
   forest <- quantile_train(
-    quantiles, regression.splitting, data$default, data$sparse, outcome.index, mtry,
+    quantiles, regression.splitting, data$train_matrix, data$sparse_train_matrix, data$outcome_index, mtry,
     num.trees, min.node.size, sample.fraction, honesty, honesty.fraction, honesty.prune.leaves,
     ci.group.size, alpha, imbalance.penalty, clusters, samples.per.cluster, num.threads, seed
   )
@@ -184,20 +182,19 @@ predict.quantile_forest <- function(object,
   forest.short <- object[-which(names(object) == "X.orig")]
 
   X <- object[["X.orig"]]
-  train.data <- create_data_matrices(X, object[["Y.orig"]])
-  outcome.index <- ncol(X) + 1
+  train.data <- create_data_matrices(X, outcome = object[["Y.orig"]])
 
   if (!is.null(newdata)) {
     validate_newdata(newdata, object$X.orig)
     data <- create_data_matrices(newdata)
     quantile_predict(
-      forest.short, quantiles, train.data$default, train.data$sparse, outcome.index,
-      data$default, data$sparse, num.threads
+      forest.short, quantiles, train.data$train_matrix, train.data$sparse_train_matrix,
+      train.data$outcome_index, data$train_matrix, data$sparse_train_matrix, num.threads
     )
   } else {
     quantile_predict_oob(
-      forest.short, quantiles, train.data$default, train.data$sparse,
-      outcome.index, num.threads
+      forest.short, quantiles, train.data$train_matrix, train.data$sparse_train_matrix,
+      train.data$outcome_index, num.threads
     )
   }
 }

--- a/r-package/grf/R/regression_forest.R
+++ b/r-package/grf/R/regression_forest.R
@@ -146,12 +146,11 @@ regression_forest <- function(X, Y,
     )
   }
 
-  data <- create_data_matrices(X, Y, sample.weights = sample.weights)
-  outcome.index <- ncol(X) + 1
-  sample.weight.index <- ncol(X) + 2
+  data <- create_data_matrices(X, outcome = Y, sample.weights = sample.weights)
   forest <- regression_train(
-    data$default, data$sparse, outcome.index, sample.weight.index,
-    !is.null(sample.weights),
+    data$train_matrix, data$sparse_train_matrix,
+    data$outcome_index, data$sample_weight_index,
+    data$use_sample_weights,
     as.numeric(tunable.params["mtry"]),
     num.trees,
     as.numeric(tunable.params["min.node.size"]),
@@ -263,8 +262,7 @@ predict.regression_forest <- function(object, newdata = NULL,
 
   forest.short <- object[-which(names(object) == "X.orig")]
   X <- object[["X.orig"]]
-  train.data <- create_data_matrices(X, object[["Y.orig"]])
-  outcome.index <- ncol(X) + 1
+  train.data <- create_data_matrices(X, outcome = object[["Y.orig"]])
 
   if (local.linear) {
     linear.correction.variables <- validate_ll_vars(linear.correction.variables, ncol(X))
@@ -288,13 +286,13 @@ predict.regression_forest <- function(object, newdata = NULL,
     validate_newdata(newdata, X)
     if (!local.linear) {
       ret <- regression_predict(
-        forest.short, train.data$default, train.data$sparse, outcome.index,
-        data$default, data$sparse, num.threads, estimate.variance
+        forest.short, train.data$train_matrix, train.data$sparse_train_matrix, train.data$outcome_index,
+        data$train_matrix, data$sparse_train_matrix, num.threads, estimate.variance
       )
     } else {
       ret <- ll_regression_predict(
-        forest.short, train.data$default, train.data$sparse, outcome.index,
-        data$default, data$sparse, ll.lambda, ll.weight.penalty, linear.correction.variables,
+        forest.short, train.data$train_matrix, train.data$sparse_train_matrix, train.data$outcome_index,
+        data$train_matrix, data$sparse_train_matrix, ll.lambda, ll.weight.penalty, linear.correction.variables,
         num.threads, estimate.variance
       )
     }
@@ -302,12 +300,12 @@ predict.regression_forest <- function(object, newdata = NULL,
     data <- create_data_matrices(X)
     if (!local.linear) {
       ret <- regression_predict_oob(
-        forest.short, train.data$default, train.data$sparse, outcome.index,
+        forest.short, train.data$train_matrix, train.data$sparse_train_matrix, train.data$outcome_index,
         num.threads, estimate.variance
       )
     } else {
       ret <- ll_regression_predict_oob(
-        forest.short, train.data$default, train.data$sparse, outcome.index,
+        forest.short, train.data$train_matrix, train.data$sparse_train_matrix, train.data$outcome_index,
         ll.lambda, ll.weight.penalty, linear.correction.variables, num.threads, estimate.variance
       )
     }

--- a/r-package/grf/R/regression_forest.R
+++ b/r-package/grf/R/regression_forest.R
@@ -148,9 +148,9 @@ regression_forest <- function(X, Y,
 
   data <- create_data_matrices(X, outcome = Y, sample.weights = sample.weights)
   forest <- regression_train(
-    data$train_matrix, data$sparse_train_matrix,
-    data$outcome_index, data$sample_weight_index,
-    data$use_sample_weights,
+    data$train.matrix, data$sparse.train.matrix,
+    data$outcome.index, data$sample.weight.index,
+    data$use.sample.weights,
     as.numeric(tunable.params["mtry"]),
     num.trees,
     as.numeric(tunable.params["min.node.size"]),
@@ -286,13 +286,13 @@ predict.regression_forest <- function(object, newdata = NULL,
     validate_newdata(newdata, X)
     if (!local.linear) {
       ret <- regression_predict(
-        forest.short, train.data$train_matrix, train.data$sparse_train_matrix, train.data$outcome_index,
-        data$train_matrix, data$sparse_train_matrix, num.threads, estimate.variance
+        forest.short, train.data$train.matrix, train.data$sparse.train.matrix, train.data$outcome.index,
+        data$train.matrix, data$sparse.train.matrix, num.threads, estimate.variance
       )
     } else {
       ret <- ll_regression_predict(
-        forest.short, train.data$train_matrix, train.data$sparse_train_matrix, train.data$outcome_index,
-        data$train_matrix, data$sparse_train_matrix, ll.lambda, ll.weight.penalty, linear.correction.variables,
+        forest.short, train.data$train.matrix, train.data$sparse.train.matrix, train.data$outcome.index,
+        data$train.matrix, data$sparse.train.matrix, ll.lambda, ll.weight.penalty, linear.correction.variables,
         num.threads, estimate.variance
       )
     }
@@ -300,12 +300,12 @@ predict.regression_forest <- function(object, newdata = NULL,
     data <- create_data_matrices(X)
     if (!local.linear) {
       ret <- regression_predict_oob(
-        forest.short, train.data$train_matrix, train.data$sparse_train_matrix, train.data$outcome_index,
+        forest.short, train.data$train.matrix, train.data$sparse.train.matrix, train.data$outcome.index,
         num.threads, estimate.variance
       )
     } else {
       ret <- ll_regression_predict_oob(
-        forest.short, train.data$train_matrix, train.data$sparse_train_matrix, train.data$outcome_index,
+        forest.short, train.data$train.matrix, train.data$sparse.train.matrix, train.data$outcome.index,
         ll.lambda, ll.weight.penalty, linear.correction.variables, num.threads, estimate.variance
       )
     }

--- a/r-package/grf/R/regression_tuning.R
+++ b/r-package/grf/R/regression_tuning.R
@@ -134,9 +134,9 @@ tune_regression_forest <- function(X, Y,
   small.forest.errors <- apply(fit.draws, 1, function(draw) {
     params <- c(fixed.params, get_params_from_draw(X, draw))
     small.forest <- regression_train(
-      data$train_matrix, data$sparse_train_matrix,
-      data$outcome_index, data$sample_weight_index,
-      data$use_sample_weights,
+      data$train.matrix, data$sparse.train.matrix,
+      data$outcome.index, data$sample.weight.index,
+      data$use.sample.weights,
       as.numeric(params["mtry"]),
       num.fit.trees,
       as.numeric(params["min.node.size"]),
@@ -155,8 +155,8 @@ tune_regression_forest <- function(X, Y,
     )
 
     prediction <- regression_predict_oob(
-      small.forest, data$train_matrix, data$sparse_train_matrix,
-      data$outcome_index, num.threads, FALSE
+      small.forest, data$train.matrix, data$sparse.train.matrix,
+      data$outcome.index, num.threads, FALSE
     )
     error <- prediction$debiased.error
     mean(error, na.rm = TRUE)
@@ -222,9 +222,9 @@ tune_regression_forest <- function(X, Y,
   retrained.forest.params <- c(fixed.params, grid[small.forest.optimal.draw, -1])
   retrained.forest.num.trees <- num.fit.trees * 4
   retrained.forest <- regression_train(
-    data$train_matrix, data$sparse_train_matrix,
-    data$outcome_index, data$sample_weight_index,
-    data$use_sample_weights,
+    data$train.matrix, data$sparse.train.matrix,
+    data$outcome.index, data$sample.weight.index,
+    data$use.sample.weights,
     as.numeric(retrained.forest.params["mtry"]),
     num.fit.trees,
     as.numeric(retrained.forest.params["min.node.size"]),
@@ -243,8 +243,8 @@ tune_regression_forest <- function(X, Y,
   )
 
   retrained.forest.prediction <- regression_predict_oob(
-    retrained.forest, data$train_matrix, data$sparse_train_matrix,
-    data$outcome_index, num.threads, FALSE
+    retrained.forest, data$train.matrix, data$sparse.train.matrix,
+    data$outcome.index, num.threads, FALSE
   )
 
   retrained.forest.error <- mean(retrained.forest.prediction$debiased.error, na.rm = TRUE)
@@ -254,9 +254,9 @@ tune_regression_forest <- function(X, Y,
   num.default.forest.trees <- num.fit.trees * 4
 
   default.forest <- regression_train(
-    data$train_matrix, data$sparse_train_matrix,
-    data$outcome_index, data$sample_weight_index,
-    data$use_sample_weights,
+    data$train.matrix, data$sparse.train.matrix,
+    data$outcome.index, data$sample.weight.index,
+    data$use.sample.weights,
     as.numeric(default.params["mtry"]),
     num.fit.trees,
     as.numeric(default.params["min.node.size"]),
@@ -275,8 +275,8 @@ tune_regression_forest <- function(X, Y,
   )
 
   default.forest.prediction <- regression_predict_oob(
-      default.forest, data$train_matrix, data$sparse_train_matrix,
-      data$outcome_index, num.threads, FALSE
+      default.forest, data$train.matrix, data$sparse.train.matrix,
+      data$outcome.index, num.threads, FALSE
   )
 
   default.forest.error <- mean(default.forest.prediction$debiased.error, na.rm = TRUE)


### PR DESCRIPTION
Suggestion:

Instead of calling and setting the offsets afterwards

```R
data <- create_data_matrices(X, Y.centered, W.centered, sample.weights = sample.weights)
outcome.index <- ncol(X) + 1
treatment.index <- ncol(X) + 2
sample.weight.index <- ncol(X) + 3
```

do

```R
data <- create_data_matrices(X, outcome = Y.centered, treatment = W.centered, sample.weights = sample.weights)
# then pass on: data$outcome_index, data$treatment_index, data$sample_weight_index,data$use_sample_weights
```

All the entry names in the create_data_matrices output are exactly the same as the signature name of the bindings: train_matrix, outcome_index, etc: allowing one further down the line to make use of this simplifying idiom:

```R
data.arguments = create_data_matrices(X, outcome = Y)
arguments = c(data.arguments, "pair list of all the other arguments")
do.call(regression_train, arguments)
```

Edit: all the variable names could stay dotted for consistency with the rest of the R side, and in do.call one would first to `gsub("\\.", "_", names(arguments))`
