### PR TITLE
Remove passing explicit default options to `findInterval()`

### DIFF
--- a/core/test/prediction/README.md
+++ b/core/test/prediction/README.md
@@ -15,7 +15,7 @@ censor.time <- rexp(n)
 Y <- pmin(failure.time, censor.time)
 D <- as.integer(failure.time <= censor.time)
 failure.times <- sort(unique(Y[D == 1]))
-Y.relabeled <- findInterval(Y, failure.times, rightmost.closed = FALSE, all.inside = FALSE, left.open = FALSE)
+Y.relabeled <- findInterval(Y, failure.times)
 
 kaplan.meier <- survfit(Surv(Y, D) ~ 1, data = data.frame(Y, D))
 

--- a/r-package/grf/R/survival_forest.R
+++ b/r-package/grf/R/survival_forest.R
@@ -137,7 +137,7 @@ survival_forest <- function(X, Y, D,
   if (is.null(failure.times)) {
     failure.times <- sort(unique(Y[D == 1]))
   }
-  Y.relabeled <- findInterval(Y, failure.times, rightmost.closed = FALSE, all.inside = FALSE, left.open = FALSE)
+  Y.relabeled <- findInterval(Y, failure.times)
 
   data <- create_train_matrices(X, outcome = Y.relabeled, sample.weights = sample.weights, censor = D)
   args <- list(num.trees = num.trees,
@@ -243,7 +243,7 @@ predict.survival_forest <- function(object,
     failure.times <- object[["failure.times"]]
     Y.relabeled <- object[["Y.relabeled"]]
   } else {
-    Y.relabeled <- findInterval(object[["Y.orig"]], failure.times, rightmost.closed = FALSE, all.inside = FALSE, left.open = FALSE)
+    Y.relabeled <- findInterval(object[["Y.orig"]], failure.times)
   }
 
   # If possible, use pre-computed predictions.


### PR DESCRIPTION
Survival analysis relies on `base::findInterval(Y.values, failure.values, rightmost.closed = FALSE, all.inside = FALSE, left.open = FALSE)` to relabel the event times.

These arguments are all FALSE by default, but were stated explicitly in case different R versions had different behavior.  

This PR removes declaring these redundant arguments as all R versions which grf supports (>= 3.5) does not break this.


