### PR TITLE
Remove typedef Eigen::Triplet

### DIFF
--- a/r-package/grf/bindings/AnalysisToolsBindings.cpp
+++ b/r-package/grf/bindings/AnalysisToolsBindings.cpp
@@ -82,7 +82,7 @@ Eigen::SparseMatrix<double> compute_sample_weights(Rcpp::List forest_object,
     for (auto it = weights.begin(); it != weights.end(); it++) {
       size_t neighbor = it->first;
       double weight = it->second;
-      triplet_list.emplace_back(Eigen::Triplet<double>(sample, neighbor, weight));
+      triplet_list.emplace_back(sample, neighbor, weight);
     }
   }
   result.setFromTriplets(triplet_list.begin(), triplet_list.end());

--- a/r-package/grf/bindings/AnalysisToolsBindings.cpp
+++ b/r-package/grf/bindings/AnalysisToolsBindings.cpp
@@ -72,8 +72,7 @@ Eigen::SparseMatrix<double> compute_sample_weights(Rcpp::List forest_object,
 
   // From http://eigen.tuxfamily.org/dox/group__TutorialSparse.html:
   // Filling a sparse matrix effectively
-  typedef Eigen::Triplet<double> T;
-  std::vector<T> triplet_list;
+  std::vector<Eigen::Triplet<double>> triplet_list;
   triplet_list.reserve(num_neighbors);
   Eigen::SparseMatrix<double> result(num_samples, num_neighbors);
 
@@ -83,7 +82,7 @@ Eigen::SparseMatrix<double> compute_sample_weights(Rcpp::List forest_object,
     for (auto it = weights.begin(); it != weights.end(); it++) {
       size_t neighbor = it->first;
       double weight = it->second;
-      triplet_list.push_back(T(sample, neighbor, weight));
+      triplet_list.emplace_back(Eigen::Triplet<double>(sample, neighbor, weight));
     }
   }
   result.setFromTriplets(triplet_list.begin(), triplet_list.end());


### PR DESCRIPTION
#578 included a typdef from the Eigen documentation example. Omit this for consistency as these are not used anywhere else in the grf codebase. (Also change to emplacing the object into the vector instead of pushing it).