### PR TITLE
Add zero-check in large Q splitting rule

### DIFF
--- a/core/src/splitting/InstrumentalSplittingRule.cpp
+++ b/core/src/splitting/InstrumentalSplittingRule.cpp
@@ -274,6 +274,11 @@ void InstrumentalSplittingRule::find_best_split_value_large_q(const Data& data,
 
   // Compute decrease of impurity for each possible split.
   for (size_t i = 0; i < num_unique - 1; ++i) {
+    // Continue if nothing here
+    if (counter[i] == 0) {
+      continue;
+    }
+
     n_left += counter[i];
     num_left_small_z += num_small_z[i];
     sum_left += sums[i];

--- a/core/src/splitting/ProbabilitySplittingRule.cpp
+++ b/core/src/splitting/ProbabilitySplittingRule.cpp
@@ -212,7 +212,7 @@ void ProbabilitySplittingRule::find_best_split_value_large_q(const Data& data,
 
   // Compute decrease of impurity for each split
   for (size_t i = 0; i < num_unique - 1; ++i) {
-    // Skip this split if the left child is empty.
+    // Continue if nothing here
     if (counter[i] == 0) {
       continue;
     }

--- a/core/src/splitting/RegressionSplittingRule.cpp
+++ b/core/src/splitting/RegressionSplittingRule.cpp
@@ -190,6 +190,11 @@ void RegressionSplittingRule::find_best_split_value_large_q(const Data& data,
 
   // Compute decrease of impurity for each split
   for (size_t i = 0; i < num_unique - 1; ++i) {
+    // Continue if nothing here
+    if (counter[i] == 0) {
+      continue;
+    }
+    
     n_left += counter[i];
     sum_left += sums[i];
 


### PR DESCRIPTION
Skip impurity calculation in large Q (pre-sorted data) for empty counts, as done in ranger.

This was already in place for [ProbabilitySplittingRule](https://github.com/grf-labs/grf/blob/master/core/src/splitting/ProbabilitySplittingRule.cpp#L216)

Closes #555 