### PR TITLE
Set splitting rule scratch arrays to subsample size

### DIFF
--- a/core/src/splitting/factory/InstrumentalSplittingRuleFactory.cpp
+++ b/core/src/splitting/factory/InstrumentalSplittingRuleFactory.cpp
@@ -20,10 +20,10 @@
 
 namespace grf {
 
-std::unique_ptr<SplittingRule> InstrumentalSplittingRuleFactory::create(const Data& data,
+std::unique_ptr<SplittingRule> InstrumentalSplittingRuleFactory::create(size_t max_num_unique_values,
                                                                         const TreeOptions& options) const {
   return std::unique_ptr<SplittingRule>(new InstrumentalSplittingRule(
-      data.get_num_rows(),
+      max_num_unique_values,
       options.get_min_node_size(),
       options.get_alpha(),
       options.get_imbalance_penalty()));

--- a/core/src/splitting/factory/InstrumentalSplittingRuleFactory.h
+++ b/core/src/splitting/factory/InstrumentalSplittingRuleFactory.h
@@ -35,7 +35,7 @@ namespace grf {
 class InstrumentalSplittingRuleFactory final: public SplittingRuleFactory {
 public:
   InstrumentalSplittingRuleFactory() = default;
-  std::unique_ptr<SplittingRule> create(const Data& data,
+  std::unique_ptr<SplittingRule> create(size_t max_num_unique_values,
                                         const TreeOptions& options) const;
 private:
   DISALLOW_COPY_AND_ASSIGN(InstrumentalSplittingRuleFactory);

--- a/core/src/splitting/factory/ProbabilitySplittingRuleFactory.cpp
+++ b/core/src/splitting/factory/ProbabilitySplittingRuleFactory.cpp
@@ -24,10 +24,10 @@ namespace grf {
 ProbabilitySplittingRuleFactory::ProbabilitySplittingRuleFactory(size_t num_classes):
     num_classes(num_classes) {}
 
-std::unique_ptr<SplittingRule> ProbabilitySplittingRuleFactory::create(const Data& data,
+std::unique_ptr<SplittingRule> ProbabilitySplittingRuleFactory::create(size_t max_num_unique_values,
                                                                        const TreeOptions& options) const {
   return std::unique_ptr<SplittingRule>(new ProbabilitySplittingRule(
-      data.get_num_rows(),
+      max_num_unique_values,
       num_classes,
       options.get_alpha(),
       options.get_imbalance_penalty()));

--- a/core/src/splitting/factory/ProbabilitySplittingRuleFactory.h
+++ b/core/src/splitting/factory/ProbabilitySplittingRuleFactory.h
@@ -34,7 +34,7 @@ namespace grf {
 class ProbabilitySplittingRuleFactory final: public SplittingRuleFactory {
 public:
   ProbabilitySplittingRuleFactory(size_t num_classes);
-  std::unique_ptr<SplittingRule> create(const Data& data,
+  std::unique_ptr<SplittingRule> create(size_t max_num_unique_values,
                                         const TreeOptions& options) const;
 
 private:

--- a/core/src/splitting/factory/RegressionSplittingRuleFactory.cpp
+++ b/core/src/splitting/factory/RegressionSplittingRuleFactory.cpp
@@ -20,10 +20,10 @@
 
 namespace grf {
 
-std::unique_ptr<SplittingRule> RegressionSplittingRuleFactory::create(const Data& data,
+std::unique_ptr<SplittingRule> RegressionSplittingRuleFactory::create(size_t max_num_unique_values,
                                                                       const TreeOptions& options) const {
   return std::unique_ptr<SplittingRule>(new RegressionSplittingRule(
-      data.get_num_rows(),
+      max_num_unique_values,
       options.get_alpha(),
       options.get_imbalance_penalty()));
 }

--- a/core/src/splitting/factory/RegressionSplittingRuleFactory.h
+++ b/core/src/splitting/factory/RegressionSplittingRuleFactory.h
@@ -32,7 +32,7 @@ namespace grf {
 class RegressionSplittingRuleFactory final: public SplittingRuleFactory {
 public:
   RegressionSplittingRuleFactory() = default;
-  std::unique_ptr<SplittingRule> create(const Data& data,
+  std::unique_ptr<SplittingRule> create(size_t max_num_unique_values,
                                         const TreeOptions& options) const;
 private:
   DISALLOW_COPY_AND_ASSIGN(RegressionSplittingRuleFactory);

--- a/core/src/splitting/factory/SplittingRuleFactory.h
+++ b/core/src/splitting/factory/SplittingRuleFactory.h
@@ -31,7 +31,7 @@ public:
 
   virtual ~SplittingRuleFactory() = default;
 
-  virtual std::unique_ptr<SplittingRule> create(const Data& data,
+  virtual std::unique_ptr<SplittingRule> create(size_t max_num_unique_values,
                                                 const TreeOptions& options) const = 0;
 };
 

--- a/core/src/tree/TreeTrainer.cpp
+++ b/core/src/tree/TreeTrainer.cpp
@@ -57,8 +57,9 @@ std::unique_ptr<Tree> TreeTrainer::train(const Data& data,
     sampler.sample_from_clusters(clusters, nodes[0]);
   }
 
+  // nodes[0].size() is the number of samples subsampled for this tree.
   std::unique_ptr<SplittingRule> splitting_rule = splitting_rule_factory->create(
-      data, options);
+      nodes[0].size(), options);
 
   size_t num_open_nodes = 1;
   size_t i = 0;

--- a/core/test/splitting/SplittingRuleInvarianceTest.cpp
+++ b/core/test/splitting/SplittingRuleInvarianceTest.cpp
@@ -36,7 +36,7 @@ void run_one_split(const Data& data,
                    size_t num_features,
                    size_t& split_var,
                    double& split_value) {
-  std::unique_ptr<SplittingRule> splitting_rule = splitting_rule_factory->create(data, options);
+  std::unique_ptr<SplittingRule> splitting_rule = splitting_rule_factory->create(data.get_num_rows(), options);
   std::vector<size_t> possible_split_vars(num_features - 1);
   // Fill with {0, 1, 2, ..., Xj}
   std::iota(possible_split_vars.begin(), possible_split_vars.end(), 0);


### PR DESCRIPTION
A tighter upper bound for the length needed for a splitting rule's scratch array is the size of the subsample used to grow the tree, as mentioned in https://github.com/grf-labs/grf/pull/635#discussion_r395917188 by @jtibshirani .

This PR updates the SplittingRuleFactory constructor with a new length argument.

