### PR TITLE
Include <stdexcept> (gcc 10 compliance)

### DIFF
--- a/core/src/commons/Data.cpp
+++ b/core/src/commons/Data.cpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <fstream>
 #include <iterator>
+#include <stdexcept>
 #include <sstream>
 
 #include "Data.h"

--- a/core/src/commons/utility.cpp
+++ b/core/src/commons/utility.cpp
@@ -16,6 +16,7 @@
  #-------------------------------------------------------------------------------*/
 
 #include <iostream>
+#include <stdexcept>
 #include <sstream>
 
 #include "utility.h"

--- a/core/src/forest/Forest.cpp
+++ b/core/src/forest/Forest.cpp
@@ -15,6 +15,8 @@
   along with grf. If not, see <http://www.gnu.org/licenses/>.
  #-------------------------------------------------------------------------------*/
 
+#include <stdexcept>
+
 #include "commons/DefaultData.h"
 #include "forest/Forest.h"
 

--- a/core/src/forest/ForestOptions.cpp
+++ b/core/src/forest/ForestOptions.cpp
@@ -16,6 +16,7 @@
  #-------------------------------------------------------------------------------*/
 #include <thread>
 #include <random>
+#include <stdexcept>
 #include "forest/ForestOptions.h"
 #include "tree/TreeOptions.h"
 

--- a/core/src/forest/ForestOptions.cpp
+++ b/core/src/forest/ForestOptions.cpp
@@ -14,9 +14,11 @@
   You should have received a copy of the GNU General Public License
   along with grf. If not, see <http://www.gnu.org/licenses/>.
  #-------------------------------------------------------------------------------*/
+ 
 #include <thread>
 #include <random>
 #include <stdexcept>
+
 #include "forest/ForestOptions.h"
 #include "tree/TreeOptions.h"
 

--- a/core/src/forest/ForestPredictor.cpp
+++ b/core/src/forest/ForestPredictor.cpp
@@ -15,6 +15,8 @@
   along with grf. If not, see <http://www.gnu.org/licenses/>.
  #-------------------------------------------------------------------------------*/
 
+#include <stdexcept>
+
 #include "forest/ForestPredictor.h"
 #include "prediction/collector/OptimizedPredictionCollector.h"
 #include "prediction/collector/DefaultPredictionCollector.h"

--- a/core/src/prediction/collector/DefaultPredictionCollector.cpp
+++ b/core/src/prediction/collector/DefaultPredictionCollector.cpp
@@ -15,6 +15,8 @@
   along with grf. If not, see <http://www.gnu.org/licenses/>.
  #-------------------------------------------------------------------------------*/
 
+#include <stdexcept>
+
 #include "prediction/collector/DefaultPredictionCollector.h"
 
 namespace grf {

--- a/core/src/prediction/collector/OptimizedPredictionCollector.cpp
+++ b/core/src/prediction/collector/OptimizedPredictionCollector.cpp
@@ -15,6 +15,8 @@
   along with grf. If not, see <http://www.gnu.org/licenses/>.
  #-------------------------------------------------------------------------------*/
 
+#include <stdexcept>
+
 #include "prediction/collector/OptimizedPredictionCollector.h"
 
 namespace grf {

--- a/core/test/forest/ForestSmokeTest.cpp
+++ b/core/test/forest/ForestSmokeTest.cpp
@@ -15,6 +15,8 @@
   along with grf. If not, see <http://www.gnu.org/licenses/>.
  #-------------------------------------------------------------------------------*/
 
+#include <stdexcept>
+
 #include "commons/utility.h"
 #include "forest/ForestPredictor.h"
 #include "forest/ForestPredictors.h"


### PR DESCRIPTION
Addressing the upcoming gcc 10 which currently [fails](https://www.stats.ox.ac.uk/pub/bdr/gcc10/grf.log)

```
src/forest/ForestOptions.cpp:50:16: error: 'runtime_error' is not a member of 'std'
   50 |     throw std::runtime_error("When confidence intervals are enabled, the"
      |                ^~~~~~~~~~~~~
src/forest/ForestOptions.cpp: In static member function 'static grf::uint grf::ForestOptions::validate_num_threads(grf::uint)':
src/forest/ForestOptions.cpp:96:16: error: 'runtime_error' is not a member of 'std'
```

Solution: include `<stdexcept>` https://en.cppreference.com/w/cpp/error/runtime_error

