### PR TITLE
Add option to predict at chosen failure times

### DIFF
--- a/core/src/prediction/SurvivalPredictionStrategy.cpp
+++ b/core/src/prediction/SurvivalPredictionStrategy.cpp
@@ -31,7 +31,7 @@ std::vector<double> SurvivalPredictionStrategy::predict(size_t prediction_sample
     const std::unordered_map<size_t, double>& weights_by_sample,
     const Data& train_data,
     const Data& data) const {
-  // the failure times will always range from 0, ..., num_failures
+  // the event times will always range from 0, ..., num_failures
   // where num_failures is the count of failures in the training data.
   std::vector<double> count_failure(num_failures + 1);
   std::vector<double> count_censor(num_failures + 1);

--- a/core/src/prediction/SurvivalPredictionStrategy.h
+++ b/core/src/prediction/SurvivalPredictionStrategy.h
@@ -37,6 +37,9 @@ public:
    * (Variance and error estimates are not supported).
    *
    * num_failures: the count of failures in the training data.
+   * The event times retrieved from data.get_outcome(sample) will always be
+   * integers in the range 0, ..., num_failures.
+   *
    */
   SurvivalPredictionStrategy(size_t num_failures);
 

--- a/r-package/grf/tests/testthat/test_survival_forest.R
+++ b/r-package/grf/tests/testthat/test_survival_forest.R
@@ -42,6 +42,14 @@ test_that("a simple survival forest workflow works", {
 
   tree <- get_tree(sf, 1)
   expect_equal(length(tree[["nodes"]]), 1)
+
+  # Predicting at the same custom grid as the training grid gives the same result
+  failure.times <- sf$failure.times
+  survival.oob.grid <- predict(sf, failure.times = failure.times)$predictions
+  survival.grid <- predict(sf, X, failure.times = failure.times)$predictions
+
+  expect_equal(survival.oob.grid, survival.oob)
+  expect_equal(survival.grid, survival)
 })
 
 test_that("sample weighted survival prediction is invariant to weight rescaling", {


### PR DESCRIPTION
Add the optional argument `failure.times` to survival forest `predict` allowing a user to make predictions at a chosen set of failure times (addresses https://github.com/grf-labs/grf/pull/647#discussion_r417000237) 

```R
n <- 2000
p <- 5
X <- matrix(rnorm(n * p), n, p)
failure.time <- exp(0.5 * X[, 1]) * rexp(n)
censor.time <- 2 * rexp(n)
Y <- pmin(failure.time, censor.time)
D <- as.integer(failure.time <= censor.time)
s.forest <- survival_forest(X, Y, D)

s.pred <- predict(s.forest, failure.times = c(0.1, 0.5, 1))
> head(s.pred$predictions)
          [,1]      [,2]      [,3]
[1,] 0.6805962 0.4427821 0.2464440
[2,] 0.4981635 0.3594178 0.3371501
[3,] 0.6571849 0.4276589 0.3011384
[4,] 0.8025943 0.6352667 0.3622079
[5,] 0.7312466 0.4533023 0.2704999
[6,] 0.6335301 0.4036986 0.2226021
```

