### PR TITLE
REFERENCE: update tuning section 

### DIFF
--- a/r-package/grf/R/causal_forest.R
+++ b/r-package/grf/R/causal_forest.R
@@ -115,10 +115,10 @@
 #' W <- rbinom(n, 1, 1 / (1 + exp(-X[, 1] - X[, 2])))
 #' Y <- pmax(X[, 2] + X[, 3], 0) + rowMeans(X[, 4:6]) / 2 + W * TAU + rnorm(n)
 #'
-#' forest.W <- regression_forest(X, W, tune.parameters = TRUE)
+#' forest.W <- regression_forest(X, W, tune.parameters = "all")
 #' W.hat <- predict(forest.W)$predictions
 #'
-#' forest.Y <- regression_forest(X, Y, tune.parameters = TRUE)
+#' forest.Y <- regression_forest(X, Y, tune.parameters = "all")
 #' Y.hat <- predict(forest.Y)$predictions
 #'
 #' forest.Y.varimp <- variable_importance(forest.Y)
@@ -130,7 +130,7 @@
 #'
 #' tau.forest <- causal_forest(X[, selected.vars], Y, W,
 #'   W.hat = W.hat, Y.hat = Y.hat,
-#'   tune.parameters = TRUE
+#'   tune.parameters = "all"
 #' )
 #' tau.hat <- predict(tau.forest)$predictions
 #' }

--- a/r-package/grf/R/tune_regression_forest.R
+++ b/r-package/grf/R/tune_regression_forest.R
@@ -1,4 +1,4 @@
-FALSE#' Regression forest tuning
+#' Regression forest tuning
 #'
 #' Trains a regression forest that can be used to estimate
 #' the conditional mean function mu(x) = E[Y | X = x]


### PR DESCRIPTION
Minor update to section with reference to the remaining parameters to tune_forest and a note on tuning sensitivity. 

Small additional fix: update an old `tune.parameters = TRUE` reference in causal_forest and remove a superfluous statement in regression_forest.  