### PR TITLE
Remove extra predict call in forest tuning

### DIFF
--- a/r-package/grf/R/tune_causal_forest.R
+++ b/r-package/grf/R/tune_causal_forest.R
@@ -160,8 +160,6 @@ tune_causal_forest <- function(X, Y, W, Y.hat, W.hat,
 
   tune.parameters.defaults <- default.parameters[tune.parameters]
   train <- causal_train
-  predict_oob <- causal_predict_oob
-  predict.data.args <- c("train.matrix", "sparse.train.matrix", "outcome.index", "treatment.index")
 
   tuning.output <- tune_forest(data = data,
                                nrow.X = nrow.X,
@@ -172,9 +170,7 @@ tune_causal_forest <- function(X, Y, W, Y.hat, W.hat,
                                num.fit.trees = tune.num.trees,
                                num.fit.reps = tune.num.reps,
                                num.optimize.reps = tune.num.draws,
-                               train = train,
-                               predict_oob = predict_oob,
-                               predict.data.args = predict.data.args)
+                               train = train)
 
   tuning.output
 }

--- a/r-package/grf/R/tune_instrumental_forest.R
+++ b/r-package/grf/R/tune_instrumental_forest.R
@@ -158,8 +158,6 @@ tune_instrumental_forest <- function(X, Y, W, Z, Y.hat, W.hat, Z.hat,
 
   tune.parameters.defaults <- default.parameters[tune.parameters]
   train <- instrumental_train
-  predict_oob <- instrumental_predict_oob
-  predict.data.args <- c("train.matrix", "sparse.train.matrix", "outcome.index", "treatment.index", "instrument.index")
 
   tuning.output <- tune_forest(data = data,
                                nrow.X = nrow.X,
@@ -170,9 +168,7 @@ tune_instrumental_forest <- function(X, Y, W, Z, Y.hat, W.hat, Z.hat,
                                num.fit.trees = tune.num.trees,
                                num.fit.reps = tune.num.reps,
                                num.optimize.reps = tune.num.draws,
-                               train = train,
-                               predict_oob = predict_oob,
-                               predict.data.args = predict.data.args)
+                               train = train)
 
   tuning.output
 }

--- a/r-package/grf/R/tune_regression_forest.R
+++ b/r-package/grf/R/tune_regression_forest.R
@@ -145,8 +145,6 @@ tune_regression_forest <- function(X, Y,
 
   tune.parameters.defaults <- default.parameters[tune.parameters]
   train <- regression_train
-  predict_oob <- regression_predict_oob
-  predict.data.args <- c("train.matrix", "sparse.train.matrix", "outcome.index")
 
   tuning.output <- tune_forest(data = data,
                                nrow.X = nrow.X,
@@ -157,9 +155,7 @@ tune_regression_forest <- function(X, Y,
                                num.fit.trees = tune.num.trees,
                                num.fit.reps = tune.num.reps,
                                num.optimize.reps = tune.num.draws,
-                               train = train,
-                               predict_oob = predict_oob,
-                               predict.data.args = predict.data.args)
+                               train = train)
 
   tuning.output
 }

--- a/r-package/grf/R/tuning.R
+++ b/r-package/grf/R/tuning.R
@@ -13,8 +13,6 @@
 #' @param num.optimize.reps The number of random parameter values considered when using the model
 #'  to select the optimal parameters.
 #' @param train The grf forest training function.
-#' @param predict_oob The grf forest oob prediction function.
-#' @param predict.data.args The names of the arguments in data passed to predict_oob.
 #'
 #' @return tuning output
 #'
@@ -29,10 +27,7 @@ tune_forest <- function(data,
                         num.fit.trees,
                         num.fit.reps,
                         num.optimize.reps,
-                        train,
-                        predict_oob,
-                        predict.data.args) {
-  predict_oob.args <- c(data[predict.data.args], num.threads = args[["num.threads"]], estimate.variance = FALSE)
+                        train) {
   fit.parameters <- args[!names(args) %in% tune.parameters]
   fit.parameters[["num.trees"]] <- num.fit.trees
   fit.parameters[["ci.group.size"]] <- 1

--- a/r-package/grf/R/tuning.R
+++ b/r-package/grf/R/tuning.R
@@ -46,9 +46,7 @@ tune_forest <- function(data,
   small.forest.errors <- apply(fit.draws, 1, function(draw) {
     draw.parameters <- get_params_from_draw(nrow.X, ncol.X, draw)
     small.forest <- do.call.rcpp(train, c(data, fit.parameters, draw.parameters))
-    prediction <- do.call.rcpp(predict_oob, c(list(forest_object = small.forest), predict_oob.args))
-    error <- prediction$debiased.error
-
+    error <- small.forest$debiased.error
     mean(error, na.rm = TRUE)
   })
 
@@ -105,14 +103,12 @@ tune_forest <- function(data,
   fit.parameters[["num.trees"]] <- num.fit.trees * 4
   retrained.forest.params <- grid[small.forest.optimal.draw, -1]
   retrained.forest <- do.call.rcpp(train, c(data, fit.parameters, retrained.forest.params))
-  retrained.forest.prediction <- do.call.rcpp(predict_oob, c(list(forest_object = retrained.forest), predict_oob.args))
-  retrained.forest.error <- mean(retrained.forest.prediction$debiased.error, na.rm = TRUE)
+  retrained.forest.error <- mean(retrained.forest$debiased.error, na.rm = TRUE)
 
   # 4. Train a forest with default parameters, and check its predicted error.
   # This improves our chances of not doing worse than default
   default.forest <- do.call.rcpp(train, c(data, fit.parameters, tune.parameters.defaults))
-  default.forest.prediction <- do.call.rcpp(predict_oob, c(list(forest_object = default.forest), predict_oob.args))
-  default.forest.error <- mean(default.forest.prediction$debiased.error, na.rm = TRUE)
+  default.forest.error <- mean(default.forest$debiased.error, na.rm = TRUE)
 
   if (default.forest.error < retrained.forest.error) {
     out <- get_tuning_output(


### PR DESCRIPTION
Bug fix: previously we mistakingly re-computed the small forest errors instead of using the already trained OOB errors. This will change tuning output slightly as the (intended) OOB errors are used instead. This also provides a modest speedup.