### PR TITLE
Add a comment explaining the small q / large q splitting rule

### DIFF
--- a/core/src/splitting/RegressionSplittingRule.cpp
+++ b/core/src/splitting/RegressionSplittingRule.cpp
@@ -64,9 +64,6 @@ bool RegressionSplittingRule::find_best_split(const Data& data,
   // For all possible split variables
   for (auto& var : possible_split_vars) {
     // Use faster method for both cases
-    // (tradeoff between nlog(n) and N)
-    // Small q: sorts the data in the node, O(nlog n)
-    // Large q: uses data pre-sorted at the forest initialization, O(N)
     double q = (double) size_node / (double) data.get_num_unique_data_values(var);
     if (q < Q_THRESHOLD) {
       find_best_split_value_small_q(data, node, var, sum_node, size_node, min_child_size,
@@ -197,7 +194,7 @@ void RegressionSplittingRule::find_best_split_value_large_q(const Data& data,
     if (counter[i] == 0) {
       continue;
     }
-
+    
     n_left += counter[i];
     sum_left += sums[i];
 

--- a/core/src/splitting/RegressionSplittingRule.cpp
+++ b/core/src/splitting/RegressionSplittingRule.cpp
@@ -64,6 +64,9 @@ bool RegressionSplittingRule::find_best_split(const Data& data,
   // For all possible split variables
   for (auto& var : possible_split_vars) {
     // Use faster method for both cases
+    // (tradeoff between nlog(n) and N)
+    // Small q: sorts the data in the node, O(nlog n)
+    // Large q: uses data pre-sorted at the forest initialization, O(N)
     double q = (double) size_node / (double) data.get_num_unique_data_values(var);
     if (q < Q_THRESHOLD) {
       find_best_split_value_small_q(data, node, var, sum_node, size_node, min_child_size,
@@ -194,7 +197,7 @@ void RegressionSplittingRule::find_best_split_value_large_q(const Data& data,
     if (counter[i] == 0) {
       continue;
     }
-    
+
     n_left += counter[i];
     sum_left += sums[i];
 

--- a/core/src/splitting/RegressionSplittingRule.h
+++ b/core/src/splitting/RegressionSplittingRule.h
@@ -32,6 +32,42 @@ public:
 
   ~RegressionSplittingRule();
 
+  /**
+   * Finds the best split at a given node in the tree.
+   *
+   * Is called repeatedly to build a tree in a DFS or BFS fashion.
+   *
+   * @param data: the data matrix containing all test samples.
+   * @param node: the node id in the tree.
+   * @param possible_split_vars: a vector of valid sample IDs.
+   * @param responses_by_sample: a vector of transformed outcomes.
+   * @param samples: a vector of samples at the given node.
+   * @param split_vars: the output of the method, the best split variable, stored at node.
+   * @param split_values: the output of the method, the best split value, stored at node.
+   * @return a boolean that will be true if no best split was found.
+   *
+   * Details:
+   *
+   * At each split variable j, this method calls into `find_best_split_value_small_q` or
+   * `find_best_split_value_large_q` depending on the following ratio q:
+   * the number of samples in the node (nj) over the total number of unique values in the data at variable j (Nj).
+   * If this value is less than Q_THRESHOLD (0.02 by default) then the small_q method is called,
+   * otherwise large_q.
+   *
+   * An expensive computation in finding the best split is sorting all the values in order to place samples
+   * on the left or right of the split.
+   * `small_q` sorts the data in the node when it is called, which has time complexity O(nj log nj), then
+   * iterates over all nj point calculating the decrease in impurity.
+   * `large_q` accesses a global sort order for all Nj points created at the initalization of forest training.
+   * To find the best split at the nj points in the node, a full scan
+   * over all Nj points is done, getting the proper position of the sample. This is dominated by O(Nj).
+   *
+   * The two splitting strategies balances O(nj log nj) and O(Nj). In large nodes at the root of the tree,
+   * Nj is smaller than nj log nj, but in smaller nodes, deeper down the tree, nj is small and
+   * Nj is larger than nj log nj.
+   *
+   * The exact value of Q_THRESHOLD has been determined empirically by the ranger developers.
+   */
   bool find_best_split(const Data& data,
                        size_t node,
                        const std::vector<size_t>& possible_split_vars,

--- a/core/src/splitting/RegressionSplittingRule.h
+++ b/core/src/splitting/RegressionSplittingRule.h
@@ -35,12 +35,12 @@ public:
   /**
    * Finds the best split at a given node in the tree.
    *
-   * Is called repeatedly to build a tree in a DFS or BFS fashion.
+   * Is called repeatedly to build a tree in a breadth-first fashion.
    *
    * @param data: the data matrix containing all test samples.
    * @param node: the node id in the tree.
-   * @param possible_split_vars: a vector of valid sample IDs.
-   * @param responses_by_sample: a vector of transformed outcomes.
+   * @param possible_split_vars: a vector of valid covariate IDs.
+   * @param responses_by_sample: a map from sample ID to response.
    * @param samples: a vector of samples at the given node.
    * @param split_vars: the output of the method, the best split variable, stored at node.
    * @param split_values: the output of the method, the best split value, stored at node.
@@ -57,7 +57,7 @@ public:
    * An expensive computation in finding the best split is sorting all the values in order to place samples
    * on the left or right of the split.
    * `small_q` sorts the data in the node when it is called, which has time complexity O(nj log nj), then
-   * iterates over all nj point calculating the decrease in impurity.
+   * iterates over all nj points calculating the decrease in impurity.
    * `large_q` accesses a global sort order for all Nj points created at the initalization of forest training.
    * To find the best split at the nj points in the node, a full scan
    * over all Nj points is done, getting the proper position of the sample. This is dominated by O(Nj).


### PR DESCRIPTION
This regression forest implementation (ranger) balances N vs nlog n depending on where in the tree the split is sought (in large nodes, further up the tree, a linear scan over the N sorted points is quicker than sorting nL values (nL lognL), while further down the tree sorting  nS values is quicker).(more details in chapter 5 in https://arxiv.org/abs/1407.7502)

 For first time readers of the code this comment might be helpful?

