### PR TITLE
compute_sample_weights: update result insertion based on Eigen docs

### DIFF
--- a/r-package/grf/bindings/AnalysisToolsBindings.cpp
+++ b/r-package/grf/bindings/AnalysisToolsBindings.cpp
@@ -70,6 +70,12 @@ Eigen::SparseMatrix<double> compute_sample_weights(Rcpp::List forest_object,
   size_t num_samples = data->get_num_rows();
   size_t num_neighbors = train_data->get_num_rows();
 
+  // From http://eigen.tuxfamily.org/dox/group__TutorialSparse.html:
+  // Filling a sparse matrix effectively
+  typedef Eigen::Triplet<double> T;
+  std::vector<T> tripletList;
+  tripletList.reserve(num_neighbors);
+  // tripletList.reserve(num_samples);
   Eigen::SparseMatrix<double> result(num_samples, num_neighbors);
 
   for (size_t sample = 0; sample < num_samples; sample++) {
@@ -78,11 +84,11 @@ Eigen::SparseMatrix<double> compute_sample_weights(Rcpp::List forest_object,
     for (auto it = weights.begin(); it != weights.end(); it++) {
       size_t neighbor = it->first;
       double weight = it->second;
-      result.insert(sample, neighbor) = weight;
+      tripletList.push_back(T(sample, neighbor, weight));
     }
   }
+  result.setFromTriplets(tripletList.begin(), tripletList.end());
 
-  result.makeCompressed();
   return result;
 }
 

--- a/r-package/grf/bindings/AnalysisToolsBindings.cpp
+++ b/r-package/grf/bindings/AnalysisToolsBindings.cpp
@@ -75,7 +75,6 @@ Eigen::SparseMatrix<double> compute_sample_weights(Rcpp::List forest_object,
   typedef Eigen::Triplet<double> T;
   std::vector<T> tripletList;
   tripletList.reserve(num_neighbors);
-  // tripletList.reserve(num_samples);
   Eigen::SparseMatrix<double> result(num_samples, num_neighbors);
 
   for (size_t sample = 0; sample < num_samples; sample++) {

--- a/r-package/grf/bindings/AnalysisToolsBindings.cpp
+++ b/r-package/grf/bindings/AnalysisToolsBindings.cpp
@@ -73,8 +73,8 @@ Eigen::SparseMatrix<double> compute_sample_weights(Rcpp::List forest_object,
   // From http://eigen.tuxfamily.org/dox/group__TutorialSparse.html:
   // Filling a sparse matrix effectively
   typedef Eigen::Triplet<double> T;
-  std::vector<T> tripletList;
-  tripletList.reserve(num_neighbors);
+  std::vector<T> triplet_list;
+  triplet_list.reserve(num_neighbors);
   Eigen::SparseMatrix<double> result(num_samples, num_neighbors);
 
   for (size_t sample = 0; sample < num_samples; sample++) {
@@ -83,10 +83,10 @@ Eigen::SparseMatrix<double> compute_sample_weights(Rcpp::List forest_object,
     for (auto it = weights.begin(); it != weights.end(); it++) {
       size_t neighbor = it->first;
       double weight = it->second;
-      tripletList.push_back(T(sample, neighbor, weight));
+      triplet_list.push_back(T(sample, neighbor, weight));
     }
   }
-  result.setFromTriplets(tripletList.begin(), tripletList.end());
+  result.setFromTriplets(triplet_list.begin(), triplet_list.end());
 
   return result;
 }


### PR DESCRIPTION
Towards #577 point 1 (Rcpp bindings):

Use the Eigen suggestion on effectively filling a sparse matrix https://eigen.tuxfamily.org/dox/group__TutorialSparse.html

Did `reserve(num_neighbors)` as the obvious lower bound on the number of non-zero entries, there may be a better one? (the output weight matrix often looks more dense than sparse)

Time:

```R
n <- 2000
p <- 10
X <- matrix(rnorm(n * p), n, p)
W <- rbinom(n, 1, 0.5)
Y <- pmax(X[, 1], 0) * W + X[, 2] + pmin(X[, 3], 0) + rnorm(n)
cf <- causal_forest(X, Y, W)

system.time(w <- get_sample_weights(cf, num.threads = 1))
#master:
# user  system elapsed 
# 41.688  35.603  77.315

#this
#   user  system elapsed
# 1.954   0.051   2.005
```

This kills the Eigen insert bottleneck. Moderate time chunk as before: the slow get operator of the STL hash table.