### PR TITLE
Remove `samples.per.cluster` option from the ACIC 2018 script

### DIFF
--- a/experiments/acic18/script.R
+++ b/experiments/acic18/script.R
@@ -1,8 +1,3 @@
-# Notes:
-# - The paper refers to an argument called `samples.per.cluster`. This option was removed in grf version 1.0
-# and is now by default (`equalize.cluster.weights = FALSE`) internally set to the size of the largest cluster.
-# For more details on clustering in grf, see the algorithm reference at:
-# https://grf-labs.github.io/grf/REFERENCE.html#cluster-robust-estimation
 set.seed(1)
 
 rm(list = ls())
@@ -57,6 +52,7 @@ selected.idx = which(varimp > mean(varimp))
 cf = causal_forest(X[,selected.idx], Y, W,
                    Y.hat = Y.hat, W.hat = W.hat,
                    clusters = school.id,
+                   samples.per.cluster = 50,
                    tune.parameters = "all")
 tau.hat = predict(cf)$predictions
 
@@ -201,6 +197,7 @@ summary(aov(dr.score ~ factor(school.id)))
 cf.noprop = causal_forest(X[,selected.idx], Y, W,
                           Y.hat = Y.hat, W.hat = mean(W),
                           tune.parameters = "all",
+                          samples.per.cluster = 50,
                           clusters = school.id)
 tau.hat.noprop = predict(cf.noprop)$predictions
 

--- a/experiments/acic18/script.R
+++ b/experiments/acic18/script.R
@@ -1,3 +1,12 @@
+# Notes:
+# - The paper refers to an argument called `samples.per.cluster`. This option was removed in grf version 1.0
+# and is now by default (`equalize.cluster.weights = FALSE`) internally set to the size of the largest cluster,
+# which means that large schools recieve larger weight than small schools. To be closer to the original behavior,
+# this script has been updated by setting `equalize.cluster.weights` to TRUE, which means each school receives
+# equal weight in ATE estimation.
+#
+# For more details on clustering in grf, see the algorithm reference at:
+# https://grf-labs.github.io/grf/REFERENCE.html#cluster-robust-estimation
 set.seed(1)
 
 rm(list = ls())
@@ -52,7 +61,7 @@ selected.idx = which(varimp > mean(varimp))
 cf = causal_forest(X[,selected.idx], Y, W,
                    Y.hat = Y.hat, W.hat = W.hat,
                    clusters = school.id,
-                   samples.per.cluster = 50,
+                   equalize.cluster.weights = TRUE,
                    tune.parameters = "all")
 tau.hat = predict(cf)$predictions
 
@@ -197,7 +206,7 @@ summary(aov(dr.score ~ factor(school.id)))
 cf.noprop = causal_forest(X[,selected.idx], Y, W,
                           Y.hat = Y.hat, W.hat = mean(W),
                           tune.parameters = "all",
-                          samples.per.cluster = 50,
+                          equalize.cluster.weights = TRUE,
                           clusters = school.id)
 tau.hat.noprop = predict(cf.noprop)$predictions
 

--- a/experiments/acic18/script.R
+++ b/experiments/acic18/script.R
@@ -47,14 +47,15 @@ X = cbind(X.raw[,-which(names(X.raw) %in% c("C1", "XC"))], C1.exp, XC.exp)
 # Grow a forest. Add extra trees for the causal forest.
 #
 
-Y.forest = regression_forest(X, Y, clusters = school.id)
+Y.forest = regression_forest(X, Y, clusters = school.id, equalize.cluster.weights = TRUE)
 Y.hat = predict(Y.forest)$predictions
-W.forest = regression_forest(X, W, clusters = school.id)
+W.forest = regression_forest(X, W, clusters = school.id, equalize.cluster.weights = TRUE)
 W.hat = predict(W.forest)$predictions
 
 cf.raw = causal_forest(X, Y, W,
                        Y.hat = Y.hat, W.hat = W.hat,
-                       clusters = school.id)
+                       clusters = school.id,
+                       equalize.cluster.weights = TRUE)
 varimp = variable_importance(cf.raw)
 selected.idx = which(varimp > mean(varimp))
 

--- a/experiments/acic18/script.R
+++ b/experiments/acic18/script.R
@@ -1,3 +1,8 @@
+# Notes:
+# - The paper refers to an argument called `samples.per.cluster`. This option was removed in grf version 1.0
+# and is now by default (`equalize.cluster.weights = FALSE`) internally set to the size of the largest cluster.
+# For more details on clustering in grf, see the algorithm reference at:
+# https://grf-labs.github.io/grf/REFERENCE.html#cluster-robust-estimation
 set.seed(1)
 
 rm(list = ls())
@@ -52,7 +57,6 @@ selected.idx = which(varimp > mean(varimp))
 cf = causal_forest(X[,selected.idx], Y, W,
                    Y.hat = Y.hat, W.hat = W.hat,
                    clusters = school.id,
-                   samples.per.cluster = 50,
                    tune.parameters = "all")
 tau.hat = predict(cf)$predictions
 
@@ -197,7 +201,6 @@ summary(aov(dr.score ~ factor(school.id)))
 cf.noprop = causal_forest(X[,selected.idx], Y, W,
                           Y.hat = Y.hat, W.hat = mean(W),
                           tune.parameters = "all",
-                          samples.per.cluster = 50,
                           clusters = school.id)
 tau.hat.noprop = predict(cf.noprop)$predictions
 


### PR DESCRIPTION
The `samples.per.cluster` option was removed in grf version 1.0 and is now by default (`equalize.cluster.weights = FALSE`) set internally to the size of the largest cluster, which means that larger clusters receive larger weights than small ones.

To be closer to the original behavior, this script is updated by setting `equalize.cluster.weights` to `TRUE`, which means each school receives equal weight in ATE estimation.


(closes #693)