### PR TITLE
Replace \dontrun with \donttest in R docstrings

### DIFF
--- a/r-package/grf/R/analysis_tools.R
+++ b/r-package/grf/R/analysis_tools.R
@@ -19,7 +19,7 @@
 #'     notation of the paper).
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Train a quantile forest.
 #' n <- 50
 #' p <- 10
@@ -113,7 +113,7 @@ get_tree <- function(forest, index) {
 #' is the number of times the feature was split on at that depth.
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Train a quantile forest.
 #' n <- 50
 #' p <- 10
@@ -143,7 +143,7 @@ split_frequencies <- function(forest, max.depth = 4) {
 #' @return A list specifying an 'importance value' for each feature.
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Train a quantile forest.
 #' n <- 50
 #' p <- 10
@@ -180,7 +180,7 @@ variable_importance <- function(forest, decay.exponent = 2, max.depth = 4) {
 #'         training data. The value at (i, j) gives the weight of training sample j for test sample i.
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' p <- 10
 #' n <- 100
 #' X <- matrix(2 * runif(n * p) - 1, n, p)

--- a/r-package/grf/R/average_partial_effect.R
+++ b/r-package/grf/R/average_partial_effect.R
@@ -30,7 +30,7 @@
 #'                               (only applies when debiasing.weights = NULL)
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' n <- 2000
 #' p <- 10
 #' X <- matrix(rnorm(n * p), n, p)

--- a/r-package/grf/R/average_treatment_effect.R
+++ b/r-package/grf/R/average_treatment_effect.R
@@ -56,7 +56,7 @@
 #' average_treatment_effect(c.forest, target.sample = "treated")
 #'
 #' # Estimate the conditional average treatment effect on samples with positive X[,1].
-#' average_treatment_effect(c.forest, target.sample = "all", X[, 1] > 0)
+#' average_treatment_effect(c.forest, target.sample = "all", subset = X[, 1] > 0)
 #' }
 #'
 #' @return An estimate of the average treatment effect, along with standard error.

--- a/r-package/grf/R/average_treatment_effect.R
+++ b/r-package/grf/R/average_treatment_effect.R
@@ -34,7 +34,7 @@
 #'               the treatment Wi or the outcome Yi.
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Train a causal forest.
 #' n <- 50
 #' p <- 10

--- a/r-package/grf/R/boosted_regression_forest.R
+++ b/r-package/grf/R/boosted_regression_forest.R
@@ -68,7 +68,7 @@
 #'         contains the trained regression forest for each step.
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Train a boosted regression forest.
 #' n <- 50
 #' p <- 10
@@ -219,7 +219,7 @@ boosted_regression_forest <- function(X, Y,
 #' @return A vector of predictions.
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Train a boosted regression forest.
 #' n <- 50
 #' p <- 10

--- a/r-package/grf/R/causal_forest.R
+++ b/r-package/grf/R/causal_forest.R
@@ -84,7 +84,7 @@
 #'  then tuning information will be included through the `tuning.output` attribute.
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Train a causal forest.
 #' n <- 500
 #' p <- 10
@@ -320,7 +320,7 @@ causal_forest <- function(X, Y, W,
 #'         enough forests to make the 'excess.error' negligible.
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Train a causal forest.
 #' n <- 100
 #' p <- 10

--- a/r-package/grf/R/custom_forest.R
+++ b/r-package/grf/R/custom_forest.R
@@ -46,7 +46,7 @@
 #' @return A trained regression forest object.
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Train a custom forest.
 #' n <- 50
 #' p <- 10
@@ -115,7 +115,7 @@ custom_forest <- function(X, Y,
 #' @return Vector of predictions.
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Train a custom forest.
 #' n <- 50
 #' p <- 10

--- a/r-package/grf/R/forest_summary.R
+++ b/r-package/grf/R/forest_summary.R
@@ -18,7 +18,7 @@
 #'             Randomized Experiments." arXiv preprint arXiv:1712.04802 (2017).
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' n <- 800
 #' p <- 5
 #' X <- matrix(rnorm(n * p), n, p)
@@ -117,7 +117,7 @@ test_calibration <- function(forest) {
 #'             other structural functions." arXiv preprint arXiv:1702.06240 (2017).
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' n <- 800
 #' p <- 5
 #' X <- matrix(rnorm(n * p), n, p)

--- a/r-package/grf/R/local_linear_forest.R
+++ b/r-package/grf/R/local_linear_forest.R
@@ -70,7 +70,7 @@
 #' @return A trained local linear forest object.
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Train a standard regression forest.
 #' n <- 50
 #' p <- 10
@@ -231,7 +231,7 @@ ll_regression_forest <- function(X, Y,
 #' @return A vector of predictions.
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Train the forest.
 #' n <- 50
 #' p <- 5

--- a/r-package/grf/R/merge_forests.R
+++ b/r-package/grf/R/merge_forests.R
@@ -14,7 +14,7 @@
 #' @return A single forest containing all the trees in each forest in the input list.
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Train standard regression forests
 #' n <- 50
 #' p <- 10

--- a/r-package/grf/R/plot.R
+++ b/r-package/grf/R/plot.R
@@ -112,7 +112,7 @@ export_graphviz <- function(tree, include.na.path) {
 #'
 #' @method plot grf_tree
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Save the plot of a tree in the causal forest.
 #' install.packages("DiagrammeR")
 #' install.packages("DiagrammeRsvg")

--- a/r-package/grf/R/plot.R
+++ b/r-package/grf/R/plot.R
@@ -112,7 +112,7 @@ export_graphviz <- function(tree, include.na.path) {
 #'
 #' @method plot grf_tree
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' # Plot a tree in the forest (requires the `DiagrammeR` package).
 #' n <- 500
 #' p <- 10
@@ -121,9 +121,6 @@ export_graphviz <- function(tree, include.na.path) {
 #' Y <- pmax(X[, 1], 0) * W + X[, 2] + pmin(X[, 3], 0) + rnorm(n)
 #' c.forest <- causal_forest(X, Y, W)
 #' plot(tree <- get_tree(c.forest, 1))
-#' }
-#'
-#' \dontrun{
 #' # Saving a plot in .svg can be done with the `DiagrammeRsvg` package.
 #' install.packages("DiagrammeRsvg")
 #' tree.plot = plot(tree)

--- a/r-package/grf/R/plot.R
+++ b/r-package/grf/R/plot.R
@@ -113,19 +113,22 @@ export_graphviz <- function(tree, include.na.path) {
 #' @method plot grf_tree
 #' @examples
 #' \donttest{
-#' # Save the plot of a tree in the causal forest.
-#' install.packages("DiagrammeR")
-#' install.packages("DiagrammeRsvg")
+#' # Plot a tree in the forest (requires the `DiagrammeR` package).
 #' n <- 500
 #' p <- 10
 #' X <- matrix(rnorm(n * p), n, p)
 #' W <- rbinom(n, 1, 0.5)
 #' Y <- pmax(X[, 1], 0) * W + X[, 2] + pmin(X[, 3], 0) + rnorm(n)
 #' c.forest <- causal_forest(X, Y, W)
-#' #save the first tree in the forest as plot.svg
-#' tree.plot = plot(get_tree(c.forest, 1))
-#' cat(DiagrammeRsvg::export_svg(tree.plot), file='plot.svg')
-#'}
+#' plot(tree <- get_tree(c.forest, 1))
+#' }
+#'
+#' \dontrun{
+#' # Saving a plot in .svg can be done with the `DiagrammeRsvg` package.
+#' install.packages("DiagrammeRsvg")
+#' tree.plot = plot(tree)
+#' cat(DiagrammeRsvg::export_svg(tree.plot), file = 'plot.svg')
+#' }
 #' @export
 plot.grf_tree <- function(x, include.na.path = NULL, ...) {
   if (!requireNamespace("DiagrammeR", quietly = TRUE)) {

--- a/r-package/grf/R/quantile_forest.R
+++ b/r-package/grf/R/quantile_forest.R
@@ -51,7 +51,7 @@
 #' @return A trained quantile forest object.
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Generate data.
 #' n <- 50
 #' p <- 10
@@ -142,7 +142,7 @@ quantile_forest <- function(X, Y,
 #' @return Predictions at each test point for each desired quantile.
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Train a quantile forest.
 #' n <- 50
 #' p <- 10

--- a/r-package/grf/R/regression_forest.R
+++ b/r-package/grf/R/regression_forest.R
@@ -64,7 +64,7 @@
 #'  then tuning information will be included through the `tuning.output` attribute.
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Train a standard regression forest.
 #' n <- 500
 #' p <- 10
@@ -212,7 +212,7 @@ regression_forest <- function(X, Y,
 #'         enough forests to make the 'excess.error' negligible.
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Train a standard regression forest.
 #' n <- 50
 #' p <- 10

--- a/r-package/grf/R/survival_forest.R
+++ b/r-package/grf/R/survival_forest.R
@@ -58,7 +58,7 @@
 #'   "Random survival forests." The Annals of Applied Statistics 2.3 (2008): 841-860.
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Train a standard survival forest.
 #' n <- 2000
 #' p <- 5
@@ -188,7 +188,7 @@ survival_forest <- function(X, Y, D,
 #' @return Vector of predictions.
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Train a standard survival forest.
 #' n <- 2000
 #' p <- 5

--- a/r-package/grf/R/tune_causal_forest.R
+++ b/r-package/grf/R/tune_causal_forest.R
@@ -65,7 +65,7 @@
 #'         error ('error').
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Find the optimal tuning parameters.
 #' n <- 500
 #' p <- 10

--- a/r-package/grf/R/tune_instrumental_forest.R
+++ b/r-package/grf/R/tune_instrumental_forest.R
@@ -70,7 +70,7 @@
 #'         error ('error').
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Find the optimal tuning parameters.
 #' n <- 3000; p <- 5
 #' X <- matrix(rbinom(n*p, 1, 0.5), n, p)

--- a/r-package/grf/R/tune_local_linear_causal_forest.R
+++ b/r-package/grf/R/tune_local_linear_causal_forest.R
@@ -13,7 +13,7 @@
 #' @return A list of lambdas tried, corresponding errors, and optimal ridge penalty lambda.
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Find the optimal tuning parameters.
 #' n <- 50
 #' p <- 10

--- a/r-package/grf/R/tune_local_linear_forest.R
+++ b/r-package/grf/R/tune_local_linear_forest.R
@@ -13,7 +13,7 @@
 #' @return A list of lambdas tried, corresponding errors, and optimal ridge penalty lambda.
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Find the optimal tuning parameters.
 #' n <- 500
 #' p <- 10

--- a/r-package/grf/R/tune_regression_forest.R
+++ b/r-package/grf/R/tune_regression_forest.R
@@ -60,7 +60,7 @@
 #'         error ('error').
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Find the optimal tuning parameters.
 #' n <- 500
 #' p <- 10


### PR DESCRIPTION
With R [release 4.0](https://stat.ethz.ch/pipermail/r-announce/2020/000653.html) `R CMD check` now automatically checks the docstring examples:

```
* R CMD check --as-cran now runs \donttest examples (which are run
      by example()) instead of instructing the tester to do so.  This
      can be temporarily circumvented during development by setting
      environment variable _R_CHECK_DONTTEST_EXAMPLES_ to a false
      value.
```

This prevents broken documentation examples from sneaking into a release.

It also has the benefit of rendering the code examples in the online documentation:

![Screen Shot 2020-04-30 at 22 57 42](https://user-images.githubusercontent.com/7185264/80786106-6f00b180-8b37-11ea-92bd-f8af6d05370b.png)

(A CRAN reviewer for policytree pointed out replacing \dontrun with \donttest)