### PR TITLE
Add  `compute.oob.predictions` option to Quantile Forest

### DIFF
--- a/r-package/grf/R/RcppExports.R
+++ b/r-package/grf/R/RcppExports.R
@@ -61,8 +61,8 @@ instrumental_predict_oob <- function(forest_object, train_matrix, sparse_train_m
     .Call('_grf_instrumental_predict_oob', PACKAGE = 'grf', forest_object, train_matrix, sparse_train_matrix, outcome_index, treatment_index, instrument_index, num_threads, estimate_variance)
 }
 
-quantile_train <- function(quantiles, regression_splits, train_matrix, sparse_train_matrix, outcome_index, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, num_threads, seed) {
-    .Call('_grf_quantile_train', PACKAGE = 'grf', quantiles, regression_splits, train_matrix, sparse_train_matrix, outcome_index, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, num_threads, seed)
+quantile_train <- function(quantiles, regression_splitting, train_matrix, sparse_train_matrix, outcome_index, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed) {
+    .Call('_grf_quantile_train', PACKAGE = 'grf', quantiles, regression_splitting, train_matrix, sparse_train_matrix, outcome_index, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed)
 }
 
 quantile_predict <- function(forest_object, quantiles, train_matrix, sparse_train_matrix, outcome_index, test_matrix, sparse_test_matrix, num_threads) {

--- a/r-package/grf/R/quantile_forest.R
+++ b/r-package/grf/R/quantile_forest.R
@@ -188,7 +188,7 @@ predict.quantile_forest <- function(object,
   # If possible, use pre-computed predictions.
   quantiles.orig <- object[["quantiles.orig"]]
   if (is.null(newdata) & identical(quantiles, quantiles.orig) & !is.null(object$predictions)) {
-    return(object$predictions)
+    return(list(predictions = object[["predictions"]]))
   }
 
   num.threads <- validate_num_threads(num.threads)
@@ -203,8 +203,10 @@ predict.quantile_forest <- function(object,
   if (!is.null(newdata)) {
     validate_newdata(newdata, object$X.orig, allow.na = TRUE)
     test.data <- create_test_matrices(newdata)
-    do.call.rcpp(quantile_predict, c(train.data, test.data, args))
+    ret <- do.call.rcpp(quantile_predict, c(train.data, test.data, args))
   } else {
-    do.call.rcpp(quantile_predict_oob, c(train.data, args))
+    ret <- do.call.rcpp(quantile_predict_oob, c(train.data, args))
   }
+
+  list(predictions = ret)
 }

--- a/r-package/grf/R/quantile_forest.R
+++ b/r-package/grf/R/quantile_forest.R
@@ -44,7 +44,7 @@
 #'  Only applies if honesty is enabled. Default is TRUE.
 #' @param alpha A tuning parameter that controls the maximum imbalance of a split. Default is 0.05.
 #' @param imbalance.penalty A tuning parameter that controls how harshly imbalanced splits are penalized. Default is 0.
-#' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed. Default is TRUE.
+#' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed. Default is FALSE.
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency.
 #' @param seed The seed of the C++ random number generator.
@@ -93,7 +93,7 @@ quantile_forest <- function(X, Y,
                             honesty.prune.leaves = TRUE,
                             alpha = 0.05,
                             imbalance.penalty = 0.0,
-                            compute.oob.predictions = TRUE,
+                            compute.oob.predictions = FALSE,
                             num.threads = NULL,
                             seed = runif(1, 0, .Machine$integer.max)) {
   if (!is.numeric(quantiles) | length(quantiles) < 1) {

--- a/r-package/grf/R/quantile_forest.R
+++ b/r-package/grf/R/quantile_forest.R
@@ -188,7 +188,7 @@ predict.quantile_forest <- function(object,
   # If possible, use pre-computed predictions.
   quantiles.orig <- object[["quantiles.orig"]]
   if (is.null(newdata) & identical(quantiles, quantiles.orig) & !is.null(object$predictions)) {
-    return(list(predictions = object[["predictions"]]))
+    return(list(predictions = object[["predictions"]], quantiles = quantiles))
   }
 
   num.threads <- validate_num_threads(num.threads)
@@ -208,5 +208,5 @@ predict.quantile_forest <- function(object,
     ret <- do.call.rcpp(quantile_predict_oob, c(train.data, args))
   }
 
-  list(predictions = ret)
+  list(predictions = ret, quantiles = quantiles)
 }

--- a/r-package/grf/R/quantile_forest.R
+++ b/r-package/grf/R/quantile_forest.R
@@ -188,7 +188,7 @@ predict.quantile_forest <- function(object,
   # If possible, use pre-computed predictions.
   quantiles.orig <- object[["quantiles.orig"]]
   if (is.null(newdata) & identical(quantiles, quantiles.orig) & !is.null(object$predictions)) {
-    return(list(predictions = object[["predictions"]]))
+    return(object$predictions)
   }
 
   num.threads <- validate_num_threads(num.threads)
@@ -203,10 +203,8 @@ predict.quantile_forest <- function(object,
   if (!is.null(newdata)) {
     validate_newdata(newdata, object$X.orig, allow.na = TRUE)
     test.data <- create_test_matrices(newdata)
-    ret <- do.call.rcpp(quantile_predict, c(train.data, test.data, args))
+    do.call.rcpp(quantile_predict, c(train.data, test.data, args))
   } else {
-    ret <- do.call.rcpp(quantile_predict_oob, c(train.data, args))
+    do.call.rcpp(quantile_predict_oob, c(train.data, args))
   }
-
-  list(predictions = ret)
 }

--- a/r-package/grf/R/quantile_forest.R
+++ b/r-package/grf/R/quantile_forest.R
@@ -188,7 +188,7 @@ predict.quantile_forest <- function(object,
   # If possible, use pre-computed predictions.
   quantiles.orig <- object[["quantiles.orig"]]
   if (is.null(newdata) & identical(quantiles, quantiles.orig) & !is.null(object$predictions)) {
-    return(list(predictions = object[["predictions"]], quantiles = quantiles))
+    return(list(predictions = object[["predictions"]]))
   }
 
   num.threads <- validate_num_threads(num.threads)
@@ -208,5 +208,5 @@ predict.quantile_forest <- function(object,
     ret <- do.call.rcpp(quantile_predict_oob, c(train.data, args))
   }
 
-  list(predictions = ret, quantiles = quantiles)
+  list(predictions = ret)
 }

--- a/r-package/grf/src/RcppExports.cpp
+++ b/r-package/grf/src/RcppExports.cpp
@@ -303,13 +303,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // quantile_train
-Rcpp::List quantile_train(std::vector<double> quantiles, bool regression_splits, Rcpp::NumericMatrix train_matrix, Eigen::SparseMatrix<double> sparse_train_matrix, size_t outcome_index, unsigned int mtry, unsigned int num_trees, int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double alpha, double imbalance_penalty, std::vector<size_t> clusters, unsigned int samples_per_cluster, int num_threads, unsigned int seed);
-RcppExport SEXP _grf_quantile_train(SEXP quantilesSEXP, SEXP regression_splitsSEXP, SEXP train_matrixSEXP, SEXP sparse_train_matrixSEXP, SEXP outcome_indexSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP ci_group_sizeSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP num_threadsSEXP, SEXP seedSEXP) {
+Rcpp::List quantile_train(std::vector<double> quantiles, bool regression_splitting, Rcpp::NumericMatrix train_matrix, Eigen::SparseMatrix<double> sparse_train_matrix, size_t outcome_index, unsigned int mtry, unsigned int num_trees, int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double alpha, double imbalance_penalty, std::vector<size_t> clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, int num_threads, unsigned int seed);
+RcppExport SEXP _grf_quantile_train(SEXP quantilesSEXP, SEXP regression_splittingSEXP, SEXP train_matrixSEXP, SEXP sparse_train_matrixSEXP, SEXP outcome_indexSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP ci_group_sizeSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP compute_oob_predictionsSEXP, SEXP num_threadsSEXP, SEXP seedSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< std::vector<double> >::type quantiles(quantilesSEXP);
-    Rcpp::traits::input_parameter< bool >::type regression_splits(regression_splitsSEXP);
+    Rcpp::traits::input_parameter< bool >::type regression_splitting(regression_splittingSEXP);
     Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< Eigen::SparseMatrix<double> >::type sparse_train_matrix(sparse_train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type outcome_index(outcome_indexSEXP);
@@ -325,9 +325,10 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< double >::type imbalance_penalty(imbalance_penaltySEXP);
     Rcpp::traits::input_parameter< std::vector<size_t> >::type clusters(clustersSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type samples_per_cluster(samples_per_clusterSEXP);
+    Rcpp::traits::input_parameter< bool >::type compute_oob_predictions(compute_oob_predictionsSEXP);
     Rcpp::traits::input_parameter< int >::type num_threads(num_threadsSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type seed(seedSEXP);
-    rcpp_result_gen = Rcpp::wrap(quantile_train(quantiles, regression_splits, train_matrix, sparse_train_matrix, outcome_index, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, num_threads, seed));
+    rcpp_result_gen = Rcpp::wrap(quantile_train(quantiles, regression_splitting, train_matrix, sparse_train_matrix, outcome_index, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -590,7 +591,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_grf_instrumental_train", (DL_FUNC) &_grf_instrumental_train, 24},
     {"_grf_instrumental_predict", (DL_FUNC) &_grf_instrumental_predict, 10},
     {"_grf_instrumental_predict_oob", (DL_FUNC) &_grf_instrumental_predict_oob, 8},
-    {"_grf_quantile_train", (DL_FUNC) &_grf_quantile_train, 19},
+    {"_grf_quantile_train", (DL_FUNC) &_grf_quantile_train, 20},
     {"_grf_quantile_predict", (DL_FUNC) &_grf_quantile_predict, 8},
     {"_grf_quantile_predict_oob", (DL_FUNC) &_grf_quantile_predict_oob, 6},
     {"_grf_regression_train", (DL_FUNC) &_grf_regression_train, 20},

--- a/r-package/grf/tests/testthat/test_quantile_forest.R
+++ b/r-package/grf/tests/testthat/test_quantile_forest.R
@@ -42,8 +42,8 @@ test_that("quantile forest predictions are positive given positive outcomes", {
   Y <- runif(n) + 100 * (X[, i] > 0)
 
   qrf <- quantile_forest(X, Y, quantiles = c(0.1, 0.5, 0.9), mtry = p, min.node.size = 10, sample.fraction = 0.632)
-  expect_true(all(predict(qrf)$predictions > 0))
-  expect_true(all(predict(qrf, X.new)$predictions > 0))
+  expect_true(all(predict(qrf) > 0))
+  expect_true(all(predict(qrf, X.new) > 0))
 })
 
 test_that("quantile forest predictions for 90th percentile are strongly positively correlated
@@ -56,8 +56,8 @@ test_that("quantile forest predictions for 90th percentile are strongly positive
   Y <- runif(n) + 100 * (X[, i] > 0)
 
   qrf <- quantile_forest(X, Y, quantiles = c(0.1, 0.5, 0.9), mtry = p, min.node.size = 10, sample.fraction = 0.632)
-  expect_true(cor(predict(qrf, quantiles = .9)$predictions, X[, i]) > .5)
-  expect_true(cor(predict(qrf, X.new, quantiles = .9)$predictions, X.new[, i]) > .5)
+  expect_true(cor(predict(qrf, quantiles = .9), X[, i]) > .5)
+  expect_true(cor(predict(qrf, X.new, quantiles = .9), X.new[, i]) > .5)
 })
 
 test_that("quantile_forest works as expected with missing values", {
@@ -81,8 +81,8 @@ test_that("quantile_forest works as expected with missing values", {
   rf.mia <- quantile_forest(X.mia, Y, quantiles = quantiles, seed = 123)
   rf <- quantile_forest(X, Y, quantiles = quantiles, seed = 123)
 
-  mean.diff.oob <- colMeans((predict(rf)$predictions - predict(rf.mia)$predictions))
-  mean.diff <- colMeans((predict(rf, X)$predictions - predict(rf.mia, X.mia)$predictions))
+  mean.diff.oob <- colMeans((predict(rf) - predict(rf.mia)))
+  mean.diff <- colMeans((predict(rf, X) - predict(rf.mia, X.mia)))
 
   expect_equal(mean.diff.oob, c(0, 0, 0), tol = 0.5)
   expect_equal(mean.diff, c(0, 0, 0), tol = 0.5)

--- a/r-package/grf/tests/testthat/test_quantile_forest.R
+++ b/r-package/grf/tests/testthat/test_quantile_forest.R
@@ -42,8 +42,8 @@ test_that("quantile forest predictions are positive given positive outcomes", {
   Y <- runif(n) + 100 * (X[, i] > 0)
 
   qrf <- quantile_forest(X, Y, quantiles = c(0.1, 0.5, 0.9), mtry = p, min.node.size = 10, sample.fraction = 0.632)
-  expect_true(all(predict(qrf) > 0))
-  expect_true(all(predict(qrf, X.new) > 0))
+  expect_true(all(predict(qrf)$predictions > 0))
+  expect_true(all(predict(qrf, X.new)$predictions > 0))
 })
 
 test_that("quantile forest predictions for 90th percentile are strongly positively correlated
@@ -56,8 +56,8 @@ test_that("quantile forest predictions for 90th percentile are strongly positive
   Y <- runif(n) + 100 * (X[, i] > 0)
 
   qrf <- quantile_forest(X, Y, quantiles = c(0.1, 0.5, 0.9), mtry = p, min.node.size = 10, sample.fraction = 0.632)
-  expect_true(cor(predict(qrf, quantiles = .9), X[, i]) > .5)
-  expect_true(cor(predict(qrf, X.new, quantiles = .9), X.new[, i]) > .5)
+  expect_true(cor(predict(qrf, quantiles = .9)$predictions, X[, i]) > .5)
+  expect_true(cor(predict(qrf, X.new, quantiles = .9)$predictions, X.new[, i]) > .5)
 })
 
 test_that("quantile_forest works as expected with missing values", {
@@ -81,8 +81,8 @@ test_that("quantile_forest works as expected with missing values", {
   rf.mia <- quantile_forest(X.mia, Y, quantiles = quantiles, seed = 123)
   rf <- quantile_forest(X, Y, quantiles = quantiles, seed = 123)
 
-  mean.diff.oob <- colMeans((predict(rf) - predict(rf.mia)))
-  mean.diff <- colMeans((predict(rf, X) - predict(rf.mia, X.mia)))
+  mean.diff.oob <- colMeans((predict(rf)$predictions - predict(rf.mia)$predictions))
+  mean.diff <- colMeans((predict(rf, X)$predictions - predict(rf.mia, X.mia)$predictions))
 
   expect_equal(mean.diff.oob, c(0, 0, 0), tol = 0.5)
   expect_equal(mean.diff, c(0, 0, 0), tol = 0.5)


### PR DESCRIPTION
Closes #663 

~2b4c2cd + 9b123e3 is a suggested small breaking change for conformity with the rest of grf: return the point predictions in the `$predictions` attribute (and the quantiles in $quantiles). Can revert if you disagree!~