### PR TITLE
Simplify some R build options in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,8 +73,8 @@ matrix:
       script:
         - cd ..
         - Rscript build_package.R
-      # Render the examples under vignettes/ and build the package documentation
-      # with 'pkgdown'. Also install required packages for vignette examples, like glmnet.
+      # Render the examples under vignettes/ and build the package documentation with 'pkgdown'.
+      # Also install required packages for vignette examples, like glmnet.
       before_deploy:
         - cd grf
         - cp ../../README.md .

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,11 @@ branches:
     - master
 
 r_packages:
+  # build_package.R requirements.
   - devtools
   - testthat
   - roxygen2
-  # Vignettes
-  - ggplot2
-  - glmnet
-  - knitr
-  - rmarkdown
-  - pkgdown
+  # Vignette requirements are installed in the `deploy` section.
 
 matrix:
   include:
@@ -77,13 +73,16 @@ matrix:
       script:
         - cd ..
         - Rscript build_package.R
-      # Render the examples under vignettes/ and build the package documentation.
+      # Render the examples under vignettes/ and build the package documentation
+      # with 'pkgdown'. Also install required packages for vignette examples, like glmnet.
       before_deploy:
         - cd grf
         - cp ../../README.md .
         - cp ../../REFERENCE.md .
         - cp ../../DEVELOPING.md .
         - cp ../../releases/CHANGELOG.md .
+        - Rscript -e 'install.packages("pkgdown")'
+        - Rscript -e 'install.packages(c("ggplot2", "glmnet"))'
         - Rscript -e 'pkgdown::build_site()'
         - cp pkgdown/favicon/* docs/
       deploy:


### PR DESCRIPTION
Move some requirements not needed for pull request builds to the `deploy` section. This may speed up PR build times.