### PR TITLE
Break the Kaplan-Meier loop when it hits zero

### DIFF
--- a/core/src/prediction/SurvivalPredictionStrategy.cpp
+++ b/core/src/prediction/SurvivalPredictionStrategy.cpp
@@ -56,6 +56,11 @@ std::vector<double> SurvivalPredictionStrategy::predict(size_t prediction_sample
   for (size_t time = 1; time <= num_failures; time++) {
    if (sum > 0) {
      kaplan_meier = kaplan_meier * (1 - count_failure[time] / sum);
+     // If the estimate hits zero it will stay zero and we can break early.
+     // This also prevents errors from accumulating which may yield some point estimates less than zero.
+     if (kaplan_meier <= 0) {
+       break;
+     }
    }
    survival_function[time - 1] = kaplan_meier;
    sum = sum - count_failure[time] - count_censor[time];


### PR DESCRIPTION
This is a very minor change.  If the estimate hits zero it will stay zero and we can break early. This also prevents errors from accumulating which may yield some point estimates less than zero.

```R
set.seed(123)
n <- 1000
p <- 5
X <- matrix(rnorm(n * p), n, p)
failure.time <- exp(0.5 * X[, 1]) * rexp(n)
censor.time <- 2 * rexp(n)
Y <- pmin(failure.time, censor.time)
D <- as.integer(failure.time <= censor.time)
sf <- survival_forest(X, Y, D)

# Before
min(predict(sf)$predictions)
# [1] -1.901894e-13

# Now
min(predict(sf)$predictions)
# [1] 0
```