### PR TITLE
Travis fix for R 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ branches:
   only:
     - master
 
-r_binary_packages:
+r_packages:
   - devtools
   - testthat
   - roxygen2
@@ -16,8 +16,6 @@ r_binary_packages:
   - glmnet
   - knitr
   - rmarkdown
-
-r_packages:
   - pkgdown
 
 matrix:


### PR DESCRIPTION
Install all R packages from source as the Travis build complains of packages being built for  R < 4.0. This can be reverted once linux binary releases are available for R 4.0