### PR TITLE
Make consistent use of logical operators in R bindings

### DIFF
--- a/r-package/grf/R/analysis_tools.R
+++ b/r-package/grf/R/analysis_tools.R
@@ -84,7 +84,7 @@ get_tree <- function(forest, index) {
   columns <- colnames(forest$X.orig)
   indices <- 1:ncol(forest$X.orig)
   tree$columns <- sapply(indices, function(i) {
-    if (!is.null(columns) & length(columns[i]) > 0) {
+    if (!is.null(columns) && length(columns[i]) > 0) {
       columns[i]
     } else {
       paste("X", i, sep = ".")

--- a/r-package/grf/R/average_late.R
+++ b/r-package/grf/R/average_late.R
@@ -67,7 +67,7 @@ average_late <- function(forest,
     subset <- 1:length(forest$Y.hat)
   }
 
-  if (class(subset) == "logical" & length(subset) == length(forest$Y.hat)) {
+  if (class(subset) == "logical" && length(subset) == length(forest$Y.hat)) {
     subset <- which(subset)
   }
 

--- a/r-package/grf/R/average_partial_effect.R
+++ b/r-package/grf/R/average_partial_effect.R
@@ -57,7 +57,7 @@ average_partial_effect <- function(forest,
     subset <- 1:length(forest$Y.hat)
   }
 
-  if (class(subset) == "logical" & length(subset) == length(forest$Y.hat)) {
+  if (class(subset) == "logical" && length(subset) == length(forest$Y.hat)) {
     subset <- which(subset)
   }
 

--- a/r-package/grf/R/average_treatment_effect.R
+++ b/r-package/grf/R/average_treatment_effect.R
@@ -75,7 +75,7 @@ average_treatment_effect <- function(forest,
     stop("Average effect estimation only implemented for causal_forest")
   }
 
-  if (cluster.se & method == "TMLE") {
+  if (cluster.se && method == "TMLE") {
     stop("TMLE has not yet been implemented with clustered observations.")
   }
 
@@ -83,7 +83,7 @@ average_treatment_effect <- function(forest,
     subset <- 1:length(forest$Y.hat)
   }
 
-  if (class(subset) == "logical" & length(subset) == length(forest$Y.hat)) {
+  if (class(subset) == "logical" && length(subset) == length(forest$Y.hat)) {
     subset <- which(subset)
   }
 

--- a/r-package/grf/R/causal_forest.R
+++ b/r-package/grf/R/causal_forest.R
@@ -354,7 +354,7 @@ predict.causal_forest <- function(object, newdata = NULL,
   allow.na <- !local.linear
 
   # If possible, use pre-computed predictions.
-  if (is.null(newdata) & !estimate.variance & !local.linear & !is.null(object$predictions)) {
+  if (is.null(newdata) && !estimate.variance && !local.linear && !is.null(object$predictions)) {
     return(data.frame(
       predictions = object$predictions,
       debiased.error = object$debiased.error,

--- a/r-package/grf/R/forest_summary.R
+++ b/r-package/grf/R/forest_summary.R
@@ -145,7 +145,7 @@ best_linear_projection <- function(forest,
     subset <- 1:length(forest$Y.hat)
   }
 
-  if (class(subset) == "logical" & length(subset) == length(forest$Y.hat)) {
+  if (class(subset) == "logical" && length(subset) == length(forest$Y.hat)) {
     subset <- which(subset)
   }
 

--- a/r-package/grf/R/input_utilities.R
+++ b/r-package/grf/R/input_utilities.R
@@ -116,7 +116,7 @@ validate_ll_vars <- function(linear.correction.variables, num.cols) {
     stop("Linear correction variables must take positive integer values.")
   } else if (max(linear.correction.variables) > num.cols) {
     stop("Invalid range of correction variables.")
-  } else if (!is.vector(linear.correction.variables) |
+  } else if (!is.vector(linear.correction.variables) ||
     !all(linear.correction.variables == floor(linear.correction.variables))) {
     stop("Linear correction variables must be a vector of integers.")
   }
@@ -126,7 +126,7 @@ validate_ll_vars <- function(linear.correction.variables, num.cols) {
 validate_ll_lambda <- function(lambda) {
   if (lambda < 0) {
     stop("Lambda cannot be negative.")
-  } else if (!is.numeric(lambda) | length(lambda) > 1) {
+  } else if (!is.numeric(lambda) || length(lambda) > 1) {
     stop("Lambda must be a scalar.")
   }
   lambda

--- a/r-package/grf/R/instrumental_forest.R
+++ b/r-package/grf/R/instrumental_forest.R
@@ -259,7 +259,7 @@ predict.instrumental_forest <- function(object, newdata = NULL,
                                         ...) {
 
   # If possible, use pre-computed predictions.
-  if (is.null(newdata) & !estimate.variance & !is.null(object$predictions)) {
+  if (is.null(newdata) && !estimate.variance && !is.null(object$predictions)) {
     return(data.frame(
       predictions = object$predictions,
       debiased.error = object$debiased.error

--- a/r-package/grf/R/quantile_forest.R
+++ b/r-package/grf/R/quantile_forest.R
@@ -96,9 +96,9 @@ quantile_forest <- function(X, Y,
                             compute.oob.predictions = FALSE,
                             num.threads = NULL,
                             seed = runif(1, 0, .Machine$integer.max)) {
-  if (!is.numeric(quantiles) | length(quantiles) < 1) {
+  if (!is.numeric(quantiles) || length(quantiles) < 1) {
     stop("Error: Must provide numeric quantiles")
-  } else if (min(quantiles) <= 0 | max(quantiles) >= 1) {
+  } else if (min(quantiles) <= 0 || max(quantiles) >= 1) {
     stop("Error: Quantiles must be in (0, 1)")
   }
 
@@ -183,16 +183,16 @@ predict.quantile_forest <- function(object,
   if (is.null(quantiles)) {
     quantiles <- object[["quantiles.orig"]]
   } else {
-    if (!is.numeric(quantiles) | length(quantiles) < 1) {
+    if (!is.numeric(quantiles) || length(quantiles) < 1) {
       stop("Error: Must provide numeric quantiles")
-    } else if (min(quantiles) <= 0 | max(quantiles) >= 1) {
+    } else if (min(quantiles) <= 0 || max(quantiles) >= 1) {
       stop("Error: Quantiles must be in (0, 1)")
     }
   }
 
   # If possible, use pre-computed predictions.
   quantiles.orig <- object[["quantiles.orig"]]
-  if (is.null(newdata) & identical(quantiles, quantiles.orig) & !is.null(object$predictions)) {
+  if (is.null(newdata) && identical(quantiles, quantiles.orig) && !is.null(object$predictions)) {
     return(object$predictions)
   }
 

--- a/r-package/grf/R/regression_forest.R
+++ b/r-package/grf/R/regression_forest.R
@@ -246,7 +246,7 @@ predict.regression_forest <- function(object, newdata = NULL,
   allow.na <- !local.linear
 
   # If possible, use pre-computed predictions.
-  if (is.null(newdata) & !estimate.variance & !local.linear & !is.null(object$predictions)) {
+  if (is.null(newdata) && !estimate.variance && !local.linear && !is.null(object$predictions)) {
     return(data.frame(
       predictions = object$predictions,
       debiased.error = object$debiased.error,

--- a/r-package/grf/R/survival_forest.R
+++ b/r-package/grf/R/survival_forest.R
@@ -236,7 +236,7 @@ survival_forest <- function(X, Y, D,
 predict.survival_forest <- function(object, newdata = NULL, num.threads = NULL, ...) {
   failure.times = object[["failure.times"]]
   # If possible, use pre-computed predictions.
-  if (is.null(newdata) & !is.null(object$predictions)) {
+  if (is.null(newdata) && !is.null(object$predictions)) {
     return(list(predictions = object$predictions, failure.times = failure.times))
   }
 


### PR DESCRIPTION
The current grf style is to prefer `&&` over `&` as it short-circuits. This PR makes everything adhere to this where element-wise comparison is not needed with `&` or `|`.