### PR TITLE
Remove estimate_error from DefaultPredictionCollector

### DIFF
--- a/core/src/prediction/collector/DefaultPredictionCollector.cpp
+++ b/core/src/prediction/collector/DefaultPredictionCollector.cpp
@@ -35,6 +35,7 @@ std::vector<Prediction> DefaultPredictionCollector::collect_predictions(
     const std::vector<std::vector<bool>>& valid_trees_by_sample,
     bool estimate_variance,
     bool estimate_error) const {
+  // Note: estimate_error is not necessary for the DefaultPredictionStrategy and is unused here.
 
   size_t num_samples = data.get_num_rows();
   std::vector<uint> thread_ranges;
@@ -59,7 +60,6 @@ std::vector<Prediction> DefaultPredictionCollector::collect_predictions(
                                  std::ref(leaf_nodes_by_tree),
                                  std::ref(valid_trees_by_sample),
                                  estimate_variance,
-                                 estimate_error,
                                  start_index,
                                  num_samples_batch));
   }
@@ -81,11 +81,10 @@ std::vector<Prediction> DefaultPredictionCollector::collect_predictions_batch(
     const std::vector<std::vector<size_t>>& leaf_nodes_by_tree,
     const std::vector<std::vector<bool>>& valid_trees_by_sample,
     bool estimate_variance,
-    bool estimate_error,
     size_t start,
     size_t num_samples) const {
   size_t num_trees = forest.get_trees().size();
-  bool record_leaf_samples = estimate_variance || estimate_error;
+  bool record_leaf_samples = estimate_variance;
 
   std::vector<Prediction> predictions;
   predictions.reserve(num_samples);

--- a/core/src/prediction/collector/DefaultPredictionCollector.cpp
+++ b/core/src/prediction/collector/DefaultPredictionCollector.cpp
@@ -35,7 +35,6 @@ std::vector<Prediction> DefaultPredictionCollector::collect_predictions(
     const std::vector<std::vector<bool>>& valid_trees_by_sample,
     bool estimate_variance,
     bool estimate_error) const {
-  // Note: estimate_error is not necessary for the DefaultPredictionStrategy and is unused here.
 
   size_t num_samples = data.get_num_rows();
   std::vector<uint> thread_ranges;

--- a/core/src/prediction/collector/DefaultPredictionCollector.cpp
+++ b/core/src/prediction/collector/DefaultPredictionCollector.cpp
@@ -104,7 +104,7 @@ std::vector<Prediction> DefaultPredictionCollector::collect_predictions_batch(
         size_t node = leaf_nodes.at(sample);
 
         const std::unique_ptr<Tree>& tree = forest.get_trees()[tree_index];
-        std::vector<std::vector<size_t>> leaf_samples = tree->get_leaf_samples();
+        const std::vector<std::vector<size_t>>& leaf_samples = tree->get_leaf_samples();
         samples_by_tree.push_back(leaf_samples.at(node));
       }
     }

--- a/core/src/prediction/collector/DefaultPredictionCollector.h
+++ b/core/src/prediction/collector/DefaultPredictionCollector.h
@@ -45,7 +45,6 @@ private:
                                                     const std::vector<std::vector<size_t>>& leaf_nodes_by_tree,
                                                     const std::vector<std::vector<bool>>& valid_trees_by_sample,
                                                     bool estimate_variance,
-                                                    bool estimate_error,
                                                     size_t start,
                                                     size_t num_samples) const;
 

--- a/core/src/prediction/collector/DefaultPredictionCollector.h
+++ b/core/src/prediction/collector/DefaultPredictionCollector.h
@@ -30,6 +30,11 @@ class DefaultPredictionCollector final: public PredictionCollector {
 public:
   DefaultPredictionCollector(std::unique_ptr<DefaultPredictionStrategy> strategy, uint num_threads);
 
+  /**
+   * Collect predictions and variance estimates computed by the DefaultPredictionStrategy.
+   *
+   * Note: estimate_error is unused as this prediction strategy does not implement error estimates.
+   */
   std::vector<Prediction> collect_predictions(const Forest& forest,
                                               const Data& train_data,
                                               const Data& data,


### PR DESCRIPTION
The [DefaultPredictionStrategy](https://github.com/grf-labs/grf/blob/master/core/src/prediction/DefaultPredictionStrategy.h) does not implement [compute_error](https://github.com/grf-labs/grf/blob/master/core/src/prediction/OptimizedPredictionStrategy.h#L104) so we can avoid [recording](https://github.com/grf-labs/grf/blob/master/core/src/prediction/collector/DefaultPredictionCollector.cpp#L98) leaf samples.

When recording leaf samples, also avoid an accidental copy (this will give a speedup for predictions with the DefaultPredictionStrategy).

Future follow up: this step may delegated to the `SampleWeightComputer`

