### PR TITLE
Instrument forest Warning Correction

### DIFF
--- a/r-package/grf/DESCRIPTION
+++ b/r-package/grf/DESCRIPTION
@@ -18,7 +18,7 @@ Description: A pluggable package for forest-based statistical estimation and inf
     quantile regression, and treatment effect estimation (optionally using instrumental
     variables).
 Depends:
-    R (>= 3.3.0)
+    R (>= 3.5.0)
 License: GPL-3
 LinkingTo: Rcpp, RcppEigen
 Imports:

--- a/r-package/grf/R/average_late.R
+++ b/r-package/grf/R/average_late.R
@@ -62,6 +62,13 @@ average_late <- function(forest,
           "only implemented for binary instruments."
       ))
   }
+  
+  if (!all(forest$subset.W.orig %in% c(0, 1))) {
+    stop(paste(
+      "Average conditional local average treatment effect estimation",
+      "only implemented for binary treatments"
+    ))
+  }
 
   if (is.null(subset)) {
     subset <- 1:length(forest$Y.hat)
@@ -132,7 +139,7 @@ average_late <- function(forest,
     ))
   }
   
-  if (abs(min(subset.compliance.score)) <= 0.01 * sd(subset.W.orig)) {
+  if (abs(min(subset.compliance.score) <= 0.01 * sd(subset.W.orig)) {
       warning(paste0(
           "The instrument appears to be weak, with some compliance scores as ",
           "low as ", round(min(subset.compliance.score), 4)

--- a/r-package/grf/R/average_late.R
+++ b/r-package/grf/R/average_late.R
@@ -139,7 +139,7 @@ average_late <- function(forest,
     ))
   }
   
-  if (abs(min(subset.compliance.score) <= 0.01 * sd(subset.W.orig)) {
+  if (abs(min(subset.compliance.score)) <= 0.01 * sd(subset.W.orig)) {
       warning(paste0(
           "The instrument appears to be weak, with some compliance scores as ",
           "low as ", round(min(subset.compliance.score), 4)

--- a/r-package/grf/R/average_late.R
+++ b/r-package/grf/R/average_late.R
@@ -111,9 +111,9 @@ average_late <- function(forest,
   subset.weights <- observation.weight[subset]
 
   if (min(subset.Z.hat) <= 0.01 || max(subset.Z.hat) >= 0.99) {
-    rng <- range(subset.W.hat)
+    rng <- range(subset.Z.hat)
     warning(paste0(
-      "Estimated treatment propensities take values between ",
+      "Estimated instrument propensities take values between ",
       round(rng[1], 3), " and ", round(rng[2], 3),
       " and in particular get very close to 0 or 1. ",
       "Poor overlap may hurt perfmance for average conditional local average ",

--- a/r-package/grf/R/average_late.R
+++ b/r-package/grf/R/average_late.R
@@ -63,13 +63,6 @@ average_late <- function(forest,
       ))
   }
   
-  if (!all(forest$subset.W.orig %in% c(0, 1))) {
-    stop(paste(
-      "Average conditional local average treatment effect estimation",
-      "only implemented for binary treatments"
-    ))
-  }
-
   if (is.null(subset)) {
     subset <- 1:length(forest$Y.hat)
   }
@@ -121,17 +114,6 @@ average_late <- function(forest,
     rng <- range(subset.Z.hat)
     warning(paste0(
       "Estimated instrument propensities take values between ",
-      round(rng[1], 3), " and ", round(rng[2], 3),
-      " and in particular get very close to 0 or 1. ",
-      "Poor overlap may hurt perfmance for average conditional local average ",
-      "treatment effect estimation."
-    ))
-  }
-
-  if (all(forest$subset.W.hat %in% c(0, 1)) && min(subset.W.hat) <= 0.01 || max(subset.W.hat) >= 0.99) {
-    rng <- range(subset.W.hat)
-    warning(paste0(
-      "Estimated treatment propensities take values between ",
       round(rng[1], 3), " and ", round(rng[2], 3),
       " and in particular get very close to 0 or 1. ",
       "Poor overlap may hurt perfmance for average conditional local average ",

--- a/r-package/grf/R/average_late.R
+++ b/r-package/grf/R/average_late.R
@@ -121,6 +121,17 @@ average_late <- function(forest,
     ))
   }
 
+  if (all(forest$subset.W.hat %in% c(0, 1)) && min(subset.W.hat) <= 0.01 || max(subset.W.hat) >= 0.99) {
+    rng <- range(subset.W.hat)
+    warning(paste0(
+      "Estimated treatment propensities take values between ",
+      round(rng[1], 3), " and ", round(rng[2], 3),
+      " and in particular get very close to 0 or 1. ",
+      "Poor overlap may hurt perfmance for average conditional local average ",
+      "treatment effect estimation."
+    ))
+  }
+  
   if (min(subset.compliance.score) <= 0.01 * sd(subset.W.orig)) {
       warning(paste0(
           "The instrument appears to be weak, with some compliance scores as ",

--- a/r-package/grf/R/average_late.R
+++ b/r-package/grf/R/average_late.R
@@ -132,7 +132,7 @@ average_late <- function(forest,
     ))
   }
   
-  if (min(subset.compliance.score) <= 0.01 * sd(subset.W.orig)) {
+  if (abs(min(subset.compliance.score)) <= 0.01 * sd(subset.W.orig)) {
       warning(paste0(
           "The instrument appears to be weak, with some compliance scores as ",
           "low as ", round(min(subset.compliance.score), 4)


### PR DESCRIPTION
I think originally the warnings given in average_late is incorrect. 

The `if` condition was to compare `z.hat`:

`if (min(subset.Z.hat) <= 0.01 || max(subset.Z.hat) >= 0.99)`

While the warning messages gives the range of W.hat:

`rng <- range(subset.W.hat)`

And the warning on treatment propensities: 

`Estimated treatment propensities take values between
`

However, z.hat is the instrument propensity, not the treatment propensity. I don't understand why we would compare the instrument propensity and gives warnings on treatment propensity. 

Shouldn't we change the if statement to compare `w.hat`, if we gives warnings on `w.hat`? 

I am not sure if this warning message is trying to warn `Z.hat` or `W.hat`.  So I added warning messages for both. 

Note that, I think the warnings on W.hat only makes sense if the variable is binary. So I have also added a condition to check that. 

Referring to #490 and #553