### PR TITLE
Bump minimum R version to 3.5.0 (#552)

### DIFF
--- a/r-package/grf/DESCRIPTION
+++ b/r-package/grf/DESCRIPTION
@@ -18,7 +18,7 @@ Description: A pluggable package for forest-based statistical estimation and inf
     quantile regression, and treatment effect estimation (optionally using instrumental
     variables).
 Depends:
-    R (>= 3.3.0)
+    R (>= 3.5.0)
 License: GPL-3
 LinkingTo: Rcpp, RcppEigen
 Imports:


### PR DESCRIPTION
closes #549 

Bump minimum R version requirement from 3.3.0 (first grf release) to 3.5.0 