### PR TITLE
fix bug when using only one variable in A with best_linear_projection

### DIFF
--- a/r-package/grf/R/forest_summary.R
+++ b/r-package/grf/R/forest_summary.R
@@ -177,7 +177,7 @@ best_linear_projection <- function(forest, A = NULL, subset = NULL) {
   
   if (!is.null(A)) {
     if (nrow(A) == length(forest$Y.orig)) {
-      A.subset <- A[subset,]
+      A.subset <- A[subset,,drop=FALSE]
     } else if (nrow(A) == length(subset)) {
       A.subset <- A
     } else {


### PR DESCRIPTION
When A has more than one variable with best_linear_projection(), it result in an error. This fixes the bug.