### PR TITLE
Clarify the survival forest prediction documentation

### DIFF
--- a/r-package/grf/R/survival_forest.R
+++ b/r-package/grf/R/survival_forest.R
@@ -187,7 +187,9 @@ survival_forest <- function(X, Y, D,
 #'                    automatically selects an appropriate amount.
 #' @param ... Additional arguments (currently ignored).
 #'
-#' @return Vector of predictions.
+#' @return A list with elements `failure.times`: a vector of event times t for the survival curve,
+#'  and `predictions`: a matrix of survival curves. Each row is the survival curve for
+#'  sample X_i: predictions[i, j] = S(failure.times[j], X_i).
 #'
 #' @examples
 #' \donttest{

--- a/r-package/grf/R/survival_forest.R
+++ b/r-package/grf/R/survival_forest.R
@@ -182,7 +182,7 @@ survival_forest <- function(X, Y, D,
 #'                that this matrix should have the number of columns as the training
 #'                matrix, and that the columns must appear in the same order.
 #' @param failure.times A vector of failure times to make predictions at. If NULL, then the
-#'  failure times used for training the forest is used. Default is NULL.
+#'  failure times used for training the forest is used. The time points should be in increasing order. Default is NULL.
 #' @param num.threads Number of threads used in training. If set to NULL, the software
 #'                    automatically selects an appropriate amount.
 #' @param ... Additional arguments (currently ignored).


### PR DESCRIPTION
* Clarify the return value in prediction.

* State that if `failure.times` are passed, they should be in increasing order.

Thanks to @davidahirshberg for pointing this out