### PR TITLE
Use do.call in tune_ll_regression_forest and tune_ll_causal_forest

### DIFF
--- a/r-package/grf/R/tune_local_linear_causal_forest.R
+++ b/r-package/grf/R/tune_local_linear_causal_forest.R
@@ -25,7 +25,7 @@
 #' tuned.lambda <- tune_ll_causal_forest(forest)
 #'
 #' # Use this parameter to predict from a local linear causal forest.
-#' predictions <- predict(forest, linear.correction.variables = 1:p, lambda = tuned.lambda)
+#' predictions <- predict(forest, linear.correction.variables = 1:p, ll.lambda = tuned.lambda$lambda.min)
 #' }
 #'
 #' @export
@@ -35,38 +35,40 @@ tune_ll_causal_forest <- function(forest,
                                   num.threads = NULL,
                                   lambda.path = NULL) {
   forest.short <- forest[-which(names(forest) == "X.orig")]
-
   X <- forest[["X.orig"]]
   Y <- forest[["Y.orig"]]
   W <- forest[["W.orig"]]
   Y.hat <- forest[["Y.hat"]]
   W.hat <- forest[["W.hat"]]
-
   Y.centered <- Y - Y.hat
   W.centered <- W - W.hat
-
-  data <- create_train_matrices(X, Y.centered, W.centered)
+  train.data <- create_train_matrices(X, outcome = Y.centered, treatment = W.centered)
 
   # Validate variables
   num.threads <- validate_num_threads(num.threads)
   linear.correction.variables <- validate_ll_vars(linear.correction.variables, ncol(X))
-  lambda.path <- validate_ll_path(lambda.path)
+  ll.lambda <- validate_ll_path(lambda.path)
 
   # Subtract 1 to account for C++ indexing
   linear.correction.variables <- linear.correction.variables - 1
 
-  # Find sequence of predictions by lambda
-  prediction.object <- ll_causal_predict_oob(forest.short, data$train.matrix, data$sparse.train.matrix,
-      data$outcome.index, data$treatment.index, lambda.path, ll.weight.penalty, linear.correction.variables, num.threads, FALSE)
-  predictions <- prediction.object$predictions
+  args <- list(forest.object = forest.short,
+               num.threads = num.threads,
+               estimate.variance = FALSE,
+               ll.lambda = ll.lambda,
+               ll.weight.penalty = ll.weight.penalty,
+               linear.correction.variables = linear.correction.variables)
 
+  # Find sequence of predictions by lambda
+  prediction.object <- do.call.rcpp(ll_causal_predict_oob, c(train.data, args))
+  predictions <- prediction.object$predictions
   errors <- apply(predictions, MARGIN = 2, FUN = function(row) {
     # compute R-learner loss
     mean(((Y - Y.hat) - (W - W.hat) * row)**2)
   })
 
   return(list(
-    lambdas = lambda.path, errors = errors, oob.predictions = predictions,
-    lambda.min = lambda.path[which.min(errors)]
+    lambdas = ll.lambda, errors = errors, oob.predictions = predictions,
+    lambda.min = ll.lambda[which.min(errors)]
   ))
 }

--- a/r-package/grf/R/tune_local_linear_forest.R
+++ b/r-package/grf/R/tune_local_linear_forest.R
@@ -23,7 +23,7 @@
 #' tuned.lambda <- tune_ll_regression_forest(forest)
 #'
 #' # Use this parameter to predict from a local linear forest.
-#' predictions <- predict(forest, linear.correction.variables = 1:p, lambda = tuned.lambda)
+#' predictions <- predict(forest, linear.correction.variables = 1:p, ll.lambda = tuned.lambda$lambda.min)
 #' }
 #'
 #' @export
@@ -33,33 +33,33 @@ tune_ll_regression_forest <- function(forest,
                                       num.threads = NULL,
                                       lambda.path = NULL) {
   forest.short <- forest[-which(names(forest) == "X.orig")]
-
   X <- forest[["X.orig"]]
   Y <- forest[["Y.orig"]]
-  data <- create_train_matrices(X, outcome = Y)
+  train.data <- create_train_matrices(X, outcome = Y)
 
   # Validate variables
   num.threads <- validate_num_threads(num.threads)
   linear.correction.variables <- validate_ll_vars(linear.correction.variables, ncol(X))
-  lambda.path <- validate_ll_path(lambda.path)
+  ll.lambda <- validate_ll_path(lambda.path)
 
   # Subtract 1 to account for C++ indexing
   linear.correction.variables <- linear.correction.variables - 1
 
-  # Enforce no variance estimates in tuning
-  estimate.variance <- FALSE
-  prediction.object <- ll_regression_predict_oob(
-    forest.short, data$train.matrix, data$sparse.train.matrix, data$outcome.index,
-    lambda.path, ll.weight.penalty, linear.correction.variables, num.threads, estimate.variance
-  )
+  args <- list(forest.object = forest.short,
+               num.threads = num.threads,
+               estimate.variance = FALSE,
+               ll.lambda = ll.lambda,
+               ll.weight.penalty = ll.weight.penalty,
+               linear.correction.variables = linear.correction.variables)
 
-  prediction.object <- prediction.object$predictions
-  errors <- apply(prediction.object, MARGIN = 2, FUN = function(row) {
+  prediction.object <- do.call.rcpp(ll_regression_predict_oob, c(train.data, args))
+  predictions <- prediction.object$predictions
+  errors <- apply(predictions, MARGIN = 2, FUN = function(row) {
     mean((row - Y)**2)
   })
 
   return(list(
-    lambdas = lambda.path, errors = errors, oob.predictions = prediction.object,
-    lambda.min = lambda.path[which.min(errors)]
+    lambdas = ll.lambda, errors = errors, oob.predictions = predictions,
+    lambda.min = ll.lambda[which.min(errors)]
   ))
 }


### PR DESCRIPTION
A simple follow up to #654 

Also a minor fix to the docstring example in these two functions, the lambda was eaten up by `...` before. 