### PR TITLE
More informative error message when subset equals one unit in summary functions

### DIFF
--- a/r-package/grf/R/average_late.R
+++ b/r-package/grf/R/average_late.R
@@ -111,7 +111,7 @@ average_late <- function(forest,
   subset.weights <- observation.weight[subset]
 
   if (length(unique(subset.clusters)) <= 1) {
-    stop("The passed subset specifies too few distinct units.")
+    stop("The specified subset must contain units from more than one cluster.")
   }
 
   if (min(subset.Z.hat) <= 0.01 || max(subset.Z.hat) >= 0.99) {

--- a/r-package/grf/R/average_late.R
+++ b/r-package/grf/R/average_late.R
@@ -110,8 +110,8 @@ average_late <- function(forest,
   subset.clusters <- clusters[subset]
   subset.weights <- observation.weight[subset]
 
-  if (length(unique(subset.clusters)) <=1) {
-    stop("subset specifies too few distinct units")
+  if (length(unique(subset.clusters)) == 1) {
+    stop("The passed subset specifies too few distinct units.")
   }
 
   if (min(subset.Z.hat) <= 0.01 || max(subset.Z.hat) >= 0.99) {

--- a/r-package/grf/R/average_late.R
+++ b/r-package/grf/R/average_late.R
@@ -110,7 +110,7 @@ average_late <- function(forest,
   subset.clusters <- clusters[subset]
   subset.weights <- observation.weight[subset]
 
-  if (length(unique(subset.clusters)) == 1) {
+  if (length(unique(subset.clusters)) <= 1) {
     stop("The passed subset specifies too few distinct units.")
   }
 

--- a/r-package/grf/R/average_late.R
+++ b/r-package/grf/R/average_late.R
@@ -62,7 +62,7 @@ average_late <- function(forest,
           "only implemented for binary instruments."
       ))
   }
-  
+
   if (is.null(subset)) {
     subset <- 1:length(forest$Y.hat)
   }
@@ -110,6 +110,10 @@ average_late <- function(forest,
   subset.clusters <- clusters[subset]
   subset.weights <- observation.weight[subset]
 
+  if (length(unique(subset.clusters)) <=1) {
+    stop("subset specifies too few distinct units")
+  }
+
   if (min(subset.Z.hat) <= 0.01 || max(subset.Z.hat) >= 0.99) {
     rng <- range(subset.Z.hat)
     warning(paste0(
@@ -120,7 +124,7 @@ average_late <- function(forest,
       "treatment effect estimation."
     ))
   }
-  
+
   if (abs(min(subset.compliance.score)) <= 0.01 * sd(subset.W.orig)) {
       warning(paste0(
           "The instrument appears to be weak, with some compliance scores as ",

--- a/r-package/grf/R/average_partial_effect.R
+++ b/r-package/grf/R/average_partial_effect.R
@@ -79,8 +79,8 @@ average_partial_effect <- function(forest,
   subset.weights.raw <- observation.weight[subset]
   subset.weights <- subset.weights.raw / mean(subset.weights.raw)
 
-  if (length(unique(subset.clusters)) <=1) {
-    stop("subset specifies too few distinct units")
+  if (length(unique(subset.clusters)) == 1) {
+    stop("The passed subset specifies too few distinct units.")
   }
 
   # This is a simple plugin estimate of the APE.

--- a/r-package/grf/R/average_partial_effect.R
+++ b/r-package/grf/R/average_partial_effect.R
@@ -11,7 +11,7 @@
 #' and there are 10 clusters with 19 units each and per-cluster ATE = 0, then
 #' the overall ATE is 0.05 (additional sample.weights allow for custom
 #' weighting). If equalize.cluster.weights = TRUE each cluster gets equal weight
-#' and the overall ATE is 0.5. 
+#' and the overall ATE is 0.5.
 #'
 #' @param forest The trained forest.
 #' @param calibrate.weights Whether to force debiasing weights to match expected
@@ -78,6 +78,10 @@ average_partial_effect <- function(forest,
   subset.clusters <- clusters[subset]
   subset.weights.raw <- observation.weight[subset]
   subset.weights <- subset.weights.raw / mean(subset.weights.raw)
+
+  if (length(unique(subset.clusters)) <=1) {
+    stop("subset specifies too few distinct units")
+  }
 
   # This is a simple plugin estimate of the APE.
   cape.plugin <- weighted.mean(tau.hat, subset.weights)

--- a/r-package/grf/R/average_partial_effect.R
+++ b/r-package/grf/R/average_partial_effect.R
@@ -80,7 +80,7 @@ average_partial_effect <- function(forest,
   subset.weights <- subset.weights.raw / mean(subset.weights.raw)
 
   if (length(unique(subset.clusters)) <= 1) {
-    stop("The passed subset specifies too few distinct units.")
+    stop("The specified subset must contain units from more than one cluster.")
   }
 
   # This is a simple plugin estimate of the APE.

--- a/r-package/grf/R/average_partial_effect.R
+++ b/r-package/grf/R/average_partial_effect.R
@@ -79,7 +79,7 @@ average_partial_effect <- function(forest,
   subset.weights.raw <- observation.weight[subset]
   subset.weights <- subset.weights.raw / mean(subset.weights.raw)
 
-  if (length(unique(subset.clusters)) == 1) {
+  if (length(unique(subset.clusters)) <= 1) {
     stop("The passed subset specifies too few distinct units.")
   }
 

--- a/r-package/grf/R/average_treatment_effect.R
+++ b/r-package/grf/R/average_treatment_effect.R
@@ -110,7 +110,7 @@ average_treatment_effect <- function(forest,
   subset.clusters <- clusters[subset]
   subset.weights <- observation.weight[subset]
 
-  if (length(unique(subset.clusters)) == 1) {
+  if (length(unique(subset.clusters)) <= 1) {
     stop("The passed subset specifies too few distinct units.")
   }
 

--- a/r-package/grf/R/average_treatment_effect.R
+++ b/r-package/grf/R/average_treatment_effect.R
@@ -21,7 +21,7 @@
 #' and there are 10 clusters with 19 units each and per-cluster ATE = 0, then
 #' the overall ATE is 0.05 (additional sample.weights allow for custom
 #' weighting). If equalize.cluster.weights = TRUE each cluster gets equal weight
-#' and the overall ATE is 0.5. 
+#' and the overall ATE is 0.5.
 #'
 #' @param forest The trained forest.
 #' @param target.sample Which sample to aggregate treatment effects over.
@@ -109,6 +109,10 @@ average_treatment_effect <- function(forest,
   tau.hat.pointwise <- predict(forest)$predictions[subset]
   subset.clusters <- clusters[subset]
   subset.weights <- observation.weight[subset]
+
+  if (length(unique(subset.clusters)) <=1) {
+    stop("subset specifies too few distinct units")
+  }
 
   # Address the overlap case separately, as this is a very different estimation problem.
   # The method argument (AIPW vs TMLE) is ignored in this case, as both methods are effectively

--- a/r-package/grf/R/average_treatment_effect.R
+++ b/r-package/grf/R/average_treatment_effect.R
@@ -110,8 +110,8 @@ average_treatment_effect <- function(forest,
   subset.clusters <- clusters[subset]
   subset.weights <- observation.weight[subset]
 
-  if (length(unique(subset.clusters)) <=1) {
-    stop("subset specifies too few distinct units")
+  if (length(unique(subset.clusters)) == 1) {
+    stop("The passed subset specifies too few distinct units.")
   }
 
   # Address the overlap case separately, as this is a very different estimation problem.

--- a/r-package/grf/R/average_treatment_effect.R
+++ b/r-package/grf/R/average_treatment_effect.R
@@ -111,7 +111,7 @@ average_treatment_effect <- function(forest,
   subset.weights <- observation.weight[subset]
 
   if (length(unique(subset.clusters)) <= 1) {
-    stop("The passed subset specifies too few distinct units.")
+    stop("The specified subset must contain units from more than one cluster.")
   }
 
   # Address the overlap case separately, as this is a very different estimation problem.

--- a/r-package/grf/R/forest_summary.R
+++ b/r-package/grf/R/forest_summary.R
@@ -180,7 +180,7 @@ best_linear_projection <- function(forest,
   subset.weights.raw <- observation.weight[subset]
   subset.weights <- subset.weights.raw / mean(subset.weights.raw)
 
-  if (length(unique(subset.clusters)) == 1) {
+  if (length(unique(subset.clusters)) <= 1) {
     stop("The passed subset specifies too few distinct units.")
   }
 

--- a/r-package/grf/R/forest_summary.R
+++ b/r-package/grf/R/forest_summary.R
@@ -181,7 +181,7 @@ best_linear_projection <- function(forest,
   subset.weights <- subset.weights.raw / mean(subset.weights.raw)
 
   if (length(unique(subset.clusters)) <= 1) {
-    stop("The passed subset specifies too few distinct units.")
+    stop("The specified subset must contain units from more than one cluster.")
   }
 
   binary.W <- all(subset.W.orig %in% c(0, 1))

--- a/r-package/grf/R/forest_summary.R
+++ b/r-package/grf/R/forest_summary.R
@@ -160,7 +160,7 @@ best_linear_projection <- function(forest,
     stop("If specified, debiasing.weights must be a vector of length n.")
   }
 
-  cluster.se <- length(forest$clusters) > 0 && length(unique(forest$clusters[subset])) > 1
+  cluster.se <- length(forest$clusters) > 0
 
   clusters <- if (cluster.se) {
     forest$clusters
@@ -179,6 +179,10 @@ best_linear_projection <- function(forest,
   subset.clusters <- clusters[subset]
   subset.weights.raw <- observation.weight[subset]
   subset.weights <- subset.weights.raw / mean(subset.weights.raw)
+
+  if (length(unique(subset.clusters)) <=1) {
+    stop("subset specifies too few distinct units")
+  }
 
   binary.W <- all(subset.W.orig %in% c(0, 1))
 

--- a/r-package/grf/R/forest_summary.R
+++ b/r-package/grf/R/forest_summary.R
@@ -180,8 +180,8 @@ best_linear_projection <- function(forest,
   subset.weights.raw <- observation.weight[subset]
   subset.weights <- subset.weights.raw / mean(subset.weights.raw)
 
-  if (length(unique(subset.clusters)) <=1) {
-    stop("subset specifies too few distinct units")
+  if (length(unique(subset.clusters)) == 1) {
+    stop("The passed subset specifies too few distinct units.")
   }
 
   binary.W <- all(subset.W.orig %in% c(0, 1))

--- a/r-package/grf/tests/testthat/test_forest_summaries.R
+++ b/r-package/grf/tests/testthat/test_forest_summaries.R
@@ -200,5 +200,5 @@ test_that("best linear projection works with edge case input types", {
   blp.single.covariate <- best_linear_projection(forest, X[, 1])
   # a forest trained with clusters, and subset equal to only one of the clusters
   expect_error(best_linear_projection(forest.clustered, X[, 1], subset = which(forest.clustered$clusters == 1)),
-               regexp = "subset specifies too few distinct units")
+               regexp = "The passed subset specifies too few distinct units.")
 })

--- a/r-package/grf/tests/testthat/test_forest_summaries.R
+++ b/r-package/grf/tests/testthat/test_forest_summaries.R
@@ -199,6 +199,6 @@ test_that("best linear projection works with edge case input types", {
   # a single covariate
   blp.single.covariate <- best_linear_projection(forest, X[, 1])
   # a forest trained with clusters, and subset equal to only one of the clusters
-  blp.single.cluster <- best_linear_projection(forest, X[, 1], subset = which(forest.clustered$clusters == 1))
-  expect_equal(1, 1)
+  expect_error(best_linear_projection(forest.clustered, X[, 1], subset = which(forest.clustered$clusters == 1)),
+               regexp = "subset specifies too few distinct units")
 })

--- a/r-package/grf/tests/testthat/test_forest_summaries.R
+++ b/r-package/grf/tests/testthat/test_forest_summaries.R
@@ -200,5 +200,5 @@ test_that("best linear projection works with edge case input types", {
   blp.single.covariate <- best_linear_projection(forest, X[, 1])
   # a forest trained with clusters, and subset equal to only one of the clusters
   expect_error(best_linear_projection(forest.clustered, X[, 1], subset = which(forest.clustered$clusters == 1)),
-               regexp = "The passed subset specifies too few distinct units.")
+               regexp = "The specified subset must contain units from more than one cluster.")
 })


### PR DESCRIPTION
When calculating a treatment summary statistic, if a user specifies `subset` to be equal only one of the clusters, there is an error.

```R
n <- 200
p <- 10
X <- matrix(rnorm(n * p), n, p)
W <- rbinom(n, 1, 1 / (1 + exp(-X[, 2]))) + rnorm(n)
Y <- pmax(X[, 1], 0) * W + X[, 2] + pmin(X[, 3], 0) + rnorm(n)
cf <- causal_forest(X, Y, W, num.trees = 50, clusters = c(rep(1, 100), rep(2, 100)))
average_partial_effect(cf, subset = cf$clusters == 1)
 Error in `contrasts<-`(`*tmp*`, value = contr.funs[1 + isOF[nn]]) : 
  contrasts can be applied only to factors with 2 or more levels 
```

Add a more informative error message by checking the number of distinct observations after subsetting. Affected functions:

best_linear_projection (fixes previous mistake)
average_partial_effect
average_late
average_treatment_effect

Note: @swager [this line](https://github.com/grf-labs/grf/blob/master/r-package/grf/R/average_partial_effect.R#L123) line will always be false...? (but the output will be the same)

Closes #628 (Thanks @gcasamat)