### PR TITLE
[On hold] RegressionSplitting: add node purity check

### DIFF
--- a/core/src/splitting/RegressionSplittingRule.cpp
+++ b/core/src/splitting/RegressionSplittingRule.cpp
@@ -50,16 +50,30 @@ bool RegressionSplittingRule::find_best_split(const Data& data,
   size_t size_node = samples[node].size();
   size_t min_child_size = std::max<size_t>(std::ceil(size_node * alpha), 1uL);
 
-  // Precompute the sum of outcomes in this node.
-  double sum_node = 0.0;
-  for (auto& sample : samples[node]) {
-    sum_node += responses_by_sample[sample];
-  }
-
   // Initialize the variables to track the best split variable.
   size_t best_var = 0;
   double best_value = 0;
   double best_decrease = 0.0;
+
+  // Precompute the sum of outcomes in this node and
+  // check if node is pure and set split value to estimate and stop if pure
+  double sum_node = 0.0;
+  bool pure = true;
+  double pure_value = responses_by_sample[samples[node][0]];
+  for (auto& sample : samples[node]) {
+    double value = responses_by_sample[sample];
+    sum_node += value;
+    if(value != pure_value) {
+      pure = false;
+    }
+    pure_value = value;
+  }
+
+  if (pure) {
+    split_vars[node] = best_var;
+    split_values[node] = pure_value;
+    return true;
+  }
 
   // For all possible split variables
   for (auto& var : possible_split_vars) {


### PR DESCRIPTION
Status: On hold

ranger has a node purity [check](https://github.com/imbs-hl/ranger/blob/3c25198f4c48c9b6028acd82383ea47b0ea5f945/src/TreeRegression.cpp#L70) before proceeding with splitting: if all the outcomes in the node are the same, stop.

Without this check ranger and grf behaves the same in the example in #539. [this](https://github.com/grf-labs/grf/blob/master/core/src/splitting/RegressionSplittingRule.cpp#L208) stopping condition is hit because Y0=0 => decrease=0.

* add an equivalent check to grf's `RegressionSplittingRule`.

Fixes #539:

```R
> set.seed(1)
> n <- 1000
> X <- matrix(runif(n), n, 1)
> Y0 <- rep(0, n)  # Always 0
> Y1 <- rep(1, n)  # Always 1

> rf1 <- grf::regression_forest(X, Y0)
> print(get_tree(rf1, 1))
GRF tree object 
Number of training samples: 500 
Variable splits: 
(1) * num_samples: 250  avg_Y: 0 

> rf2 <- grf::regression_forest(X, Y1)
> print(get_tree(rf2, 1))
GRF tree object 
Number of training samples: 500 
Variable splits: 
(1) * num_samples: 250  avg_Y: 1 
````

For treatment propensity prediction this purity check can have a small performance impact

```R
n <- 2000
p <- 20
X <- matrix(rnorm(n * p), n, p)
TAU <- 1 / (1 + exp(-X[, 3]))
W <- rbinom(n, 1, 1 / (1 + exp(-X[, 1] - X[, 2])))

system.time(rf <- regression_forest(X, W, seed = 1)) # regression-impurity-check
# user  system elapsed 
# 27.774   0.070   4.861 
 
system.time(rfm <- regression_forest(X, W, seed=1)) # master
# user  system elapsed 
# 37.085   0.076   5.913 
```

Edit: The purity check was removed in #362 (can close this PR?)