### PR TITLE
Treat warnings as errors in testthat

### DIFF
--- a/r-package/grf/tests/testthat.R
+++ b/r-package/grf/tests/testthat.R
@@ -1,4 +1,6 @@
 library(testthat)
 library(grf)
 
+# This treats warnings as errors
+options(warn = 2)
 test_check("grf")

--- a/r-package/grf/tests/testthat/test_causal_forest_tuning.R
+++ b/r-package/grf/tests/testthat/test_causal_forest_tuning.R
@@ -18,24 +18,6 @@ test_that("causal forest tuning decreases prediction error", {
   expect_true(tuned.error < error * 0.75)
 })
 
-test_that("causal forest forest tuning tunes each parameter", {
-  p <- 4
-  n <- 100
-
-  X <- matrix(2 * runif(n * p) - 1, n, p)
-  W <- rbinom(n, 1, 0.5)
-  TAU <- 0.1 * (X[, 1] > 0)
-  Y <- TAU * (W - 1 / 2) + 2 * rnorm(n)
-  tunable.params <- c("sample.fraction", "mtry", "min.node.size", "honesty.fraction",
-                    "honesty.prune.leaves", "alpha", "imbalance.penalty")
-  for (param in tunable.params) {
-    capture_output(tuned.forest <- causal_forest(X, Y, W, W.hat = 0, Y.hat = 0,
-                                                 num.trees = 100, tune.parameters = param,
-                                                 tune.num.trees = 10, tune.num.reps = 10))
-    expect_true(param == names(tuned.forest$tuning.output$params))
-  }
-})
-
 test_that("local linear causal forest tuning returns lambda and decreases error", {
   p <- 6
   n <- 1000

--- a/r-package/grf/tests/testthat/test_regression_forest.R
+++ b/r-package/grf/tests/testthat/test_regression_forest.R
@@ -41,19 +41,21 @@ test_that("changing honest.fraction behaves as expected", {
 
   expect_equal(length(samples$split_sample), n * sample_fraction_1 * honesty_fraction_1)
   expect_equal(length(samples$estimation_sample), n * sample_fraction_1 * (1 - honesty_fraction_1))
+  # Checking for the runtime_error:
+  # "The honesty fraction is too close to 1 or 0, as no observations will be sampled."
   expect_error(
     grf::regression_forest(X, Y,
       sample.fraction = sample_fraction_2,
       honesty = TRUE, honesty.fraction = honesty_fraction_2
     ),
-    "The honesty fraction is too close to 1 or 0, as no observations will be sampled."
+    class = "std::runtime_error"
   )
   expect_error(
     grf::regression_forest(X, Y,
       sample.fraction = sample_fraction_3,
       honesty = TRUE, honesty.fraction = honesty_fraction_3
     ),
-    "The honesty fraction is too close to 1 or 0, as no observations will be sampled."
+    class = "std::runtime_error"
   )
 })
 

--- a/r-package/grf/tests/testthat/test_regression_forest_tuning.R
+++ b/r-package/grf/tests/testthat/test_regression_forest_tuning.R
@@ -17,17 +17,3 @@ test_that("regression forest tuning decreases prediction error", {
 
   expect_true(tuned.error < error * 0.75)
 })
-
-test_that("regression forest tuning tunes each parameter", {
-  n <- 100
-  p <- 2
-
-  X <- matrix(2 * runif(n * p) - 1, n, p)
-  Y <- (X[, 1] > 0) + rnorm(n)
-  tunable.params <- c("sample.fraction", "mtry", "min.node.size", "honesty.fraction",
-                    "honesty.prune.leaves", "alpha", "imbalance.penalty")
-  for (param in tunable.params) {
-    tuned.forest <- regression_forest(X, Y, num.trees = 100, tune.parameters = param)
-    expect_true(param == names(tuned.forest$tuning.output$params))
-  }
-})


### PR DESCRIPTION
This PR enables treating warnings as errors in testthat.

One might introduce a coding error somewhere such that an existing test that passed without warning, now gives a warning (such as for example most average treatment effect functions, and tuning functions).

This PR enables warnings as errors to avoid this. It also updates tests to remove the 4 current warnings.

You can still write tests that will give a warning with `expect_error`
