### PR TITLE
Add pkgdown workaround for vignette urls

### DIFF
--- a/r-package/grf/pkgdown/extra.js
+++ b/r-package/grf/pkgdown/extra.js
@@ -7,4 +7,8 @@ $(function() {
         /* Replace '/R/' with '/r-package/grf/R/' in all external links to .R files of grf GitHub repo */
         $('a[href^="https://github.com/grf-labs/grf/blob/master/R"][href*=".R"]').attr('href', (i, val) => { return val.replace('/R/', '/r-package/grf/R/'); });
     }
+    if(window.location.pathname.toLocaleLowerCase().indexOf('/articles') != -1) {
+        /* Replace '/vignettes/' with '/r-package/grf/vignettes/' in all external links to .Rmd files of grf GitHub repo */
+        $('a[href^="https://github.com/grf-labs/grf/blob/master/vignettes"][href*=".Rmd"]').attr('href', (i, val) => { return val.replace('/vignettes/', '/r-package/grf/vignettes/'); });
+    }
 });


### PR DESCRIPTION
This is an addition to #575 which corrects the online vignette links.

Example:

Under "Source:" in https://grf-labs.github.io/grf/articles/llf.html the link will now lead to the vignette source file. 