### PR TITLE
[Bug] Fix queue order in get_tree

### DIFF
--- a/r-package/grf/R/analysis_tools.R
+++ b/r-package/grf/R/analysis_tools.R
@@ -70,7 +70,7 @@ get_tree <- function(forest, index) {
         right_child = node.index + 2
       )
       node.index <- node.index + 2
-      frontier <- c(left[node] + 1, right[node] + 1, frontier)
+      frontier <- c(frontier, left[node] + 1, right[node] + 1)
     }
   }
 

--- a/r-package/grf/tests/testthat/test_analysis_tools.R
+++ b/r-package/grf/tests/testthat/test_analysis_tools.R
@@ -181,3 +181,28 @@ test_that("instrumental forest leaf nodes contains 'avg_Y', 'avg_W', and 'avg_Z'
     }
   }
 })
+
+test_that("result of get_tree is consistent with internal tree representation (child_nodes and leaf_samples)", {
+  n <- 100
+  p <- 5
+  X <- matrix(rnorm(n * p), n, p)
+  Y <- abs(X[, 1]) + rnorm(n)
+
+  # The following index check only make sense when the tree is not pruned (honesty = FALSE)
+  rf <- regression_forest(X, Y, num.trees = 1, ci.group.size = 1, honesty = FALSE)
+
+  child.nodes <- rf[["_child_nodes"]][[1]]
+  leaf.samples <- rf[["_leaf_samples"]][[1]]
+  tree <- get_tree(rf, 1)
+
+  for (i in 1:length(tree$nodes)) {
+    node <- tree$nodes[[i]]
+    if (node$is_leaf) {
+      expect_false(child.nodes[[1]][i] == 1)
+      expect_false(child.nodes[[2]][i] == 1)
+      expect_equal(length(node$samples), length(leaf.samples[[i]]))
+    } else {
+      expect_equal(length(leaf.samples[[i]]), 0)
+    }
+  }
+})


### PR DESCRIPTION
#528 accidentally pushed elements onto the frontier in the wrong order.

The printed tree nodes are in the wrong order, example:

```R
set.seed(123)
n <- 20
p <- 10
X <- matrix(rnorm(n * p), n, p)
Y <- abs(X[, 1]) + rnorm(n)

rf <- regression_forest(X, Y, num.trees = 1, ci.group.size = 1, honesty = F, seed = 123))
```

The tree (0-indexed):

```
> rf$`_child_nodes`
[[1]]
[[1]][[1]]
[1] 1 3 0 0 0

[[1]][[2]]
[1] 2 4 0 0 0


> rf$`_leaf_samples`
[[1]]
[[1]][[1]]
numeric(0)

[[1]][[2]]
numeric(0)

[[1]][[3]]
[1]  8 15  0  9 ## node 3 should have size 4

[[1]][[4]]
[1]  3 17  5

[[1]][[5]]
[1]  7 14 18

```

Master:
```
> get_tree(rf, 1)
GRF tree object 
Number of training samples: 10 
Variable splits: 
(1) split_variable: X.4  split_value: 0.303529 
  (2) split_variable: X.8  split_value: -0.372439 
    (4) * num_samples: 3  avg_Y: -0.1 
    (5) * num_samples: 4  avg_Y: 2.24 
  (3) * num_samples: 3  avg_Y: 1.03  ## Wrong node size
```

This:
```
> get_tree(rf, 1)
GRF tree object 
Number of training samples: 10 
Variable splits: 
(1) split_variable: X.4  split_value: 0.303529 
  (2) split_variable: X.8  split_value: -0.372439 
    (4) * num_samples: 3  avg_Y: 1.03 
    (5) * num_samples: 3  avg_Y: -0.1 
  (3) * num_samples: 4  avg_Y: 2.24 ## Right
```

