### PR TITLE
Add validate_newdata to get_sample_weights

### DIFF
--- a/r-package/grf/R/analysis_tools.R
+++ b/r-package/grf/R/analysis_tools.R
@@ -195,10 +195,12 @@ get_sample_weights <- function(forest, newdata = NULL, num.threads = NULL) {
   num.threads <- validate_num_threads(num.threads)
 
   forest.short <- forest[-which(names(forest) == "X.orig")]
-  train.data <- create_data_matrices(forest[["X.orig"]])
+  X <- forest[["X.orig"]]
+  train.data <- create_data_matrices(X)
 
   if (!is.null(newdata)) {
     data <- create_data_matrices(newdata)
+    validate_newdata(newdata, X)
     compute_weights(
       forest.short, train.data$train.matrix, train.data$sparse.train.matrix,
       data$train.matrix, data$sparse.train.matrix, num.threads

--- a/r-package/grf/R/analysis_tools.R
+++ b/r-package/grf/R/analysis_tools.R
@@ -170,7 +170,7 @@ variable_importance <- function(forest, decay.exponent = 2, max.depth = 4) {
 #' @param newdata Points at which predictions should be made. If NULL,
 #'                makes out-of-bag predictions on the training set instead
 #'                (i.e., provides predictions at Xi using only trees that did
-#'                not use the i-th training example).#' @param max.depth Maximum depth of splits to consider.
+#'                not use the i-th training example).
 #' @param num.threads Number of threads used in training. If set to NULL, the software
 #'                    automatically selects an appropriate amount.
 #' @return A sparse matrix where each row represents a test sample, and each column is a sample in the

--- a/r-package/grf/R/input_utilities.R
+++ b/r-package/grf/R/input_utilities.R
@@ -135,7 +135,7 @@ validate_ll_path <- function(lambda.path) {
 }
 
 validate_newdata <- function(newdata, X) {
-  if (ncol(newdata) != ncol(X)) {
+  if (NCOL(newdata) != ncol(X)) {
     stop("newdata must have the same number of columns as the training matrix.")
   }
   validate_X(newdata)


### PR DESCRIPTION
Earlier this all went through and produced output (which was wrong)

```R
n <- 500
p <- 10
X <- matrix(rnorm(n * p), n, p)
W <- rbinom(n, 1, 0.5)
Y <- pmax(X[, 1], 0) * W + X[, 2] + pmin(X[, 3], 0) + rnorm(n)
c.forest <- causal_forest(X, Y, W)

get_sample_weights(c.forest, matrix(0, 1, 3))
get_sample_weights(c.forest, 42) 
get_sample_weights(c.forest, c(42, 12))
```

The added input check is the same as the one performed in predict.

validate_newdata update: The change to `NCOL` from `ncol` is for case 2) and 3) above: `NCOL(c(42, 12)` is 1. `ncol(c(42,12)` is `NULL`.

