### PR TITLE
Add `@keyword internal` to internal functions

### DIFF
--- a/r-package/grf/R/analysis_tools.R
+++ b/r-package/grf/R/analysis_tools.R
@@ -224,6 +224,7 @@ leaf_stats <- function(forest, samples) UseMethod("leaf_stats")
 #' @return NULL
 #'
 #' @method leaf_stats default
+#' @keywords internal
 leaf_stats.default <- function(forest, samples, ...){
   return(NULL)
 }
@@ -236,6 +237,7 @@ leaf_stats.default <- function(forest, samples, ...){
 #' @return A named vector containing summary stats
 #'
 #' @method leaf_stats regression_forest
+#' @keywords internal
 leaf_stats.regression_forest <- function(forest, samples, ...){
   leaf_stats <- c()
   leaf_stats["avg_Y"] <- round(mean(forest$Y.orig[samples]), 2)
@@ -250,6 +252,7 @@ leaf_stats.regression_forest <- function(forest, samples, ...){
 #' @return A named vector containing summary stats
 #'
 #' @method leaf_stats causal_forest
+#' @keywords internal
 leaf_stats.causal_forest <- function(forest, samples, ...){
   leaf_stats <- c()
   leaf_stats["avg_Y"] <- round(mean(forest$Y.orig[samples]), 2)
@@ -265,6 +268,7 @@ leaf_stats.causal_forest <- function(forest, samples, ...){
 #' @return A named vector containing summary stats
 #'
 #' @method leaf_stats instrumental_forest
+#' @keywords internal
 leaf_stats.instrumental_forest <- function(forest, samples, ...){
 
   leaf_stats <- c()

--- a/r-package/grf/R/tuning.R
+++ b/r-package/grf/R/tuning.R
@@ -18,6 +18,7 @@
 #'
 #' @importFrom stats sd runif
 #' @importFrom utils capture.output
+#' @keywords internal
 tune_forest <- function(data,
                         nrow.X,
                         ncol.X,


### PR DESCRIPTION
Explicitly declare some documented R package functions as internal. This will remove five items in the following warning message from `pkgdown` when building the online reference

```
Warning messages:
1: Topics missing from index: 
* custom_forest
* grf
* leaf_stats.causal_forest
* leaf_stats.default
* leaf_stats.instrumental_forest
* leaf_stats.regression_forest
* predict.custom_forest
* tune_forest 
```