### PR TITLE
Correct the generated documentation for `best_linear_projection`

### DIFF
--- a/r-package/grf/R/forest_summary.R
+++ b/r-package/grf/R/forest_summary.R
@@ -85,9 +85,7 @@ test_calibration <- function(forest) {
 #' using a causal forest.
 #'
 #' Let tau(Xi) = E[Y(1) - Y(0) | X = Xi] be the CATE, and Ai be a vector of user-provided
-#' covariates. This function provides a (doubly robust) fit to the linear model
-#'
-#' tau(Xi) ~ beta_0 + Ai * beta
+#' covariates. This function provides a (doubly robust) fit to the linear model tau(Xi) ~ beta_0 + Ai * beta.
 #'
 #' Procedurally, we do so by regressing doubly robust scores derived from the causal
 #' forest against the Ai. Note the covariates Ai may consist of a subset of the Xi,


### PR DESCRIPTION
See #688. This takes care of `best_linear_projection` (will make a pass over the rest of the documentation later).