### PR TITLE
Add optional Nelson-Aalen estimates of the survival function

### DIFF
--- a/core/src/forest/ForestPredictors.cpp
+++ b/core/src/forest/ForestPredictors.cpp
@@ -71,9 +71,10 @@ ForestPredictor ll_causal_predictor(uint num_threads,
   return ForestPredictor(num_threads, std::move(prediction_strategy));
 }
 
-ForestPredictor survival_predictor(uint num_threads, size_t num_failures) {
+ForestPredictor survival_predictor(uint num_threads, size_t num_failures, int prediction_type) {
   num_threads = ForestOptions::validate_num_threads(num_threads);
-  std::unique_ptr<DefaultPredictionStrategy> prediction_strategy(new SurvivalPredictionStrategy(num_failures));
+  std::unique_ptr<DefaultPredictionStrategy> prediction_strategy(
+    new SurvivalPredictionStrategy(num_failures, prediction_type));
   return ForestPredictor(num_threads, std::move(prediction_strategy));
 }
 

--- a/core/src/forest/ForestPredictors.h
+++ b/core/src/forest/ForestPredictors.h
@@ -41,7 +41,7 @@ ForestPredictor ll_causal_predictor(uint num_threads,
                                    bool weight_penalty,
                                    std::vector<size_t> linear_correction_variables);
 
-ForestPredictor survival_predictor(uint num_threads, size_t num_failures);
+ForestPredictor survival_predictor(uint num_threads, size_t num_failures, int prediction_type);
 
 } // namespace grf
 

--- a/core/src/prediction/SurvivalPredictionStrategy.cpp
+++ b/core/src/prediction/SurvivalPredictionStrategy.cpp
@@ -24,9 +24,13 @@ const int SurvivalPredictionStrategy::KAPLAN_MEIER = 0;
 const int SurvivalPredictionStrategy::NELSON_AALEN = 1;
 
 SurvivalPredictionStrategy::SurvivalPredictionStrategy(size_t num_failures,
-                                                       int prediction_type) :
-  num_failures(num_failures),
-  prediction_type(prediction_type) {};
+                                                       int prediction_type) {
+  if (prediction_type != 0 || prediction_type != 1) {
+    throw std::runtime_error("SurvivalPredictionStrategy: unknown prediction type");
+  }
+  this->num_failures = num_failures;
+  this->prediction_type = prediction_type;
+}
 
 size_t SurvivalPredictionStrategy::prediction_length() const {
   return num_failures;
@@ -58,8 +62,6 @@ std::vector<double> SurvivalPredictionStrategy::predict(size_t prediction_sample
     return predict_nelson_aalen(count_failure, count_censor, sum);
   } else if (prediction_type == KAPLAN_MEIER) {
     return predict_kaplan_meier(count_failure, count_censor, sum);
-  } else {
-    throw std::runtime_error("SurvivalPredictionStrategy: unknown prediction type");
   }
 }
 

--- a/core/src/prediction/SurvivalPredictionStrategy.cpp
+++ b/core/src/prediction/SurvivalPredictionStrategy.cpp
@@ -82,6 +82,19 @@ std::vector<double> SurvivalPredictionStrategy::predict_nelson_aalen(
   const std::vector<double>& count_censor,
   double sum) const {
   // Nelson-Aalen estimator of the survival function S(t)
+  double nelson_aalen = 0;
+  sum = sum - count_censor[0];
+  std::vector<double> survival_function(num_failures);
+
+  for (size_t time = 1; time <= num_failures; time++) {
+    if (sum > 0) {
+      nelson_aalen = nelson_aalen - count_failure[time] / sum;
+    }
+    survival_function[time - 1] = exp(nelson_aalen);
+    sum = sum - count_failure[time] - count_censor[time];
+  }
+
+   return survival_function;
 }
 
 std::vector<double> SurvivalPredictionStrategy::compute_variance(

--- a/core/src/prediction/SurvivalPredictionStrategy.cpp
+++ b/core/src/prediction/SurvivalPredictionStrategy.cpp
@@ -48,6 +48,14 @@ std::vector<double> SurvivalPredictionStrategy::predict(size_t prediction_sample
     }
     sum += forest_weight * sample_weight;
   }
+
+  return predict_kaplan_meier(count_failure, count_censor, sum);
+}
+
+std::vector<double> SurvivalPredictionStrategy::predict_kaplan_meier(
+  const std::vector<double>& count_failure,
+  const std::vector<double>& count_censor,
+  double sum) const {
   // Kaplan–Meier estimator of the survival function S(t)
   double kaplan_meier = 1;
   sum = sum - count_censor[0];
@@ -67,6 +75,13 @@ std::vector<double> SurvivalPredictionStrategy::predict(size_t prediction_sample
   }
 
   return survival_function;
+}
+
+std::vector<double> SurvivalPredictionStrategy::predict_nelson_aalen(
+  const std::vector<double>& count_failure,
+  const std::vector<double>& count_censor,
+  double sum) const {
+  // Nelson-Aalen estimator of the survival function S(t)
 }
 
 std::vector<double> SurvivalPredictionStrategy::compute_variance(

--- a/core/src/prediction/SurvivalPredictionStrategy.cpp
+++ b/core/src/prediction/SurvivalPredictionStrategy.cpp
@@ -20,8 +20,13 @@
 
 namespace grf {
 
-SurvivalPredictionStrategy::SurvivalPredictionStrategy(size_t num_failures) :
-  num_failures(num_failures) {};
+const int SurvivalPredictionStrategy::KAPLAN_MEIER = 0;
+const int SurvivalPredictionStrategy::NELSON_AALEN = 1;
+
+SurvivalPredictionStrategy::SurvivalPredictionStrategy(size_t num_failures,
+                                                       int prediction_type) :
+  num_failures(num_failures),
+  prediction_type(prediction_type) {};
 
 size_t SurvivalPredictionStrategy::prediction_length() const {
   return num_failures;
@@ -49,7 +54,13 @@ std::vector<double> SurvivalPredictionStrategy::predict(size_t prediction_sample
     sum += forest_weight * sample_weight;
   }
 
-  return predict_kaplan_meier(count_failure, count_censor, sum);
+  if (prediction_type == NELSON_AALEN) {
+    return predict_nelson_aalen(count_failure, count_censor, sum);
+  } else if (prediction_type == KAPLAN_MEIER) {
+    return predict_kaplan_meier(count_failure, count_censor, sum);
+  } else {
+    throw std::runtime_error("SurvivalPredictionStrategy: unknown prediction type");
+  }
 }
 
 std::vector<double> SurvivalPredictionStrategy::predict_kaplan_meier(

--- a/core/src/prediction/SurvivalPredictionStrategy.cpp
+++ b/core/src/prediction/SurvivalPredictionStrategy.cpp
@@ -25,7 +25,7 @@ const int SurvivalPredictionStrategy::NELSON_AALEN = 1;
 
 SurvivalPredictionStrategy::SurvivalPredictionStrategy(size_t num_failures,
                                                        int prediction_type) {
-  if (prediction_type != 0 || prediction_type != 1) {
+  if (!(prediction_type == 0 || prediction_type == 1)) {
     throw std::runtime_error("SurvivalPredictionStrategy: unknown prediction type");
   }
   this->num_failures = num_failures;

--- a/core/src/prediction/SurvivalPredictionStrategy.h
+++ b/core/src/prediction/SurvivalPredictionStrategy.h
@@ -59,6 +59,16 @@ public:
     size_t ci_group_size) const;
 
 private:
+  std::vector<double> predict_kaplan_meier(
+    const std::vector<double>& count_failure,
+    const std::vector<double>& count_censor,
+    double sum) const;
+
+  std::vector<double> predict_nelson_aalen(
+    const std::vector<double>& count_failure,
+    const std::vector<double>& count_censor,
+    double sum) const;
+
   size_t num_failures;
 };
 

--- a/core/src/prediction/SurvivalPredictionStrategy.h
+++ b/core/src/prediction/SurvivalPredictionStrategy.h
@@ -27,12 +27,15 @@ namespace grf {
 
 class SurvivalPredictionStrategy final: public DefaultPredictionStrategy {
 public:
+  static const int KAPLAN_MEIER;
+  static const int NELSON_AALEN;
 
   /**
-   * Compute Kaplan-Meier estimates of the survival function.
+   * Compute the Kaplan-Meier (prediction_type = 0) or the Nelson-Aalen
+   * (prediction_type = 1) estimates of the survival function.
    *
    * This estimate is weighted by the random forest weights (alpha) and
-   * the sample weights.
+   * if provided, the sample weights.
    *
    * (Variance and error estimates are not supported).
    *
@@ -41,7 +44,8 @@ public:
    * integers in the range 0, ..., num_failures.
    *
    */
-  SurvivalPredictionStrategy(size_t num_failures);
+  SurvivalPredictionStrategy(size_t num_failures,
+                             int prediction_type);
 
   size_t prediction_length() const;
 
@@ -70,6 +74,7 @@ private:
     double sum) const;
 
   size_t num_failures;
+  size_t prediction_type;
 };
 
 } // namespace grf

--- a/core/test/forest/ForestCharacterizationTest.cpp
+++ b/core/test/forest/ForestCharacterizationTest.cpp
@@ -387,7 +387,8 @@ TEST_CASE("survival forest predictions have not changed", "[survival], [characte
   ForestOptions options = ForestTestUtilities::default_options();
   Forest forest = trainer.train(*data, options);
 
-  ForestPredictor predictor = survival_predictor(4, num_failures);
+  int prediction_type = 0;
+  ForestPredictor predictor = survival_predictor(4, num_failures, prediction_type);
   std::vector<Prediction> oob_predictions = predictor.predict_oob(forest, *data, false);
   std::vector<Prediction> predictions = predictor.predict(forest, *data, *data, false);
 
@@ -415,7 +416,8 @@ TEST_CASE("survival forest predictions with NaNs have not changed", "[NaN], [sur
   ForestOptions options = ForestTestUtilities::default_options();
   Forest forest = trainer.train(*data, options);
 
-  ForestPredictor predictor = survival_predictor(4, num_failures);
+  int prediction_type = 0;
+  ForestPredictor predictor = survival_predictor(4, num_failures, prediction_type);
   std::vector<Prediction> oob_predictions = predictor.predict_oob(forest, *data, false);
   std::vector<Prediction> predictions = predictor.predict(forest, *data, *data, false);
 

--- a/core/test/prediction/README.md
+++ b/core/test/prediction/README.md
@@ -17,9 +17,10 @@ D <- as.integer(failure.time <= censor.time)
 failure.times <- sort(unique(Y[D == 1]))
 Y.relabeled <- findInterval(Y, failure.times)
 
-kaplan.meier <- survfit(Surv(Y, D) ~ 1, data = data.frame(Y, D))
+sfit <- survfit(Surv(Y, D) ~ 1, data = data.frame(Y, D))
 
 length(failure.times) # num_failures
 dput(c(Y.relabeled, D)) # data_matrix
-dput(summary(kaplan.meier)$surv) # expected_predictions
+dput(summary(sfit)$surv) # expected_predictions Kaplan-Meier
+dput(exp(-sfit$cumhaz[D[order(Y)] == 1])) # expected_predictions Nelson-Aalen
 ```

--- a/core/test/prediction/SurvivalPredictionStrategyTest.cpp
+++ b/core/test/prediction/SurvivalPredictionStrategyTest.cpp
@@ -132,6 +132,49 @@ TEST_CASE("Kaplan-Meier estimates on duplicated data is the same as with sample 
   }
 }
 
+TEST_CASE("Nelson-Aalen survival estimates are correct", "[survival], [prediction]") {
+  size_t num_failures = 22;
+  size_t num_rows = 50;
+  size_t num_cols = 2;
+  size_t outcome_index = 0;
+
+  std::vector<double> data_matrix = {
+    4L, 22L, 14L, 0L, 7L, 20L, 17L, 12L, 11L, 5L, 8L, 4L, 3L, 19L,
+    4L, 2L, 0L, 10L, 7L, 10L, 9L, 6L, 19L, 14L, 16L, 5L, 8L, 5L,
+    1L, 12L, 18L, 9L, 22L, 22L, 18L, 21L, 14L, 0L, 18L, 13L, 18L,
+    14L, 1L, 5L, 21L, 15L, 5L, 22L, 18L, 5L, 0L, 0L, 1L, 0L, 0L,
+    1L, 1L, 1L, 1L, 0L, 0L, 1L, 1L, 0L, 0L, 1L, 0L, 0L, 1L, 1L, 1L,
+    1L, 1L, 0L, 1L, 0L, 1L, 1L, 1L, 0L, 1L, 0L, 0L, 0L, 0L, 1L, 0L,
+    0L, 0L, 1L, 0L, 0L, 0L, 0L, 0L, 1L, 0L, 1L, 0L, 0L
+  };
+
+  std::vector<double> expected_predictions = {
+    0.97894815422497, 0.957433685808603, 0.93591923773897, 0.914404811451839,
+    0.891828076215377, 0.865979823358339, 0.840131627802034, 0.813463058299102,
+    0.785890725111755, 0.757316087518952, 0.727621298988366, 0.697926678757696,
+    0.666912936246344, 0.635899453849941, 0.599572517227092, 0.563246254787088,
+    0.526920805646219, 0.490596349988852, 0.439004902655648, 0.380563647994161,
+    0.322140173184762, 0.25088301913505
+  };
+
+  DefaultData data(data_matrix, num_rows, num_cols);
+  data.set_outcome_index(outcome_index);
+  data.set_censor_index(outcome_index + 1);
+
+  std::unordered_map<size_t, double> weights_by_sample;
+  for (size_t i = 0; i < num_rows; i++) {
+    weights_by_sample[i] = 1.0;
+  }
+
+  int prediction_type = 1; // Nelson-Aalen
+  SurvivalPredictionStrategy prediction_strategy(num_failures, prediction_type);
+  std::vector<double> predictions = prediction_strategy.predict(0, weights_by_sample, data, data);
+
+  for (size_t i = 0; i < predictions.size(); i++) {
+    REQUIRE(equal_doubles(predictions[i], expected_predictions[i], 1e-10));
+  }
+}
+
 TEST_CASE("Nelson-Aalen estimates on duplicated data is the same as with sample weights equal to two", "[survival], [prediction]") {
   size_t num_failures = 24;
   size_t num_rows = 50;

--- a/core/test/prediction/SurvivalPredictionStrategyTest.cpp
+++ b/core/test/prediction/SurvivalPredictionStrategyTest.cpp
@@ -57,7 +57,8 @@ TEST_CASE("Kaplan-Meier survival estimates are correct", "[survival], [predictio
     weights_by_sample[i] = 1.0;
   }
 
-  SurvivalPredictionStrategy prediction_strategy(num_failures);
+  int prediction_type = 0; // Kaplan-Meier
+  SurvivalPredictionStrategy prediction_strategy(num_failures, prediction_type);
   std::vector<double> predictions = prediction_strategy.predict(0, weights_by_sample, data, data);
 
   for (size_t i = 0; i < predictions.size(); i++) {
@@ -118,7 +119,74 @@ TEST_CASE("Kaplan-Meier estimates on duplicated data is the same as with sample 
     weights_by_sample[i] = 1.0;
   }
 
-  SurvivalPredictionStrategy prediction_strategy(num_failures);
+  int prediction_type = 0;
+  SurvivalPredictionStrategy prediction_strategy(num_failures, prediction_type);
+  std::vector<double> predictions_weighted = prediction_strategy.predict(0, weights_by_sample, data, data);
+  for (size_t i = num_rows; i < num_rows + num_duplicates; i++) {
+    weights_by_sample[i] = 1.0;
+  }
+  std::vector<double> predictions_duplicated = prediction_strategy.predict(0, weights_by_sample, data_duplicated, data_duplicated);
+
+  for (size_t i = 0; i < predictions_duplicated.size(); i++) {
+    REQUIRE(equal_doubles(predictions_weighted[i], predictions_duplicated[i], 1e-10));
+  }
+}
+
+TEST_CASE("Nelson-Aalen estimates on duplicated data is the same as with sample weights equal to two", "[survival], [prediction]") {
+  size_t num_failures = 24;
+  size_t num_rows = 50;
+  size_t num_cols = 2;
+  size_t outcome_index = 0;
+
+  std::vector<double> data_matrix = {
+    10L, 22L, 19L, 0L, 18L, 7L, 6L, 13L, 4L, 14L, 5L, 10L, 24L,
+    4L, 9L, 23L, 4L, 3L, 16L, 11L, 11L, 7L, 20L, 7L, 21L, 1L, 23L,
+    10L, 24L, 7L, 15L, 2L, 12L, 8L, 17L, 14L, 9L, 10L, 2L, 11L, 23L,
+    20L, 16L, 8L, 8L, 10L, 24L, 23L, 22L, 10L, 0L, 1L, 1L, 0L, 1L,
+    1L, 1L, 1L, 0L, 0L, 1L, 0L, 0L, 1L, 0L, 0L, 0L, 1L, 1L, 0L, 1L,
+    0L, 0L, 0L, 1L, 1L, 0L, 0L, 0L, 0L, 1L, 0L, 1L, 0L, 1L, 1L, 1L,
+    1L, 1L, 0L, 1L, 1L, 0L, 0L, 1L, 0L, 1L, 0L, 0L, 0L
+  };
+
+  // Duplicate the first 10 samples
+  std::vector<double> data_matrix_duplicated = {
+    10L, 22L, 19L, 0L, 18L, 7L, 6L, 13L, 4L, 14L, 5L, 10L, 24L,
+    4L, 9L, 23L, 4L, 3L, 16L, 11L, 11L, 7L, 20L, 7L, 21L, 1L, 23L,
+    10L, 24L, 7L, 15L, 2L, 12L, 8L, 17L, 14L, 9L, 10L, 2L, 11L, 23L,
+    20L, 16L, 8L, 8L, 10L, 24L, 23L, 22L, 10L,
+    10L, 22L, 19L, 0L, 18L, 7L, 6L, 13L, 4L, 14L, // duplicated
+    0L, 1L, 1L, 0L, 1L, 1L, 1L, 1L, 0L, 0L, 1L, 0L, 0L, 1L, 0L, 0L,
+    0L, 1L, 1L, 0L, 1L, 0L, 0L, 0L, 1L, 1L, 0L, 0L, 0L, 0L, 1L, 0L,
+    1L, 0L, 1L, 1L, 1L, 1L, 1L, 0L, 1L, 1L, 0L, 0L, 1L, 0L, 1L, 0L, 0L,
+    0L, 0L, 1L, 1L, 0L, 1L, 1L, 1L, 1L, 0L, 0L // duplicated
+  };
+
+  // add sample weights
+  size_t num_duplicates = 10;
+  for (size_t i = 0; i < num_rows; i++) {
+    if (i < num_duplicates) {
+      data_matrix.push_back(2);
+    } else {
+      data_matrix.push_back(1);
+    }
+  }
+
+  DefaultData data(data_matrix, num_rows, num_cols + 1);
+  data.set_outcome_index(outcome_index);
+  data.set_censor_index(outcome_index + 1);
+  data.set_weight_index(outcome_index + 2);
+
+  DefaultData data_duplicated(data_matrix_duplicated, num_rows + num_duplicates, num_cols);
+  data_duplicated.set_outcome_index(outcome_index);
+  data_duplicated.set_censor_index(outcome_index + 1);
+
+  std::unordered_map<size_t, double> weights_by_sample;
+  for (size_t i = 0; i < num_rows; i++) {
+    weights_by_sample[i] = 1.0;
+  }
+
+  int prediction_type = 1;
+  SurvivalPredictionStrategy prediction_strategy(num_failures, prediction_type);
   std::vector<double> predictions_weighted = prediction_strategy.predict(0, weights_by_sample, data, data);
   for (size_t i = num_rows; i < num_rows + num_duplicates; i++) {
     weights_by_sample[i] = 1.0;

--- a/r-package/grf/R/RcppExports.R
+++ b/r-package/grf/R/RcppExports.R
@@ -97,15 +97,15 @@ ll_regression_predict_oob <- function(forest_object, train_matrix, sparse_train_
     .Call('_grf_ll_regression_predict_oob', PACKAGE = 'grf', forest_object, train_matrix, sparse_train_matrix, outcome_index, ll_lambda, ll_weight_penalty, linear_correction_variables, num_threads, estimate_variance)
 }
 
-survival_train <- function(train_matrix, sparse_train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, alpha, num_failures, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed) {
-    .Call('_grf_survival_train', PACKAGE = 'grf', train_matrix, sparse_train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, alpha, num_failures, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed)
+survival_train <- function(train_matrix, sparse_train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, alpha, num_failures, clusters, samples_per_cluster, compute_oob_predictions, prediction_type, num_threads, seed) {
+    .Call('_grf_survival_train', PACKAGE = 'grf', train_matrix, sparse_train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, alpha, num_failures, clusters, samples_per_cluster, compute_oob_predictions, prediction_type, num_threads, seed)
 }
 
-survival_predict <- function(forest_object, train_matrix, sparse_train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, test_matrix, sparse_test_matrix, num_threads, num_failures) {
-    .Call('_grf_survival_predict', PACKAGE = 'grf', forest_object, train_matrix, sparse_train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, test_matrix, sparse_test_matrix, num_threads, num_failures)
+survival_predict <- function(forest_object, train_matrix, sparse_train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, prediction_type, test_matrix, sparse_test_matrix, num_threads, num_failures) {
+    .Call('_grf_survival_predict', PACKAGE = 'grf', forest_object, train_matrix, sparse_train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, prediction_type, test_matrix, sparse_test_matrix, num_threads, num_failures)
 }
 
-survival_predict_oob <- function(forest_object, train_matrix, sparse_train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, num_threads, num_failures) {
-    .Call('_grf_survival_predict_oob', PACKAGE = 'grf', forest_object, train_matrix, sparse_train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, num_threads, num_failures)
+survival_predict_oob <- function(forest_object, train_matrix, sparse_train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, prediction_type, num_threads, num_failures) {
+    .Call('_grf_survival_predict_oob', PACKAGE = 'grf', forest_object, train_matrix, sparse_train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, prediction_type, num_threads, num_failures)
 }
 

--- a/r-package/grf/R/input_utilities.R
+++ b/r-package/grf/R/input_utilities.R
@@ -172,6 +172,16 @@ validate_sample_weights <- function(sample.weights, X) {
   }
 }
 
+validate_prediction_type <- function(prediction.type) {
+  type <- match.arg(tolower(prediction.type), c("kaplan-meier", "nelson-aalen"))
+  if (type == "kaplan-meier") {
+    return (0)
+  }
+  if (type == "nelson-aalen") {
+    return (1)
+  }
+}
+
 #' @importFrom Matrix Matrix cBind
 #' @importFrom methods new
 create_train_matrices <- function(X, outcome = NULL, treatment = NULL,

--- a/r-package/grf/R/survival_forest.R
+++ b/r-package/grf/R/survival_forest.R
@@ -47,7 +47,7 @@
 #' @param alpha A tuning parameter that controls the maximum imbalance of a split. Default is 0.05
 #'  (meaning the count of failures on each side of a split has to be at least 5 \% of the total observation count in a node)
 #' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed. Default is TRUE.
-#' @param prediction.type The type of estimate of the survival function, choices are "Kaplan-Meier" and "Nelson-Aalen".
+#' @param prediction.type The type of estimate of the survival function, choices are "Kaplan-Meier" or "Nelson-Aalen".
 #' Only relevant if `compute.oob.predictions` is TRUE. Default is "Kaplan-Meier".
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency.
@@ -189,7 +189,7 @@ survival_forest <- function(X, Y, D,
 #'                matrix, and that the columns must appear in the same order.
 #' @param failure.times A vector of failure times to make predictions at. If NULL, then the
 #'  failure times used for training the forest is used. The time points should be in increasing order. Default is NULL.
-#' @param prediction.type The type of estimate of the survival function, choices are "Kaplan-Meier" and "Nelson-Aalen".
+#' @param prediction.type The type of estimate of the survival function, choices are "Kaplan-Meier" or "Nelson-Aalen".
 #'  Default is "Kaplan-Meier".
 #' @param num.threads Number of threads used in training. If set to NULL, the software
 #'                    automatically selects an appropriate amount.

--- a/r-package/grf/R/survival_forest.R
+++ b/r-package/grf/R/survival_forest.R
@@ -178,8 +178,8 @@ survival_forest <- function(X, Y, D,
 
 #' Predict with a survival forest forest
 #'
-#' Gets estimates of the conditional survival function S(t, x) using a trained survival forest (estimated using
-#' Kaplan-Meier).
+#' Gets estimates of the conditional survival function S(t, x) using a trained survival forest. The curve can be
+#' estimated by Kaplan-Meier (default), or Nelson-Aalen.
 #'
 #' @param object The trained forest.
 #' @param newdata Points at which predictions should be made. If NULL, makes out-of-bag

--- a/r-package/grf/R/survival_forest.R
+++ b/r-package/grf/R/survival_forest.R
@@ -47,6 +47,8 @@
 #' @param alpha A tuning parameter that controls the maximum imbalance of a split. Default is 0.05
 #'  (meaning the count of failures on each side of a split has to be at least 5 \% of the total observation count in a node)
 #' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed. Default is TRUE.
+#' @param prediction.type The type of estimate of the survival function, choices are "Kaplan-Meier" and "Nelson-Aalen".
+#' Only relevant if `compute.oob.predictions` is TRUE. Default is "Kaplan-Meier".
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency.
 #' @param seed The seed of the C++ random number generator.
@@ -115,6 +117,7 @@ survival_forest <- function(X, Y, D,
                             honesty.fraction = 0.5,
                             honesty.prune.leaves = TRUE,
                             alpha = 0.05,
+                            prediction.type = "Kaplan-Meier",
                             compute.oob.predictions = TRUE,
                             num.threads = NULL,
                             seed = runif(1, 0, .Machine$integer.max)) {
@@ -128,6 +131,7 @@ survival_forest <- function(X, Y, D,
   clusters <- validate_clusters(clusters, X)
   samples.per.cluster <- validate_equalize_cluster_weights(equalize.cluster.weights, clusters, sample.weights)
   num.threads <- validate_num_threads(num.threads)
+  prediction.type = validate_prediction_type(prediction.type)
 
   # Relabel the times to consecutive integers such that:
   # if the failure time is less than the smallest failure time: set it to 0
@@ -151,6 +155,7 @@ survival_forest <- function(X, Y, D,
                honesty.prune.leaves = honesty.prune.leaves,
                alpha = alpha,
                num.failures = length(failure.times),
+               prediction.type = prediction.type,
                compute.oob.predictions = compute.oob.predictions,
                num.threads = num.threads,
                seed = seed)
@@ -166,6 +171,7 @@ survival_forest <- function(X, Y, D,
   forest[["equalize.cluster.weights"]] <- equalize.cluster.weights
   forest[["has.missing.values"]] <- has.missing.values
   forest[["failure.times"]] <- failure.times
+  forest[["prediction.type"]] <- prediction.type
 
   forest
 }
@@ -183,6 +189,8 @@ survival_forest <- function(X, Y, D,
 #'                matrix, and that the columns must appear in the same order.
 #' @param failure.times A vector of failure times to make predictions at. If NULL, then the
 #'  failure times used for training the forest is used. The time points should be in increasing order. Default is NULL.
+#' @param prediction.type The type of estimate of the survival function, choices are "Kaplan-Meier" and "Nelson-Aalen".
+#'  Default is "Kaplan-Meier".
 #' @param num.threads Number of threads used in training. If set to NULL, the software
 #'                    automatically selects an appropriate amount.
 #' @param ... Additional arguments (currently ignored).
@@ -240,7 +248,10 @@ survival_forest <- function(X, Y, D,
 predict.survival_forest <- function(object,
                                     newdata = NULL,
                                     failure.times = NULL,
+                                    prediction.type = "Kaplan-Meier",
                                     num.threads = NULL, ...) {
+  prediction.type = validate_prediction_type(prediction.type)
+  num.threads <- validate_num_threads(num.threads)
   if (is.null(failure.times)) {
     failure.times <- object[["failure.times"]]
     Y.relabeled <- object[["Y.relabeled"]]
@@ -250,11 +261,11 @@ predict.survival_forest <- function(object,
 
   # If possible, use pre-computed predictions.
   failure.times.orig <- object[["failure.times"]]
-  if (is.null(newdata) && identical(failure.times, failure.times.orig) && !is.null(object$predictions)) {
+  prediction.type.orig <- object[["prediction.type"]]
+  if (is.null(newdata) && identical(failure.times, failure.times.orig)
+      && identical(prediction.type, prediction.type.orig) && !is.null(object$predictions)) {
     return(list(predictions = object$predictions, failure.times = failure.times))
   }
-
-  num.threads <- validate_num_threads(num.threads)
 
   forest.short <- object[-which(names(object) == "X.orig")]
   X <- object[["X.orig"]]
@@ -265,7 +276,8 @@ predict.survival_forest <- function(object,
 
   args <- list(forest.object = forest.short,
                num.threads = num.threads,
-               num.failures = length(failure.times))
+               num.failures = length(failure.times),
+               prediction.type = prediction.type)
 
   if (!is.null(newdata)) {
     validate_newdata(newdata, X, allow.na = TRUE)

--- a/r-package/grf/bindings/SurvivalForestBindings.cpp
+++ b/r-package/grf/bindings/SurvivalForestBindings.cpp
@@ -45,6 +45,7 @@ Rcpp::List survival_train(Rcpp::NumericMatrix train_matrix,
                           std::vector<size_t> clusters,
                           unsigned int samples_per_cluster,
                           bool compute_oob_predictions,
+                          int prediction_type,
                           unsigned int num_threads,
                           unsigned int seed) {
   ForestTrainer trainer = survival_trainer();
@@ -64,7 +65,7 @@ Rcpp::List survival_train(Rcpp::NumericMatrix train_matrix,
 
   std::vector<Prediction> predictions;
   if (compute_oob_predictions) {
-    ForestPredictor predictor = survival_predictor(num_threads, num_failures);
+    ForestPredictor predictor = survival_predictor(num_threads, num_failures, prediction_type);
     predictions = predictor.predict_oob(forest, *data, false);
   }
 
@@ -79,6 +80,7 @@ Rcpp::List survival_predict(Rcpp::List forest_object,
                             size_t censor_index,
                             size_t sample_weight_index,
                             bool use_sample_weights,
+                            int prediction_type,
                             Rcpp::NumericMatrix test_matrix,
                             Eigen::SparseMatrix<double> sparse_test_matrix,
                             unsigned int num_threads,
@@ -94,7 +96,7 @@ Rcpp::List survival_predict(Rcpp::List forest_object,
   Forest forest = RcppUtilities::deserialize_forest(forest_object);
 
   bool estimate_variance = false;
-  ForestPredictor predictor = survival_predictor(num_threads, num_failures);
+  ForestPredictor predictor = survival_predictor(num_threads, num_failures, prediction_type);
   std::vector<Prediction> predictions = predictor.predict(forest, *train_data, *data, estimate_variance);
 
   return RcppUtilities::create_prediction_object(predictions);
@@ -108,6 +110,7 @@ Rcpp::List survival_predict_oob(Rcpp::List forest_object,
                                 size_t censor_index,
                                 size_t sample_weight_index,
                                 bool use_sample_weights,
+                                int prediction_type,
                                 unsigned int num_threads,
                                 size_t num_failures) {
   std::unique_ptr<Data> data = RcppUtilities::convert_data(train_matrix, sparse_train_matrix);
@@ -120,7 +123,7 @@ Rcpp::List survival_predict_oob(Rcpp::List forest_object,
   Forest forest = RcppUtilities::deserialize_forest(forest_object);
 
   bool estimate_variance = false;
-  ForestPredictor predictor = survival_predictor(num_threads, num_failures);
+  ForestPredictor predictor = survival_predictor(num_threads, num_failures, prediction_type);
   std::vector<Prediction> predictions = predictor.predict_oob(forest, *data, estimate_variance);
 
   Rcpp::List result = RcppUtilities::create_prediction_object(predictions);

--- a/r-package/grf/src/RcppExports.cpp
+++ b/r-package/grf/src/RcppExports.cpp
@@ -505,8 +505,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // survival_train
-Rcpp::List survival_train(Rcpp::NumericMatrix train_matrix, Eigen::SparseMatrix<double> sparse_train_matrix, size_t outcome_index, size_t censor_index, size_t sample_weight_index, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, double alpha, size_t num_failures, std::vector<size_t> clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, unsigned int num_threads, unsigned int seed);
-RcppExport SEXP _grf_survival_train(SEXP train_matrixSEXP, SEXP sparse_train_matrixSEXP, SEXP outcome_indexSEXP, SEXP censor_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP alphaSEXP, SEXP num_failuresSEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP compute_oob_predictionsSEXP, SEXP num_threadsSEXP, SEXP seedSEXP) {
+Rcpp::List survival_train(Rcpp::NumericMatrix train_matrix, Eigen::SparseMatrix<double> sparse_train_matrix, size_t outcome_index, size_t censor_index, size_t sample_weight_index, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, double alpha, size_t num_failures, std::vector<size_t> clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, int prediction_type, unsigned int num_threads, unsigned int seed);
+RcppExport SEXP _grf_survival_train(SEXP train_matrixSEXP, SEXP sparse_train_matrixSEXP, SEXP outcome_indexSEXP, SEXP censor_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP alphaSEXP, SEXP num_failuresSEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP compute_oob_predictionsSEXP, SEXP prediction_typeSEXP, SEXP num_threadsSEXP, SEXP seedSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -528,15 +528,16 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< std::vector<size_t> >::type clusters(clustersSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type samples_per_cluster(samples_per_clusterSEXP);
     Rcpp::traits::input_parameter< bool >::type compute_oob_predictions(compute_oob_predictionsSEXP);
+    Rcpp::traits::input_parameter< int >::type prediction_type(prediction_typeSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type seed(seedSEXP);
-    rcpp_result_gen = Rcpp::wrap(survival_train(train_matrix, sparse_train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, alpha, num_failures, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed));
+    rcpp_result_gen = Rcpp::wrap(survival_train(train_matrix, sparse_train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, alpha, num_failures, clusters, samples_per_cluster, compute_oob_predictions, prediction_type, num_threads, seed));
     return rcpp_result_gen;
 END_RCPP
 }
 // survival_predict
-Rcpp::List survival_predict(Rcpp::List forest_object, Rcpp::NumericMatrix train_matrix, Eigen::SparseMatrix<double> sparse_train_matrix, size_t outcome_index, size_t censor_index, size_t sample_weight_index, bool use_sample_weights, Rcpp::NumericMatrix test_matrix, Eigen::SparseMatrix<double> sparse_test_matrix, unsigned int num_threads, size_t num_failures);
-RcppExport SEXP _grf_survival_predict(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP sparse_train_matrixSEXP, SEXP outcome_indexSEXP, SEXP censor_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP test_matrixSEXP, SEXP sparse_test_matrixSEXP, SEXP num_threadsSEXP, SEXP num_failuresSEXP) {
+Rcpp::List survival_predict(Rcpp::List forest_object, Rcpp::NumericMatrix train_matrix, Eigen::SparseMatrix<double> sparse_train_matrix, size_t outcome_index, size_t censor_index, size_t sample_weight_index, bool use_sample_weights, int prediction_type, Rcpp::NumericMatrix test_matrix, Eigen::SparseMatrix<double> sparse_test_matrix, unsigned int num_threads, size_t num_failures);
+RcppExport SEXP _grf_survival_predict(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP sparse_train_matrixSEXP, SEXP outcome_indexSEXP, SEXP censor_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP prediction_typeSEXP, SEXP test_matrixSEXP, SEXP sparse_test_matrixSEXP, SEXP num_threadsSEXP, SEXP num_failuresSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -547,17 +548,18 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< size_t >::type censor_index(censor_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type sample_weight_index(sample_weight_indexSEXP);
     Rcpp::traits::input_parameter< bool >::type use_sample_weights(use_sample_weightsSEXP);
+    Rcpp::traits::input_parameter< int >::type prediction_type(prediction_typeSEXP);
     Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type test_matrix(test_matrixSEXP);
     Rcpp::traits::input_parameter< Eigen::SparseMatrix<double> >::type sparse_test_matrix(sparse_test_matrixSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     Rcpp::traits::input_parameter< size_t >::type num_failures(num_failuresSEXP);
-    rcpp_result_gen = Rcpp::wrap(survival_predict(forest_object, train_matrix, sparse_train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, test_matrix, sparse_test_matrix, num_threads, num_failures));
+    rcpp_result_gen = Rcpp::wrap(survival_predict(forest_object, train_matrix, sparse_train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, prediction_type, test_matrix, sparse_test_matrix, num_threads, num_failures));
     return rcpp_result_gen;
 END_RCPP
 }
 // survival_predict_oob
-Rcpp::List survival_predict_oob(Rcpp::List forest_object, Rcpp::NumericMatrix train_matrix, Eigen::SparseMatrix<double> sparse_train_matrix, size_t outcome_index, size_t censor_index, size_t sample_weight_index, bool use_sample_weights, unsigned int num_threads, size_t num_failures);
-RcppExport SEXP _grf_survival_predict_oob(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP sparse_train_matrixSEXP, SEXP outcome_indexSEXP, SEXP censor_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP num_threadsSEXP, SEXP num_failuresSEXP) {
+Rcpp::List survival_predict_oob(Rcpp::List forest_object, Rcpp::NumericMatrix train_matrix, Eigen::SparseMatrix<double> sparse_train_matrix, size_t outcome_index, size_t censor_index, size_t sample_weight_index, bool use_sample_weights, int prediction_type, unsigned int num_threads, size_t num_failures);
+RcppExport SEXP _grf_survival_predict_oob(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP sparse_train_matrixSEXP, SEXP outcome_indexSEXP, SEXP censor_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP prediction_typeSEXP, SEXP num_threadsSEXP, SEXP num_failuresSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -568,9 +570,10 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< size_t >::type censor_index(censor_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type sample_weight_index(sample_weight_indexSEXP);
     Rcpp::traits::input_parameter< bool >::type use_sample_weights(use_sample_weightsSEXP);
+    Rcpp::traits::input_parameter< int >::type prediction_type(prediction_typeSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     Rcpp::traits::input_parameter< size_t >::type num_failures(num_failuresSEXP);
-    rcpp_result_gen = Rcpp::wrap(survival_predict_oob(forest_object, train_matrix, sparse_train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, num_threads, num_failures));
+    rcpp_result_gen = Rcpp::wrap(survival_predict_oob(forest_object, train_matrix, sparse_train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, prediction_type, num_threads, num_failures));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -600,9 +603,9 @@ static const R_CallMethodDef CallEntries[] = {
     {"_grf_ll_regression_train", (DL_FUNC) &_grf_ll_regression_train, 24},
     {"_grf_ll_regression_predict", (DL_FUNC) &_grf_ll_regression_predict, 11},
     {"_grf_ll_regression_predict_oob", (DL_FUNC) &_grf_ll_regression_predict_oob, 9},
-    {"_grf_survival_train", (DL_FUNC) &_grf_survival_train, 20},
-    {"_grf_survival_predict", (DL_FUNC) &_grf_survival_predict, 11},
-    {"_grf_survival_predict_oob", (DL_FUNC) &_grf_survival_predict_oob, 9},
+    {"_grf_survival_train", (DL_FUNC) &_grf_survival_train, 21},
+    {"_grf_survival_predict", (DL_FUNC) &_grf_survival_predict, 12},
+    {"_grf_survival_predict_oob", (DL_FUNC) &_grf_survival_predict_oob, 10},
     {NULL, NULL, 0}
 };
 

--- a/r-package/grf/tests/testthat/test_survival_forest.R
+++ b/r-package/grf/tests/testthat/test_survival_forest.R
@@ -57,10 +57,9 @@ test_that("a simple survival forest workflow works", {
 })
 
 test_that("sample weighted survival prediction is invariant to weight rescaling", {
-  # With Kaplan-Meier estimates of the survival function adjusting each sample count
+  # Estimates of the survival function adjusting each sample count
   # by its rescaled sample weight should leave predictions unchanged.
-
-  # We can not do a check on one forest with some samples duplicated as the splits might be different
+  # (We can not do a check on one forest with some samples duplicated as the splits might be different)
   n <- 500
   p <- 5
   X <- matrix(rnorm(n * p), n, p)
@@ -78,8 +77,10 @@ test_that("sample weighted survival prediction is invariant to weight rescaling"
                         sample.weights = runif(1) * sample.weights,
                         num.trees = 50,
                         seed = 1)
-
-  expect_true(sum(abs(predict(sf1, X)$pred - predict(sf2, X)$pred)) < 1e-8)
+  type <- "Kaplan-Meier"
+  expect_true(sum(abs(predict(sf1, X, prediction.type = type)$pred - predict(sf2, X, prediction.type = type)$pred)) < 1e-8)
+  type <- "Nelson-Aalen"
+  expect_true(sum(abs(predict(sf1, X, prediction.type = type)$pred - predict(sf2, X, prediction.type = type)$pred)) < 1e-8)
 })
 
 test_that("survival_forest works as expected with missing values", {

--- a/r-package/grf/tests/testthat/test_survival_forest.R
+++ b/r-package/grf/tests/testthat/test_survival_forest.R
@@ -14,6 +14,7 @@ test_that("a simple survival forest workflow works", {
 
   survival.oob <- predict(sf)$predictions
   survival <- predict(sf, X)$predictions
+  survival.na <- predict(sf, X, prediction.type = "Nelson-Aalen")$predictions
 
   # Predictions are monotonically decreasing
   if (n.failures > 1) {
@@ -26,6 +27,9 @@ test_that("a simple survival forest workflow works", {
                dim(survival.oob))
   expect_equal(c(n, n.failures),
              dim(survival))
+
+  # Nelson-Aalen estimates of the survival curve is above zero
+  expect_true(all(survival.na > 0))
 
   # A tree with no failures does not split
   sf <- survival_forest(X, Y, rep(0, n), num.trees = 50)


### PR DESCRIPTION
This PR adds the optional argument `prediction.type` to survival forest `predict` allowing a user to select between Kaplan-Meier (default from grf 1.2) and Nelson-Aalen for survival curve estimates.

Example

```R
n <- 500
p <- 5
X <- matrix(rnorm(n * p), n, p)
failure.time <- exp(0.5 * X[, 1]) * rexp(n)
censor.time <- 2 * rexp(n)
Y <- pmin(failure.time, censor.time)
D <- as.integer(failure.time <= censor.time)
sf <- survival_forest(X, Y, D)
predict(sf, prediction.type = "Kaplan-Meier")$predictions
predict(sf, prediction.type = "Nelson-Aalen")$predictions
```

Details:

[Nelson-Aalen](https://en.wikipedia.org/wiki/Nelson%E2%80%93Aalen_estimator) is bounded below and is needed for #660, see equation (4) in https://arxiv.org/pdf/2001.09887.pdf: the survival function of the censoring process appears several places in the denominator and an estimate based on Kaplan-Meier may be zero regardless of identifying assumptions holding. There is no way out of this but estimating the censoring process with Nelson-Aalen.

Code detail: went with  the simple primitive type `int prediction_type` instead of for example `std::string prediction_type ("Kaplan-Meier")` for simplicity and potential bindings with future languages that do not know `std::string`.