### PR TITLE
Minor ForestTrainer/Tree checkup

### DIFF
--- a/core/src/forest/ForestTrainer.cpp
+++ b/core/src/forest/ForestTrainer.cpp
@@ -103,12 +103,7 @@ std::vector<std::unique_ptr<Tree>> ForestTrainer::train_batch(
   std::mt19937_64 random_number_generator(options.get_random_seed() + start);
   nonstd::uniform_int_distribution<uint> udist;
   std::vector<std::unique_ptr<Tree>> trees;
-
-  if (ci_group_size == 1) {
-    trees.reserve(num_trees);
-  } else {
-    trees.reserve(num_trees * ci_group_size);
-  }
+  trees.reserve(num_trees * ci_group_size);
 
   for (size_t i = 0; i < num_trees; i++) {
     uint tree_seed = udist(random_number_generator);

--- a/core/src/forest/ForestTrainer.h
+++ b/core/src/forest/ForestTrainer.h
@@ -18,6 +18,8 @@
 #ifndef GRF_FORESTTRAINER_H
 #define GRF_FORESTTRAINER_H
 
+#include <memory>
+
 #include "prediction/OptimizedPredictionStrategy.h"
 #include "relabeling/RelabelingStrategy.h"
 #include "splitting/factory/SplittingRuleFactory.h"
@@ -26,11 +28,6 @@
 #include "tree/TreeTrainer.h"
 #include "forest/Forest.h"
 #include "ForestOptions.h"
-
-#include <future>
-#include <memory>
-#include <set>
-#include <thread>
 
 namespace grf {
 

--- a/core/src/tree/Tree.h
+++ b/core/src/tree/Tree.h
@@ -19,7 +19,6 @@
 #define GRF_TREE_H_
 
 #include <vector>
-#include <iostream>
 
 #include "commons/globals.h"
 #include "commons/DefaultData.h"


### PR DESCRIPTION
Removes some old unused `#includes` and drop the unnecessary if statement before ` trees.reserve`.