### PR TITLE
Add neighbors check to DefaultPredictionCollector

### DIFF
--- a/core/src/prediction/QuantilePredictionStrategy.cpp
+++ b/core/src/prediction/QuantilePredictionStrategy.cpp
@@ -38,6 +38,10 @@ std::vector<double> QuantilePredictionStrategy::predict(
     const std::unordered_map<size_t, double>& weights_by_sample,
     const Data& train_data,
     const Data& data) const {
+  if (weights_by_sample.empty()) {
+    return std::vector<double>(quantiles.size(), NAN);
+  }
+
   std::vector<std::pair<size_t, double>> samples_and_values;
   for (const auto& entry : weights_by_sample) {
     size_t sample = entry.first;

--- a/core/src/prediction/QuantilePredictionStrategy.cpp
+++ b/core/src/prediction/QuantilePredictionStrategy.cpp
@@ -38,10 +38,6 @@ std::vector<double> QuantilePredictionStrategy::predict(
     const std::unordered_map<size_t, double>& weights_by_sample,
     const Data& train_data,
     const Data& data) const {
-  if (weights_by_sample.empty()) {
-    return std::vector<double>(quantiles.size(), NAN);
-  }
-
   std::vector<std::pair<size_t, double>> samples_and_values;
   for (const auto& entry : weights_by_sample) {
     size_t sample = entry.first;

--- a/core/src/prediction/collector/DefaultPredictionCollector.cpp
+++ b/core/src/prediction/collector/DefaultPredictionCollector.cpp
@@ -93,6 +93,14 @@ std::vector<Prediction> DefaultPredictionCollector::collect_predictions_batch(
         sample, forest, leaf_nodes_by_tree, valid_trees_by_sample);
     std::vector<std::vector<size_t>> samples_by_tree;
 
+    // If this sample has no neighbors, then return placeholder predictions. Note
+    // that this can only occur when honesty is enabled, and is expected to be rare.
+    if (weights_by_sample.empty()) {
+      std::vector<double> nan(strategy->prediction_length(), NAN);
+      predictions.emplace_back(nan, nan, nan, nan);
+      continue;
+    }
+
     if (record_leaf_samples) {
       samples_by_tree.resize(num_trees);
 


### PR DESCRIPTION
Add a check to the DefaultPredictionCollector which is already in place for the [OptimizedPredictionCollector](https://github.com/grf-labs/grf/blob/master/core/src/prediction/collector/OptimizedPredictionCollector.cpp#L120-L124).

QuantilePredictionStrategy [segfaults](https://user-images.githubusercontent.com/7185264/81639585-367f9400-93d1-11ea-8eba-ff6e757998a7.png) if `weights_by_sample` is empty as is the case when OOB predicting with sample.fraction = 1 and honesty = TRUE as in for example [this](https://github.com/grf-labs/grf/blob/master/r-package/grf/tests/testthat/test_analysis_tools.R#L36) test case.


