### PR TITLE
Added simulations from R-Learner paper

### DIFF
--- a/experiments/benchmarking/dgps.R
+++ b/experiments/benchmarking/dgps.R
@@ -39,9 +39,11 @@
 #' To add an additonal DGP, fill in the template below and add an entry to `dgp` and `.minp`.
 #'
 gen_data <- function(n, p, sigma.m = 1, sigma.tau = 0.1, sigma.noise = 1,
-                     dgp = c("simple", "aw1", "aw2", "aw3", "ai1", "ai2", "kunzel"),
+                     dgp = c("simple", "aw1", "aw2", "aw3", "ai1", "ai2", "kunzel",
+                             "nwA", "nwB", "nwC", "nwD"),
                      ...) {
-  .minp <- c(simple=3, aw1=2, aw2=2, aw3=1, ai1=2, ai2=6, kunzel=2)
+  .minp <- c(simple=3, aw1=2, aw2=2, aw3=1, ai1=2, ai2=6, kunzel=2,
+             nwA=5, nwB=5, nwC=3, nwD=5)
   dgp <- match.arg(dgp)
   minp <- .minp[dgp]
   if (p < minp) {
@@ -67,8 +69,8 @@ gen_data <- function(n, p, sigma.m = 1, sigma.tau = 0.1, sigma.noise = 1,
   } else if (dgp == "aw1") {
     # equation (27) of https://arxiv.org/pdf/1510.04342.pdf
     X <- matrix(runif(n * p, min = 0, max = 1), n, p)
-    tau <- 0
-    e <- (1 / 4) * (1 + dbeta(X[, 1], 2, 4))
+    tau <- rep(0, n)  # Treatment effect is zero
+    e <- (1 / 4) * (1 + dbeta(X[, 1], 2, 4))  # Confounding
     W <- rbinom(n = n, size = 1, prob = e)
     m <- 2 * X[, 1] - 1 + e * tau
     V <- 1
@@ -78,7 +80,7 @@ gen_data <- function(n, p, sigma.m = 1, sigma.tau = 0.1, sigma.noise = 1,
     zeta1 <- 1 + 1 / (1 + exp(-20 * (X[, 1] - (1 / 3))))
     zeta2 <- 1 + 1 / (1 + exp(-20 * (X[, 2] - (1 / 3))))
     tau <- zeta1 * zeta2
-    e <- 0.5
+    e <- 0.5  # Randomized trial (no confounding)
     W <- rbinom(n = n, size = 1, prob = e)
     m <- e * tau
     V <- 1
@@ -89,7 +91,17 @@ gen_data <- function(n, p, sigma.m = 1, sigma.tau = 0.1, sigma.noise = 1,
     zeta1 <- 1 + 1 / (1 + exp(-20 * (X[, 1] - (1 / 3))))
     zeta2 <- 1 + 1 / (1 + exp(-20 * (X[, 2] - (1 / 3))))
     tau <- zeta1 * zeta2
-    e <- (1 / 4) * (1 + dbeta(X[, 1], 2, 4))
+    e <- (1 / 4) * (1 + dbeta(X[, 1], 2, 4))  # Confounding
+    W <- rbinom(n = n, size = 1, prob = e)
+    m <- 2 * X[, 1] - 1 + e * tau
+    V <- 1
+  } else if (dgp == "aw3reverse") {
+    # Same as aw3, but HTEs anticorrelated with baseline
+    X <- matrix(runif(n * p), n, p)
+    zeta1 <- 1 + 1 / (1 + exp(20 * (X[, 1] - (1 / 3))))
+    zeta2 <- 1 + 1 / (1 + exp(20 * (X[, 2] - (1 / 3))))
+    tau <- zeta1 * zeta2
+    e <- (1 / 4) * (1 + dbeta(X[, 1], 2, 4))  # Confounding
     W <- rbinom(n = n, size = 1, prob = e)
     m <- 2 * X[, 1] - 1 + e * tau
     V <- 1
@@ -110,6 +122,8 @@ gen_data <- function(n, p, sigma.m = 1, sigma.tau = 0.1, sigma.noise = 1,
     m <- nu_x + e * tau
     V <- 0.1^2
   } else if (dgp == "kunzel") {
+    # "Simulation 1" from A.1 in https://arxiv.org/pdf/1706.03461.pdf
+    # Extremely unbalanced treatment assignment, easy treatment effect.
     X <- MASS::mvrnorm(n = n, mu = rep(0, p), Sigma = toeplitz(0.5^seq(0, p - 1)))
     tau <- 8 * (X[, 2] > 0.1)
     beta <- runif(p, -5, 5)
@@ -119,17 +133,57 @@ gen_data <- function(n, p, sigma.m = 1, sigma.tau = 0.1, sigma.noise = 1,
     W <- rbinom(n = n, size = 1, prob = e)
     m <- W * mu_1 + (1 - W) * mu_0 - (W - e) * tau
     V <- 1
+  } else if (dgp == "nwA") {
+    # "Setup A" from Section 4 of https://arxiv.org/pdf/1712.04912.pdf
+    # Difficult nuisance components, easy treatment effect function.
+    X <- matrix(runif(n * p, min=0, max=1), n, p)
+    tau <- (X[,1] + X[,2]) / 2
+    eta <- 0.1
+    e <- pmax(eta, pmin(sin(pi * X[,1] * X[,2]), 1-eta))
+    W <- rbinom(n = n, size = 1, prob = e)
+    m <- sin(pi * X[,1] * X[,2]) + 2 * (X[,3] - 0.5)^2 + X[,4] + 0.5 * X[,5]
+    V <- 1
+  } else if (dgp == "nwB") {
+    # "Setup B" from Section 4 of https://arxiv.org/pdf/1712.04912.pdf
+    # Randomized trial 
+    X <- matrix(rnorm(n * p), n, p)
+    tau <- X[,1] + log(1 + exp(X[,2]))
+    e <- 0.5
+    W <- rbinom(n = n, size = 1, prob = e)
+    m <- pmax(0, X[,1] + X[,2], X[,3]) + pmax(0, X[,4] + X[,5])
+    V <- 1
+  } else if (dgp == "nwC") {
+    # "Setup C" from Section 4 of https://arxiv.org/pdf/1712.04912.pdf
+    # Easy propensity score, strong confounding, difficult baseline,
+    # constant treatment effect
+    X <- matrix(rnorm(n * p), n, p)
+    tau <- rep(1, n)
+    e <- 1/(1 + exp(X[,2] + X[,3]))
+    W <- rbinom(n = n, size = 1, prob = e)
+    m <- 2 * log(1 + exp(X[,1] + X[,2] + X[,3]))
+    V <- 1
+  } else if (dgp == "nwD") {
+    # "Setup D" from Section 4 of https://arxiv.org/pdf/1712.04912.pdf
+    # Unrelated treatment and control arms
+    # (No upside to learning them jointly)
+    X <- matrix(rnorm(n*p), n, p)
+    tau <- pmax(X[,1] + X[,2] + X[,3], 0) - pmax(X[,4] + X[,5], 0)
+    e <- 1/(1 + exp(-X[,1]) + exp(-X[,2]))
+    W <- rbinom(n = n, size = 1, prob = e)
+    m <- (pmax(X[,1] + X[,2] + X[,3], 0) + pmax(X[,4] + X[,5], 0)) / 2
+    V <- 1
   }
+  
   # Scale and return data (rescale if `m` and `tau` is not constant)
-  if (!is.na(sd(m))) {
+  if (!is.na(sd(m)) & !(sd(tau) == 0)) {
     m <- m / sd(m) * sigma.m
   }
-  if (!is.na(sd(tau))) {
+  if (!is.na(sd(tau)) & !(sd(tau) == 0)) {
     tau <- tau / sd(tau) * sigma.tau
   }
   V <- V / mean(V) * sigma.noise^2
   Y <- m + (W - e) * tau + sqrt(V) * rnorm(n)
   out <- list(X = X, Y = Y, W = W, tau = tau, m = m, e = e, dgp = dgp)
-
+  
   out
 }


### PR DESCRIPTION
**Overview:**

- Added DGPs from [R-Learner paper](https://github.com/xnie/rlearner/blob/master/experiments_for_paper/run_simu.R) to benchmarking code in benchmarking/dgps.R. 
- Adapted R-Learner DGP code to conform to style in `grf`.
- Added in functionality to increase/decrease signal of tau, m, and noise (not originally available in R-Learner code).
- Updated `aw1` to give a vector of 0's for tau rather than a single scalar (need to verify that this doesn't break downstream functionality)
- Added more robust checks when dividing by standard deviation
- Added an `aw3reverse` DGP in which the treatment effect is anticorrelated with the baseline.