### PR TITLE
Use more stable calibration for APE in case of low variation W.hat.

### DIFF
--- a/r-package/grf/R/average_partial_effect.R
+++ b/r-package/grf/R/average_partial_effect.R
@@ -99,8 +99,14 @@ average_partial_effect <- function(forest,
   # Modify debiasing weights gamma to make this true, i.e., compute
   # argmin {||gamma - gamma.original||_2^2 : A'gamma = b}
   if (calibrate.weights) {
-    A <- cbind(1, subset.W.orig, subset.W.hat) / sum(subset.weights)
-    b <- c(0, 1, 0)
+    # Don't attempt to balance W.hat if it has too little variation.
+    if (sd(subset.W.hat) > 0.01 * sd(subset.W.orig)) {
+      A <- cbind(1, subset.W.orig, subset.W.hat) / sum(subset.weights)
+      b <- c(0, 1, 0)
+    } else {
+      A <- cbind(1, subset.W.orig) / sum(subset.weights)
+      b <- c(0, 1)
+    }
     bias <- t(A) %*% debiasing.weights - b
     lambda <- solve(t(A) %*% A, bias)
     correction <- A %*% lambda

--- a/r-package/grf/tests/testthat/test_average_effect.R
+++ b/r-package/grf/tests/testthat/test_average_effect.R
@@ -289,7 +289,7 @@ test_that("cluster robust average effects do weighting correctly", {
   # groups, whereas `best_linear_projection` does not.
   cate.aipw.blp <- best_linear_projection(forest.causal, A = NULL)
   expect_equal(as.numeric(cate.aipw[1]), cate.aipw.blp[1,1], tol = 0.001)
-  expect_equal(as.numeric(cate.aipw[2]), cate.aipw.blp[1,2], tol = 0.001)
+  expect_equal(as.numeric(cate.aipw[2]), cate.aipw.blp[1,2], tol = 0.002)
 
   catt.aipw <- average_treatment_effect(forest.causal, target.sample = "treated", method = "AIPW")
   expect_true(abs(catt.aipw[1] - t0) / (3 * catt.aipw[2]) <= 1)


### PR DESCRIPTION
In response to #610.

In existing the implementation, we calibrated the double robustness weights used in `average_partial_effect` so that they exactly balance 3 things: W, W.hat, and an intercept. This could create numerical issues when W.hat (i.e., our out-of-bag estimate of E[W|X]) was nearly constant. Here, we do not attempt to calibrate weights to balance W.hat if there's not enough variation in W.hat (although we do still balance W and the intercept).