### PR TITLE
Add a causal forest diagnostics vignette

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ In addition, GRF supports 'honest' estimation (where one subset of the data is u
 Some helpful links for getting started:
 
 - The [R package documentation](https://grf-labs.github.io/grf) contains usage examples and method reference.
-- The [GRF reference](REFERENCE.md) gives a detailed description of the GRF algorithm and includes troubleshooting suggestions.
+- The [GRF reference](https://grf-labs.github.io/grf/REFERENCE.html) gives a detailed description of the GRF algorithm and includes troubleshooting suggestions.
 - For community questions and answers around usage, see [Github issues labelled 'question'](https://github.com/grf-labs/grf/issues?q=label%3Aquestion).
 
 The repository first started as a fork of the [ranger](https://github.com/imbs-hl/ranger) repository -- we owe a great deal of thanks to the ranger authors for their useful and free package.
@@ -122,7 +122,7 @@ test_calibration(tau.forest)
 
 ### Developing
 
-In addition to providing out-of-the-box forests for quantile regression and causal effect estimation, GRF provides a framework for creating forests tailored to new statistical tasks. If you'd like to develop using GRF, please consult the [algorithm reference](REFERENCE.md) and [development guide](DEVELOPING.md).
+In addition to providing out-of-the-box forests for quantile regression and causal effect estimation, GRF provides a framework for creating forests tailored to new statistical tasks. If you'd like to develop using GRF, please consult the [algorithm reference](https://grf-labs.github.io/grf/REFERENCE.html) and [development guide](https://grf-labs.github.io/grf/DEVELOPING.html).
 
 ### References
 

--- a/r-package/grf/pkgdown/_pkgdown.yml
+++ b/r-package/grf/pkgdown/_pkgdown.yml
@@ -6,12 +6,14 @@ navbar:
     href: articles/grf.html
   - text: "Reference"
     href: reference/index.html
-  - text: "Examples"
+  - text: "Articles" # A collection of smaller vignettes, this list is kept alphabetical
     menu:
       - text: "Categorical inputs"
         href: articles/categorical_inputs.html
       - text: "Confidence intervals and the number of trees"
         href: articles/ci_and_num.trees.html
+      - text: "Evaluating a causal forest fit"
+        href: articles/diagnostics.html
       - text: "Sample weighting"
         href: articles/sample_weighting_examples.html
   - text: "Algorithm reference"

--- a/r-package/grf/pkgdown/_pkgdown.yml
+++ b/r-package/grf/pkgdown/_pkgdown.yml
@@ -6,7 +6,7 @@ navbar:
     href: articles/grf.html
   - text: "Reference"
     href: reference/index.html
-  - text: "Articles" # A collection of smaller vignettes, this list is kept alphabetical
+  - text: "Tutorials" # A collection of smaller vignettes, this list is kept alphabetical
     menu:
       - text: "Categorical inputs"
         href: articles/categorical_inputs.html

--- a/r-package/grf/vignettes/diagnostics.Rmd
+++ b/r-package/grf/vignettes/diagnostics.Rmd
@@ -26,7 +26,7 @@ n <- 2000
 p <- 10
 X <- matrix(rnorm(n * p), n, p)
 
-W <- rbinom(n, 1, 0.5)
+W <- rbinom(n, 1, 0.4 + 0.2 * (X[, 1] > 0))
 Y <- pmax(X[, 1], 0) * W + X[, 2] + pmin(X[, 3], 0) + rnorm(n)
 cf <- causal_forest(X, Y, W)
 ```

--- a/r-package/grf/vignettes/diagnostics.Rmd
+++ b/r-package/grf/vignettes/diagnostics.Rmd
@@ -1,0 +1,52 @@
+---
+title: "Evaluating a causal forest fit"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{diagnostics}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+set.seed(123)
+```
+
+```{r setup}
+library(grf)
+```
+
+Two common diagnostics to evaluate if the identifying assumptions behind grf hold is a propensity score histogram and covariance balance plot.
+
+```{r}
+n <- 2000
+p <- 10
+X <- matrix(rnorm(n * p), n, p)
+
+W <- rbinom(n, 1, 0.5)
+Y <- pmax(X[, 1], 0) * W + X[, 2] + pmin(X[, 3], 0) + rnorm(n)
+cf <- causal_forest(X, Y, W)
+```
+
+The overlap assumptions requires a positive probability of treatment for each $X_i$. We should not be able to deterministically decide the treatment status of an individual based on its covariates, meaning none of the estimated propensity scores should be close to one or zero. One can check this with a histogram:
+
+```{r}
+hist(e.hat <- cf$W.hat)
+```
+
+One can also check that the covariates are balanced across the control and treated group by plotting the histogram $X_i | W_i = k$, overlaid here for each feature:
+
+```{r, fig.height = 25}
+par(mar = c(5, 5, 1, 1), oma = c(0, 0, 2, 0), mfrow = c(p/2, 2))
+plots <- lapply(1:p, function (i) {
+  control.hist <- hist(X[W == 0, i], plot = FALSE)
+  treated.hist <- hist(X[W == 1, i], plot = FALSE)
+
+  plot(control.hist, col= rgb(1, 0, 0, 0.5), main = paste("variable", i), xlab = "")
+  plot(treated.hist, col= rgb(0, 0, 1, 0.5), add = TRUE)
+})
+title("Covariate histograms, control/treated (red/blue)", outer = TRUE)
+```

--- a/r-package/grf/vignettes/grf.Rmd
+++ b/r-package/grf/vignettes/grf.Rmd
@@ -108,4 +108,4 @@ Check whether causal forest predictions are well calibrated.
 test_calibration(tau.forest)
 ```
 
-For more worked examples see the _Articles_ section for a collection of vignettes.
+For more worked examples see the _Tutorials_ section.

--- a/r-package/grf/vignettes/grf.Rmd
+++ b/r-package/grf/vignettes/grf.Rmd
@@ -107,3 +107,5 @@ Check whether causal forest predictions are well calibrated.
 ```{r}
 test_calibration(tau.forest)
 ```
+
+For more worked examples see the _Articles_ section for a collection of vignettes.


### PR DESCRIPTION
This vignette adds two quick diagnostics checks one can do after fitting a model with grf:

* check the histogram of estimated propensity scores
* check the histogram of each Xi in the control/treated group

A note at the end of the main grf vignette refers to the collection of "Tutorials" (renamed from "Examples")