### PR TITLE
Use do.call.rcpp in forest prediction functions

### DIFF
--- a/r-package/grf/R/RcppExports.R
+++ b/r-package/grf/R/RcppExports.R
@@ -29,12 +29,12 @@ causal_predict_oob <- function(forest_object, train_matrix, sparse_train_matrix,
     .Call('_grf_causal_predict_oob', PACKAGE = 'grf', forest_object, train_matrix, sparse_train_matrix, outcome_index, treatment_index, num_threads, estimate_variance)
 }
 
-ll_causal_predict <- function(forest, input_data, training_data, sparse_input_data, sparse_training_data, outcome_index, treatment_index, lambdas, use_weighted_penalty, linear_correction_variables, num_threads, estimate_variance) {
-    .Call('_grf_ll_causal_predict', PACKAGE = 'grf', forest, input_data, training_data, sparse_input_data, sparse_training_data, outcome_index, treatment_index, lambdas, use_weighted_penalty, linear_correction_variables, num_threads, estimate_variance)
+ll_causal_predict <- function(forest_object, train_matrix, sparse_train_matrix, outcome_index, treatment_index, test_matrix, sparse_test_matrix, ll_lambda, ll_weight_penalty, linear_correction_variables, num_threads, estimate_variance) {
+    .Call('_grf_ll_causal_predict', PACKAGE = 'grf', forest_object, train_matrix, sparse_train_matrix, outcome_index, treatment_index, test_matrix, sparse_test_matrix, ll_lambda, ll_weight_penalty, linear_correction_variables, num_threads, estimate_variance)
 }
 
-ll_causal_predict_oob <- function(forest, input_data, sparse_input_data, outcome_index, treatment_index, lambdas, use_weighted_penalty, linear_correction_variables, num_threads, estimate_variance) {
-    .Call('_grf_ll_causal_predict_oob', PACKAGE = 'grf', forest, input_data, sparse_input_data, outcome_index, treatment_index, lambdas, use_weighted_penalty, linear_correction_variables, num_threads, estimate_variance)
+ll_causal_predict_oob <- function(forest_object, train_matrix, sparse_train_matrix, outcome_index, treatment_index, ll_lambda, ll_weight_penalty, linear_correction_variables, num_threads, estimate_variance) {
+    .Call('_grf_ll_causal_predict_oob', PACKAGE = 'grf', forest_object, train_matrix, sparse_train_matrix, outcome_index, treatment_index, ll_lambda, ll_weight_penalty, linear_correction_variables, num_threads, estimate_variance)
 }
 
 custom_train <- function(train_matrix, sparse_train_matrix, outcome_index, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed) {
@@ -85,16 +85,16 @@ regression_predict_oob <- function(forest_object, train_matrix, sparse_train_mat
     .Call('_grf_regression_predict_oob', PACKAGE = 'grf', forest_object, train_matrix, sparse_train_matrix, outcome_index, num_threads, estimate_variance)
 }
 
-ll_regression_train <- function(train_matrix, sparse_train_matrix, outcome_index, sample_weight_index, split_lambda, weight_penalty, ll_split_variables, ll_split_cutoff, overall_beta, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, num_threads, seed) {
-    .Call('_grf_ll_regression_train', PACKAGE = 'grf', train_matrix, sparse_train_matrix, outcome_index, sample_weight_index, split_lambda, weight_penalty, ll_split_variables, ll_split_cutoff, overall_beta, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, num_threads, seed)
+ll_regression_train <- function(train_matrix, sparse_train_matrix, outcome_index, sample_weight_index, ll_split_lambda, ll_split_weight_penalty, ll_split_variables, ll_split_cutoff, overall_beta, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, num_threads, seed) {
+    .Call('_grf_ll_regression_train', PACKAGE = 'grf', train_matrix, sparse_train_matrix, outcome_index, sample_weight_index, ll_split_lambda, ll_split_weight_penalty, ll_split_variables, ll_split_cutoff, overall_beta, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, num_threads, seed)
 }
 
-ll_regression_predict <- function(forest, train_matrix, sparse_train_matrix, outcome_index, test_matrix, sparse_test_matrix, lambdas, weight_penalty, linear_correction_variables, num_threads, estimate_variance) {
-    .Call('_grf_ll_regression_predict', PACKAGE = 'grf', forest, train_matrix, sparse_train_matrix, outcome_index, test_matrix, sparse_test_matrix, lambdas, weight_penalty, linear_correction_variables, num_threads, estimate_variance)
+ll_regression_predict <- function(forest_object, train_matrix, sparse_train_matrix, outcome_index, test_matrix, sparse_test_matrix, ll_lambda, ll_weight_penalty, linear_correction_variables, num_threads, estimate_variance) {
+    .Call('_grf_ll_regression_predict', PACKAGE = 'grf', forest_object, train_matrix, sparse_train_matrix, outcome_index, test_matrix, sparse_test_matrix, ll_lambda, ll_weight_penalty, linear_correction_variables, num_threads, estimate_variance)
 }
 
-ll_regression_predict_oob <- function(forest, train_matrix, sparse_train_matrix, outcome_index, lambdas, weight_penalty, linear_correction_variables, num_threads, estimate_variance) {
-    .Call('_grf_ll_regression_predict_oob', PACKAGE = 'grf', forest, train_matrix, sparse_train_matrix, outcome_index, lambdas, weight_penalty, linear_correction_variables, num_threads, estimate_variance)
+ll_regression_predict_oob <- function(forest_object, train_matrix, sparse_train_matrix, outcome_index, ll_lambda, ll_weight_penalty, linear_correction_variables, num_threads, estimate_variance) {
+    .Call('_grf_ll_regression_predict_oob', PACKAGE = 'grf', forest_object, train_matrix, sparse_train_matrix, outcome_index, ll_lambda, ll_weight_penalty, linear_correction_variables, num_threads, estimate_variance)
 }
 
 survival_train <- function(train_matrix, sparse_train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, alpha, num_failures, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed) {

--- a/r-package/grf/R/causal_forest.R
+++ b/r-package/grf/R/causal_forest.R
@@ -391,7 +391,7 @@ predict.causal_forest <- function(object, newdata = NULL,
                    linear.correction.variables = linear.correction.variables)
 
    if (!is.null(newdata)) {
-     validate_newdata(newdata, object$X.orig, allow.na = allow.na)
+     validate_newdata(newdata, X, allow.na = allow.na)
      test.data <- create_test_matrices(newdata)
      if (!local.linear) {
        ret <- do.call.rcpp(causal_predict, c(train.data, test.data, args))

--- a/r-package/grf/R/quantile_forest.R
+++ b/r-package/grf/R/quantile_forest.R
@@ -172,23 +172,19 @@ predict.quantile_forest <- function(object,
   }
 
   num.threads <- validate_num_threads(num.threads)
-
   forest.short <- object[-which(names(object) == "X.orig")]
-
   X <- object[["X.orig"]]
   train.data <- create_train_matrices(X, outcome = object[["Y.orig"]])
 
+  args <- list(forest.object = forest.short,
+               quantiles = quantiles,
+               num.threads = num.threads)
+
   if (!is.null(newdata)) {
     validate_newdata(newdata, object$X.orig, allow.na = TRUE)
-    data <- create_train_matrices(newdata)
-    quantile_predict(
-      forest.short, quantiles, train.data$train.matrix, train.data$sparse.train.matrix,
-      train.data$outcome.index, data$train.matrix, data$sparse.train.matrix, num.threads
-    )
+    test.data <- create_test_matrices(newdata)
+    do.call.rcpp(quantile_predict, c(train.data, test.data, args))
   } else {
-    quantile_predict_oob(
-      forest.short, quantiles, train.data$train.matrix, train.data$sparse.train.matrix,
-      train.data$outcome.index, num.threads
-    )
+    do.call.rcpp(quantile_predict_oob, c(train.data, args))
   }
 }

--- a/r-package/grf/R/regression_forest.R
+++ b/r-package/grf/R/regression_forest.R
@@ -250,12 +250,10 @@ predict.regression_forest <- function(object, newdata = NULL,
     return(data.frame(
       predictions = object$predictions,
       debiased.error = object$debiased.error,
-      excess.error = object$excess.error
-    ))
+      excess.error = object$excess.error))
   }
 
   num.threads <- validate_num_threads(num.threads)
-
   forest.short <- object[-which(names(object) == "X.orig")]
   X <- object[["X.orig"]]
   train.data <- create_train_matrices(X, outcome = object[["Y.orig"]])
@@ -266,8 +264,7 @@ predict.regression_forest <- function(object, newdata = NULL,
     if (is.null(ll.lambda)) {
       ll.regularization.path <- tune_ll_regression_forest(
         object, linear.correction.variables,
-        ll.weight.penalty, num.threads
-      )
+        ll.weight.penalty, num.threads)
       ll.lambda <- ll.regularization.path$lambda.min
     } else {
       ll.lambda <- validate_ll_lambda(ll.lambda)
@@ -276,34 +273,28 @@ predict.regression_forest <- function(object, newdata = NULL,
     # subtract 1 to account for C++ indexing
     linear.correction.variables <- linear.correction.variables - 1
   }
+  args <- list(forest.object = forest.short,
+               num.threads = num.threads,
+               estimate.variance = estimate.variance)
+  ll.args <- list(ll.lambda = ll.lambda,
+                  ll.weight.penalty = ll.weight.penalty,
+                  linear.correction.variables = linear.correction.variables)
 
   if (!is.null(newdata)) {
-    data <- create_train_matrices(newdata)
     validate_newdata(newdata, X, allow.na = allow.na)
+    test.data <- create_test_matrices(newdata)
     if (!local.linear) {
-      ret <- regression_predict(
-        forest.short, train.data$train.matrix, train.data$sparse.train.matrix, train.data$outcome.index,
-        data$train.matrix, data$sparse.train.matrix, num.threads, estimate.variance
-      )
+      ret <- do.call.rcpp(regression_predict, c(train.data, test.data, args))
     } else {
-      ret <- ll_regression_predict(
-        forest.short, train.data$train.matrix, train.data$sparse.train.matrix, train.data$outcome.index,
-        data$train.matrix, data$sparse.train.matrix, ll.lambda, ll.weight.penalty, linear.correction.variables,
-        num.threads, estimate.variance
-      )
+      args <- modifyList(args, ll.args)
+      ret <- do.call.rcpp(ll_regression_predict, c(train.data, test.data, args))
     }
   } else {
-    data <- create_train_matrices(X)
     if (!local.linear) {
-      ret <- regression_predict_oob(
-        forest.short, train.data$train.matrix, train.data$sparse.train.matrix, train.data$outcome.index,
-        num.threads, estimate.variance
-      )
+      ret <- do.call.rcpp(regression_predict_oob, c(train.data, args))
     } else {
-      ret <- ll_regression_predict_oob(
-        forest.short, train.data$train.matrix, train.data$sparse.train.matrix, train.data$outcome.index,
-        ll.lambda, ll.weight.penalty, linear.correction.variables, num.threads, estimate.variance
-      )
+      args <- modifyList(args, ll.args)
+      ret <- do.call.rcpp(ll_regression_predict_oob, c(train.data, args))
     }
   }
 

--- a/r-package/grf/bindings/CausalForestBindings.cpp
+++ b/r-package/grf/bindings/CausalForestBindings.cpp
@@ -124,29 +124,28 @@ Rcpp::List causal_predict_oob(Rcpp::List forest_object,
 }
 
 // [[Rcpp::export]]
-Rcpp::List ll_causal_predict(Rcpp::List forest,
-                             Rcpp::NumericMatrix input_data,
-                             Rcpp::NumericMatrix training_data,
-                             Eigen::SparseMatrix<double> sparse_input_data,
-                             Eigen::SparseMatrix<double> sparse_training_data,
+Rcpp::List ll_causal_predict(Rcpp::List forest_object,
+                             Rcpp::NumericMatrix train_matrix,
+                             Eigen::SparseMatrix<double> sparse_train_matrix,
                              size_t outcome_index,
                              size_t treatment_index,
-                             std::vector<double> lambdas,
-                             bool use_weighted_penalty,
+                             Rcpp::NumericMatrix test_matrix,
+                             Eigen::SparseMatrix<double> sparse_test_matrix,
+                             std::vector<double> ll_lambda,
+                             bool ll_weight_penalty,
                              std::vector<size_t> linear_correction_variables,
                              unsigned int num_threads,
                              bool estimate_variance) {
-  std::unique_ptr<Data> data = RcppUtilities::convert_data(input_data, sparse_input_data);
-  std::unique_ptr<Data> train_data = RcppUtilities::convert_data(training_data, sparse_training_data);
-
+  std::unique_ptr<Data> train_data = RcppUtilities::convert_data(train_matrix, sparse_train_matrix);
   train_data->set_outcome_index(outcome_index - 1);
   train_data->set_treatment_index(treatment_index - 1);
   train_data->set_instrument_index(treatment_index - 1);
+  std::unique_ptr<Data> data = RcppUtilities::convert_data(test_matrix, sparse_test_matrix);
 
-  Forest deserialized_forest = RcppUtilities::deserialize_forest(forest);
+  Forest deserialized_forest = RcppUtilities::deserialize_forest(forest_object);
 
-  ForestPredictor predictor = ll_causal_predictor(num_threads, lambdas, use_weighted_penalty,
-                                                                 linear_correction_variables);
+  ForestPredictor predictor = ll_causal_predictor(num_threads, ll_lambda, ll_weight_penalty,
+                                                  linear_correction_variables);
   std::vector<Prediction> predictions = predictor.predict(deserialized_forest, *train_data, *data, estimate_variance);
   Rcpp::List result = RcppUtilities::create_prediction_object(predictions);
 
@@ -154,26 +153,26 @@ Rcpp::List ll_causal_predict(Rcpp::List forest,
 }
 
 // [[Rcpp::export]]
-Rcpp::List ll_causal_predict_oob(Rcpp::List forest,
-                                     Rcpp::NumericMatrix input_data,
-                                     Eigen::SparseMatrix<double> sparse_input_data,
-                                     size_t outcome_index,
-                                     size_t treatment_index,
-                                     std::vector<double> lambdas,
-                                     bool use_weighted_penalty,
-                                     std::vector<size_t> linear_correction_variables,
-                                     unsigned int num_threads,
-                                     bool estimate_variance) {
-  std::unique_ptr<Data> data = RcppUtilities::convert_data(input_data, sparse_input_data);
+Rcpp::List ll_causal_predict_oob(Rcpp::List forest_object,
+                                 Rcpp::NumericMatrix train_matrix,
+                                 Eigen::SparseMatrix<double> sparse_train_matrix,
+                                 size_t outcome_index,
+                                 size_t treatment_index,
+                                 std::vector<double> ll_lambda,
+                                 bool ll_weight_penalty,
+                                 std::vector<size_t> linear_correction_variables,
+                                 unsigned int num_threads,
+                                 bool estimate_variance) {
+  std::unique_ptr<Data> data = RcppUtilities::convert_data(train_matrix, sparse_train_matrix);
 
   data->set_outcome_index(outcome_index - 1);
   data->set_treatment_index(treatment_index - 1);
   data->set_instrument_index(treatment_index - 1);
 
-  Forest deserialized_forest = RcppUtilities::deserialize_forest(forest);
+  Forest deserialized_forest = RcppUtilities::deserialize_forest(forest_object);
 
-  ForestPredictor predictor = ll_causal_predictor(num_threads, lambdas, use_weighted_penalty,
-                                                                 linear_correction_variables);
+  ForestPredictor predictor = ll_causal_predictor(num_threads, ll_lambda, ll_weight_penalty,
+                                                  linear_correction_variables);
   std::vector<Prediction> predictions = predictor.predict_oob(deserialized_forest, *data, estimate_variance);
   Rcpp::List result = RcppUtilities::create_prediction_object(predictions);
 

--- a/r-package/grf/bindings/RegressionForestBindings.cpp
+++ b/r-package/grf/bindings/RegressionForestBindings.cpp
@@ -115,8 +115,8 @@ Rcpp::List ll_regression_train(Rcpp::NumericMatrix train_matrix,
                             Eigen::SparseMatrix<double> sparse_train_matrix,
                             size_t outcome_index,
                             size_t sample_weight_index,
-                            double split_lambda,
-                            bool weight_penalty,
+                            double ll_split_lambda,
+                            bool ll_split_weight_penalty,
                             std::vector<size_t> ll_split_variables,
                             size_t ll_split_cutoff,
                             std::vector<double> overall_beta,
@@ -135,7 +135,7 @@ Rcpp::List ll_regression_train(Rcpp::NumericMatrix train_matrix,
                             unsigned int samples_per_cluster,
                             unsigned int num_threads,
                             unsigned int seed) {
-  ForestTrainer trainer = ll_regression_trainer(split_lambda, weight_penalty, overall_beta,
+  ForestTrainer trainer = ll_regression_trainer(ll_split_lambda, ll_split_weight_penalty, overall_beta,
                                                ll_split_cutoff, ll_split_variables);
 
   std::unique_ptr<Data> data = RcppUtilities::convert_data(train_matrix, sparse_train_matrix);
@@ -153,14 +153,14 @@ Rcpp::List ll_regression_train(Rcpp::NumericMatrix train_matrix,
 }
 
 // [[Rcpp::export]]
-Rcpp::List ll_regression_predict(Rcpp::List forest,
+Rcpp::List ll_regression_predict(Rcpp::List forest_object,
                                 Rcpp::NumericMatrix train_matrix,
                                 Eigen::SparseMatrix<double> sparse_train_matrix,
                                 size_t outcome_index,
                                 Rcpp::NumericMatrix test_matrix,
                                 Eigen::SparseMatrix<double> sparse_test_matrix,
-                                std::vector<double> lambdas,
-                                bool weight_penalty,
+                                std::vector<double> ll_lambda,
+                                bool ll_weight_penalty,
                                 std::vector<size_t> linear_correction_variables,
                                 unsigned int num_threads,
                                 bool estimate_variance) {
@@ -168,10 +168,10 @@ Rcpp::List ll_regression_predict(Rcpp::List forest,
   train_data->set_outcome_index(outcome_index - 1);
   std::unique_ptr<Data> data = RcppUtilities::convert_data(test_matrix, sparse_test_matrix);
 
-  Forest deserialized_forest = RcppUtilities::deserialize_forest(forest);
+  Forest deserialized_forest = RcppUtilities::deserialize_forest(forest_object);
 
   ForestPredictor predictor = ll_regression_predictor(num_threads,
-      lambdas, weight_penalty, linear_correction_variables);
+      ll_lambda, ll_weight_penalty, linear_correction_variables);
   std::vector<Prediction> predictions = predictor.predict(deserialized_forest, *train_data, *data, estimate_variance);
   Rcpp::List result = RcppUtilities::create_prediction_object(predictions);
 
@@ -179,22 +179,22 @@ Rcpp::List ll_regression_predict(Rcpp::List forest,
 }
 
 // [[Rcpp::export]]
-Rcpp::List ll_regression_predict_oob(Rcpp::List forest,
+Rcpp::List ll_regression_predict_oob(Rcpp::List forest_object,
                                     Rcpp::NumericMatrix train_matrix,
                                     Eigen::SparseMatrix<double> sparse_train_matrix,
                                     size_t outcome_index,
-                                    std::vector<double> lambdas,
-                                    bool weight_penalty,
+                                    std::vector<double> ll_lambda,
+                                    bool ll_weight_penalty,
                                     std::vector<size_t> linear_correction_variables,
                                     unsigned int num_threads,
                                     bool estimate_variance) {
   std::unique_ptr<Data> data = RcppUtilities::convert_data(train_matrix, sparse_train_matrix);
   data->set_outcome_index(outcome_index - 1);
 
-  Forest deserialized_forest = RcppUtilities::deserialize_forest(forest);
+  Forest deserialized_forest = RcppUtilities::deserialize_forest(forest_object);
 
   ForestPredictor predictor = ll_regression_predictor(num_threads,
-      lambdas, weight_penalty, linear_correction_variables);
+      ll_lambda, ll_weight_penalty, linear_correction_variables);
   std::vector<Prediction> predictions = predictor.predict_oob(deserialized_forest, *data, estimate_variance);
   Rcpp::List result = RcppUtilities::create_prediction_object(predictions);
 

--- a/r-package/grf/src/RcppExports.cpp
+++ b/r-package/grf/src/RcppExports.cpp
@@ -129,44 +129,44 @@ BEGIN_RCPP
 END_RCPP
 }
 // ll_causal_predict
-Rcpp::List ll_causal_predict(Rcpp::List forest, Rcpp::NumericMatrix input_data, Rcpp::NumericMatrix training_data, Eigen::SparseMatrix<double> sparse_input_data, Eigen::SparseMatrix<double> sparse_training_data, size_t outcome_index, size_t treatment_index, std::vector<double> lambdas, bool use_weighted_penalty, std::vector<size_t> linear_correction_variables, unsigned int num_threads, bool estimate_variance);
-RcppExport SEXP _grf_ll_causal_predict(SEXP forestSEXP, SEXP input_dataSEXP, SEXP training_dataSEXP, SEXP sparse_input_dataSEXP, SEXP sparse_training_dataSEXP, SEXP outcome_indexSEXP, SEXP treatment_indexSEXP, SEXP lambdasSEXP, SEXP use_weighted_penaltySEXP, SEXP linear_correction_variablesSEXP, SEXP num_threadsSEXP, SEXP estimate_varianceSEXP) {
+Rcpp::List ll_causal_predict(Rcpp::List forest_object, Rcpp::NumericMatrix train_matrix, Eigen::SparseMatrix<double> sparse_train_matrix, size_t outcome_index, size_t treatment_index, Rcpp::NumericMatrix test_matrix, Eigen::SparseMatrix<double> sparse_test_matrix, std::vector<double> ll_lambda, bool ll_weight_penalty, std::vector<size_t> linear_correction_variables, unsigned int num_threads, bool estimate_variance);
+RcppExport SEXP _grf_ll_causal_predict(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP sparse_train_matrixSEXP, SEXP outcome_indexSEXP, SEXP treatment_indexSEXP, SEXP test_matrixSEXP, SEXP sparse_test_matrixSEXP, SEXP ll_lambdaSEXP, SEXP ll_weight_penaltySEXP, SEXP linear_correction_variablesSEXP, SEXP num_threadsSEXP, SEXP estimate_varianceSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< Rcpp::List >::type forest(forestSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type input_data(input_dataSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type training_data(training_dataSEXP);
-    Rcpp::traits::input_parameter< Eigen::SparseMatrix<double> >::type sparse_input_data(sparse_input_dataSEXP);
-    Rcpp::traits::input_parameter< Eigen::SparseMatrix<double> >::type sparse_training_data(sparse_training_dataSEXP);
+    Rcpp::traits::input_parameter< Rcpp::List >::type forest_object(forest_objectSEXP);
+    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< Eigen::SparseMatrix<double> >::type sparse_train_matrix(sparse_train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type outcome_index(outcome_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type treatment_index(treatment_indexSEXP);
-    Rcpp::traits::input_parameter< std::vector<double> >::type lambdas(lambdasSEXP);
-    Rcpp::traits::input_parameter< bool >::type use_weighted_penalty(use_weighted_penaltySEXP);
+    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type test_matrix(test_matrixSEXP);
+    Rcpp::traits::input_parameter< Eigen::SparseMatrix<double> >::type sparse_test_matrix(sparse_test_matrixSEXP);
+    Rcpp::traits::input_parameter< std::vector<double> >::type ll_lambda(ll_lambdaSEXP);
+    Rcpp::traits::input_parameter< bool >::type ll_weight_penalty(ll_weight_penaltySEXP);
     Rcpp::traits::input_parameter< std::vector<size_t> >::type linear_correction_variables(linear_correction_variablesSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     Rcpp::traits::input_parameter< bool >::type estimate_variance(estimate_varianceSEXP);
-    rcpp_result_gen = Rcpp::wrap(ll_causal_predict(forest, input_data, training_data, sparse_input_data, sparse_training_data, outcome_index, treatment_index, lambdas, use_weighted_penalty, linear_correction_variables, num_threads, estimate_variance));
+    rcpp_result_gen = Rcpp::wrap(ll_causal_predict(forest_object, train_matrix, sparse_train_matrix, outcome_index, treatment_index, test_matrix, sparse_test_matrix, ll_lambda, ll_weight_penalty, linear_correction_variables, num_threads, estimate_variance));
     return rcpp_result_gen;
 END_RCPP
 }
 // ll_causal_predict_oob
-Rcpp::List ll_causal_predict_oob(Rcpp::List forest, Rcpp::NumericMatrix input_data, Eigen::SparseMatrix<double> sparse_input_data, size_t outcome_index, size_t treatment_index, std::vector<double> lambdas, bool use_weighted_penalty, std::vector<size_t> linear_correction_variables, unsigned int num_threads, bool estimate_variance);
-RcppExport SEXP _grf_ll_causal_predict_oob(SEXP forestSEXP, SEXP input_dataSEXP, SEXP sparse_input_dataSEXP, SEXP outcome_indexSEXP, SEXP treatment_indexSEXP, SEXP lambdasSEXP, SEXP use_weighted_penaltySEXP, SEXP linear_correction_variablesSEXP, SEXP num_threadsSEXP, SEXP estimate_varianceSEXP) {
+Rcpp::List ll_causal_predict_oob(Rcpp::List forest_object, Rcpp::NumericMatrix train_matrix, Eigen::SparseMatrix<double> sparse_train_matrix, size_t outcome_index, size_t treatment_index, std::vector<double> ll_lambda, bool ll_weight_penalty, std::vector<size_t> linear_correction_variables, unsigned int num_threads, bool estimate_variance);
+RcppExport SEXP _grf_ll_causal_predict_oob(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP sparse_train_matrixSEXP, SEXP outcome_indexSEXP, SEXP treatment_indexSEXP, SEXP ll_lambdaSEXP, SEXP ll_weight_penaltySEXP, SEXP linear_correction_variablesSEXP, SEXP num_threadsSEXP, SEXP estimate_varianceSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< Rcpp::List >::type forest(forestSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type input_data(input_dataSEXP);
-    Rcpp::traits::input_parameter< Eigen::SparseMatrix<double> >::type sparse_input_data(sparse_input_dataSEXP);
+    Rcpp::traits::input_parameter< Rcpp::List >::type forest_object(forest_objectSEXP);
+    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< Eigen::SparseMatrix<double> >::type sparse_train_matrix(sparse_train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type outcome_index(outcome_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type treatment_index(treatment_indexSEXP);
-    Rcpp::traits::input_parameter< std::vector<double> >::type lambdas(lambdasSEXP);
-    Rcpp::traits::input_parameter< bool >::type use_weighted_penalty(use_weighted_penaltySEXP);
+    Rcpp::traits::input_parameter< std::vector<double> >::type ll_lambda(ll_lambdaSEXP);
+    Rcpp::traits::input_parameter< bool >::type ll_weight_penalty(ll_weight_penaltySEXP);
     Rcpp::traits::input_parameter< std::vector<size_t> >::type linear_correction_variables(linear_correction_variablesSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     Rcpp::traits::input_parameter< bool >::type estimate_variance(estimate_varianceSEXP);
-    rcpp_result_gen = Rcpp::wrap(ll_causal_predict_oob(forest, input_data, sparse_input_data, outcome_index, treatment_index, lambdas, use_weighted_penalty, linear_correction_variables, num_threads, estimate_variance));
+    rcpp_result_gen = Rcpp::wrap(ll_causal_predict_oob(forest_object, train_matrix, sparse_train_matrix, outcome_index, treatment_index, ll_lambda, ll_weight_penalty, linear_correction_variables, num_threads, estimate_variance));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -430,8 +430,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // ll_regression_train
-Rcpp::List ll_regression_train(Rcpp::NumericMatrix train_matrix, Eigen::SparseMatrix<double> sparse_train_matrix, size_t outcome_index, size_t sample_weight_index, double split_lambda, bool weight_penalty, std::vector<size_t> ll_split_variables, size_t ll_split_cutoff, std::vector<double> overall_beta, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double alpha, double imbalance_penalty, std::vector<size_t> clusters, unsigned int samples_per_cluster, unsigned int num_threads, unsigned int seed);
-RcppExport SEXP _grf_ll_regression_train(SEXP train_matrixSEXP, SEXP sparse_train_matrixSEXP, SEXP outcome_indexSEXP, SEXP sample_weight_indexSEXP, SEXP split_lambdaSEXP, SEXP weight_penaltySEXP, SEXP ll_split_variablesSEXP, SEXP ll_split_cutoffSEXP, SEXP overall_betaSEXP, SEXP use_sample_weightsSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP ci_group_sizeSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP num_threadsSEXP, SEXP seedSEXP) {
+Rcpp::List ll_regression_train(Rcpp::NumericMatrix train_matrix, Eigen::SparseMatrix<double> sparse_train_matrix, size_t outcome_index, size_t sample_weight_index, double ll_split_lambda, bool ll_split_weight_penalty, std::vector<size_t> ll_split_variables, size_t ll_split_cutoff, std::vector<double> overall_beta, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double alpha, double imbalance_penalty, std::vector<size_t> clusters, unsigned int samples_per_cluster, unsigned int num_threads, unsigned int seed);
+RcppExport SEXP _grf_ll_regression_train(SEXP train_matrixSEXP, SEXP sparse_train_matrixSEXP, SEXP outcome_indexSEXP, SEXP sample_weight_indexSEXP, SEXP ll_split_lambdaSEXP, SEXP ll_split_weight_penaltySEXP, SEXP ll_split_variablesSEXP, SEXP ll_split_cutoffSEXP, SEXP overall_betaSEXP, SEXP use_sample_weightsSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP ci_group_sizeSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP num_threadsSEXP, SEXP seedSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -439,8 +439,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< Eigen::SparseMatrix<double> >::type sparse_train_matrix(sparse_train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type outcome_index(outcome_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type sample_weight_index(sample_weight_indexSEXP);
-    Rcpp::traits::input_parameter< double >::type split_lambda(split_lambdaSEXP);
-    Rcpp::traits::input_parameter< bool >::type weight_penalty(weight_penaltySEXP);
+    Rcpp::traits::input_parameter< double >::type ll_split_lambda(ll_split_lambdaSEXP);
+    Rcpp::traits::input_parameter< bool >::type ll_split_weight_penalty(ll_split_weight_penaltySEXP);
     Rcpp::traits::input_parameter< std::vector<size_t> >::type ll_split_variables(ll_split_variablesSEXP);
     Rcpp::traits::input_parameter< size_t >::type ll_split_cutoff(ll_split_cutoffSEXP);
     Rcpp::traits::input_parameter< std::vector<double> >::type overall_beta(overall_betaSEXP);
@@ -459,47 +459,47 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< unsigned int >::type samples_per_cluster(samples_per_clusterSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type seed(seedSEXP);
-    rcpp_result_gen = Rcpp::wrap(ll_regression_train(train_matrix, sparse_train_matrix, outcome_index, sample_weight_index, split_lambda, weight_penalty, ll_split_variables, ll_split_cutoff, overall_beta, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, num_threads, seed));
+    rcpp_result_gen = Rcpp::wrap(ll_regression_train(train_matrix, sparse_train_matrix, outcome_index, sample_weight_index, ll_split_lambda, ll_split_weight_penalty, ll_split_variables, ll_split_cutoff, overall_beta, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, num_threads, seed));
     return rcpp_result_gen;
 END_RCPP
 }
 // ll_regression_predict
-Rcpp::List ll_regression_predict(Rcpp::List forest, Rcpp::NumericMatrix train_matrix, Eigen::SparseMatrix<double> sparse_train_matrix, size_t outcome_index, Rcpp::NumericMatrix test_matrix, Eigen::SparseMatrix<double> sparse_test_matrix, std::vector<double> lambdas, bool weight_penalty, std::vector<size_t> linear_correction_variables, unsigned int num_threads, bool estimate_variance);
-RcppExport SEXP _grf_ll_regression_predict(SEXP forestSEXP, SEXP train_matrixSEXP, SEXP sparse_train_matrixSEXP, SEXP outcome_indexSEXP, SEXP test_matrixSEXP, SEXP sparse_test_matrixSEXP, SEXP lambdasSEXP, SEXP weight_penaltySEXP, SEXP linear_correction_variablesSEXP, SEXP num_threadsSEXP, SEXP estimate_varianceSEXP) {
+Rcpp::List ll_regression_predict(Rcpp::List forest_object, Rcpp::NumericMatrix train_matrix, Eigen::SparseMatrix<double> sparse_train_matrix, size_t outcome_index, Rcpp::NumericMatrix test_matrix, Eigen::SparseMatrix<double> sparse_test_matrix, std::vector<double> ll_lambda, bool ll_weight_penalty, std::vector<size_t> linear_correction_variables, unsigned int num_threads, bool estimate_variance);
+RcppExport SEXP _grf_ll_regression_predict(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP sparse_train_matrixSEXP, SEXP outcome_indexSEXP, SEXP test_matrixSEXP, SEXP sparse_test_matrixSEXP, SEXP ll_lambdaSEXP, SEXP ll_weight_penaltySEXP, SEXP linear_correction_variablesSEXP, SEXP num_threadsSEXP, SEXP estimate_varianceSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< Rcpp::List >::type forest(forestSEXP);
+    Rcpp::traits::input_parameter< Rcpp::List >::type forest_object(forest_objectSEXP);
     Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< Eigen::SparseMatrix<double> >::type sparse_train_matrix(sparse_train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type outcome_index(outcome_indexSEXP);
     Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type test_matrix(test_matrixSEXP);
     Rcpp::traits::input_parameter< Eigen::SparseMatrix<double> >::type sparse_test_matrix(sparse_test_matrixSEXP);
-    Rcpp::traits::input_parameter< std::vector<double> >::type lambdas(lambdasSEXP);
-    Rcpp::traits::input_parameter< bool >::type weight_penalty(weight_penaltySEXP);
+    Rcpp::traits::input_parameter< std::vector<double> >::type ll_lambda(ll_lambdaSEXP);
+    Rcpp::traits::input_parameter< bool >::type ll_weight_penalty(ll_weight_penaltySEXP);
     Rcpp::traits::input_parameter< std::vector<size_t> >::type linear_correction_variables(linear_correction_variablesSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     Rcpp::traits::input_parameter< bool >::type estimate_variance(estimate_varianceSEXP);
-    rcpp_result_gen = Rcpp::wrap(ll_regression_predict(forest, train_matrix, sparse_train_matrix, outcome_index, test_matrix, sparse_test_matrix, lambdas, weight_penalty, linear_correction_variables, num_threads, estimate_variance));
+    rcpp_result_gen = Rcpp::wrap(ll_regression_predict(forest_object, train_matrix, sparse_train_matrix, outcome_index, test_matrix, sparse_test_matrix, ll_lambda, ll_weight_penalty, linear_correction_variables, num_threads, estimate_variance));
     return rcpp_result_gen;
 END_RCPP
 }
 // ll_regression_predict_oob
-Rcpp::List ll_regression_predict_oob(Rcpp::List forest, Rcpp::NumericMatrix train_matrix, Eigen::SparseMatrix<double> sparse_train_matrix, size_t outcome_index, std::vector<double> lambdas, bool weight_penalty, std::vector<size_t> linear_correction_variables, unsigned int num_threads, bool estimate_variance);
-RcppExport SEXP _grf_ll_regression_predict_oob(SEXP forestSEXP, SEXP train_matrixSEXP, SEXP sparse_train_matrixSEXP, SEXP outcome_indexSEXP, SEXP lambdasSEXP, SEXP weight_penaltySEXP, SEXP linear_correction_variablesSEXP, SEXP num_threadsSEXP, SEXP estimate_varianceSEXP) {
+Rcpp::List ll_regression_predict_oob(Rcpp::List forest_object, Rcpp::NumericMatrix train_matrix, Eigen::SparseMatrix<double> sparse_train_matrix, size_t outcome_index, std::vector<double> ll_lambda, bool ll_weight_penalty, std::vector<size_t> linear_correction_variables, unsigned int num_threads, bool estimate_variance);
+RcppExport SEXP _grf_ll_regression_predict_oob(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP sparse_train_matrixSEXP, SEXP outcome_indexSEXP, SEXP ll_lambdaSEXP, SEXP ll_weight_penaltySEXP, SEXP linear_correction_variablesSEXP, SEXP num_threadsSEXP, SEXP estimate_varianceSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< Rcpp::List >::type forest(forestSEXP);
+    Rcpp::traits::input_parameter< Rcpp::List >::type forest_object(forest_objectSEXP);
     Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< Eigen::SparseMatrix<double> >::type sparse_train_matrix(sparse_train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type outcome_index(outcome_indexSEXP);
-    Rcpp::traits::input_parameter< std::vector<double> >::type lambdas(lambdasSEXP);
-    Rcpp::traits::input_parameter< bool >::type weight_penalty(weight_penaltySEXP);
+    Rcpp::traits::input_parameter< std::vector<double> >::type ll_lambda(ll_lambdaSEXP);
+    Rcpp::traits::input_parameter< bool >::type ll_weight_penalty(ll_weight_penaltySEXP);
     Rcpp::traits::input_parameter< std::vector<size_t> >::type linear_correction_variables(linear_correction_variablesSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     Rcpp::traits::input_parameter< bool >::type estimate_variance(estimate_varianceSEXP);
-    rcpp_result_gen = Rcpp::wrap(ll_regression_predict_oob(forest, train_matrix, sparse_train_matrix, outcome_index, lambdas, weight_penalty, linear_correction_variables, num_threads, estimate_variance));
+    rcpp_result_gen = Rcpp::wrap(ll_regression_predict_oob(forest_object, train_matrix, sparse_train_matrix, outcome_index, ll_lambda, ll_weight_penalty, linear_correction_variables, num_threads, estimate_variance));
     return rcpp_result_gen;
 END_RCPP
 }


### PR DESCRIPTION
This is only a simplification of the way the various prediction wrappers are called. With the addition of `create_test_matrices` from #647 we can simplify all the `forest.predict` methods by using `do.call.rcpp(forest_predict_function, args)` for the bindings.

This has the added benefit of always using named arguments, avoiding errors arising from argument order switching.

Additional changes are made to make names consistent across function signatures. Code is also restructured to be consistent between functions. This was particularly relevant for local linear forests, @rinafriedberg please see if you agree. (Summary: if something is called chicken in function X, try to stick to calling it chicken every other place. If chicken comes before cow in function X, try to make chicken come before cow all other places too, unless the ordering affects results)

