### PR TITLE
Remove unnecessary sample weight argument from survival bindings

### DIFF
--- a/r-package/grf/R/RcppExports.R
+++ b/r-package/grf/R/RcppExports.R
@@ -101,11 +101,11 @@ survival_train <- function(train_matrix, sparse_train_matrix, outcome_index, cen
     .Call('_grf_survival_train', PACKAGE = 'grf', train_matrix, sparse_train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, alpha, num_failures, clusters, samples_per_cluster, compute_oob_predictions, prediction_type, num_threads, seed)
 }
 
-survival_predict <- function(forest_object, train_matrix, sparse_train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, prediction_type, test_matrix, sparse_test_matrix, num_threads, num_failures) {
-    .Call('_grf_survival_predict', PACKAGE = 'grf', forest_object, train_matrix, sparse_train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, prediction_type, test_matrix, sparse_test_matrix, num_threads, num_failures)
+survival_predict <- function(forest_object, train_matrix, sparse_train_matrix, outcome_index, censor_index, prediction_type, test_matrix, sparse_test_matrix, num_threads, num_failures) {
+    .Call('_grf_survival_predict', PACKAGE = 'grf', forest_object, train_matrix, sparse_train_matrix, outcome_index, censor_index, prediction_type, test_matrix, sparse_test_matrix, num_threads, num_failures)
 }
 
-survival_predict_oob <- function(forest_object, train_matrix, sparse_train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, prediction_type, num_threads, num_failures) {
-    .Call('_grf_survival_predict_oob', PACKAGE = 'grf', forest_object, train_matrix, sparse_train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, prediction_type, num_threads, num_failures)
+survival_predict_oob <- function(forest_object, train_matrix, sparse_train_matrix, outcome_index, censor_index, prediction_type, num_threads, num_failures) {
+    .Call('_grf_survival_predict_oob', PACKAGE = 'grf', forest_object, train_matrix, sparse_train_matrix, outcome_index, censor_index, prediction_type, num_threads, num_failures)
 }
 

--- a/r-package/grf/R/survival_forest.R
+++ b/r-package/grf/R/survival_forest.R
@@ -285,7 +285,6 @@ predict.survival_forest <- function(object,
   X <- object[["X.orig"]]
   train.data <- create_train_matrices(X,
                                       outcome = Y.relabeled,
-                                      sample.weights = object[["sample.weights"]],
                                       censor = object[["D.orig"]])
 
   args <- list(forest.object = forest.short,

--- a/r-package/grf/bindings/SurvivalForestBindings.cpp
+++ b/r-package/grf/bindings/SurvivalForestBindings.cpp
@@ -78,8 +78,6 @@ Rcpp::List survival_predict(Rcpp::List forest_object,
                             Eigen::SparseMatrix<double> sparse_train_matrix,
                             size_t outcome_index,
                             size_t censor_index,
-                            size_t sample_weight_index,
-                            bool use_sample_weights,
                             int prediction_type,
                             Rcpp::NumericMatrix test_matrix,
                             Eigen::SparseMatrix<double> sparse_test_matrix,
@@ -88,9 +86,6 @@ Rcpp::List survival_predict(Rcpp::List forest_object,
   std::unique_ptr<Data> train_data = RcppUtilities::convert_data(train_matrix, sparse_train_matrix);
   train_data->set_outcome_index(outcome_index - 1);
   train_data->set_censor_index(censor_index - 1);
-  if (use_sample_weights) {
-      train_data->set_weight_index(sample_weight_index - 1);
-  }
 
   std::unique_ptr<Data> data = RcppUtilities::convert_data(test_matrix, sparse_test_matrix);
   Forest forest = RcppUtilities::deserialize_forest(forest_object);
@@ -108,17 +103,12 @@ Rcpp::List survival_predict_oob(Rcpp::List forest_object,
                                 Eigen::SparseMatrix<double> sparse_train_matrix,
                                 size_t outcome_index,
                                 size_t censor_index,
-                                size_t sample_weight_index,
-                                bool use_sample_weights,
                                 int prediction_type,
                                 unsigned int num_threads,
                                 size_t num_failures) {
   std::unique_ptr<Data> data = RcppUtilities::convert_data(train_matrix, sparse_train_matrix);
   data->set_outcome_index(outcome_index - 1);
   data->set_censor_index(censor_index - 1);
-  if (use_sample_weights) {
-      data->set_weight_index(sample_weight_index - 1);
-  }
 
   Forest forest = RcppUtilities::deserialize_forest(forest_object);
 

--- a/r-package/grf/src/RcppExports.cpp
+++ b/r-package/grf/src/RcppExports.cpp
@@ -536,8 +536,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // survival_predict
-Rcpp::List survival_predict(Rcpp::List forest_object, Rcpp::NumericMatrix train_matrix, Eigen::SparseMatrix<double> sparse_train_matrix, size_t outcome_index, size_t censor_index, size_t sample_weight_index, bool use_sample_weights, int prediction_type, Rcpp::NumericMatrix test_matrix, Eigen::SparseMatrix<double> sparse_test_matrix, unsigned int num_threads, size_t num_failures);
-RcppExport SEXP _grf_survival_predict(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP sparse_train_matrixSEXP, SEXP outcome_indexSEXP, SEXP censor_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP prediction_typeSEXP, SEXP test_matrixSEXP, SEXP sparse_test_matrixSEXP, SEXP num_threadsSEXP, SEXP num_failuresSEXP) {
+Rcpp::List survival_predict(Rcpp::List forest_object, Rcpp::NumericMatrix train_matrix, Eigen::SparseMatrix<double> sparse_train_matrix, size_t outcome_index, size_t censor_index, int prediction_type, Rcpp::NumericMatrix test_matrix, Eigen::SparseMatrix<double> sparse_test_matrix, unsigned int num_threads, size_t num_failures);
+RcppExport SEXP _grf_survival_predict(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP sparse_train_matrixSEXP, SEXP outcome_indexSEXP, SEXP censor_indexSEXP, SEXP prediction_typeSEXP, SEXP test_matrixSEXP, SEXP sparse_test_matrixSEXP, SEXP num_threadsSEXP, SEXP num_failuresSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -546,20 +546,18 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< Eigen::SparseMatrix<double> >::type sparse_train_matrix(sparse_train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type outcome_index(outcome_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type censor_index(censor_indexSEXP);
-    Rcpp::traits::input_parameter< size_t >::type sample_weight_index(sample_weight_indexSEXP);
-    Rcpp::traits::input_parameter< bool >::type use_sample_weights(use_sample_weightsSEXP);
     Rcpp::traits::input_parameter< int >::type prediction_type(prediction_typeSEXP);
     Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type test_matrix(test_matrixSEXP);
     Rcpp::traits::input_parameter< Eigen::SparseMatrix<double> >::type sparse_test_matrix(sparse_test_matrixSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     Rcpp::traits::input_parameter< size_t >::type num_failures(num_failuresSEXP);
-    rcpp_result_gen = Rcpp::wrap(survival_predict(forest_object, train_matrix, sparse_train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, prediction_type, test_matrix, sparse_test_matrix, num_threads, num_failures));
+    rcpp_result_gen = Rcpp::wrap(survival_predict(forest_object, train_matrix, sparse_train_matrix, outcome_index, censor_index, prediction_type, test_matrix, sparse_test_matrix, num_threads, num_failures));
     return rcpp_result_gen;
 END_RCPP
 }
 // survival_predict_oob
-Rcpp::List survival_predict_oob(Rcpp::List forest_object, Rcpp::NumericMatrix train_matrix, Eigen::SparseMatrix<double> sparse_train_matrix, size_t outcome_index, size_t censor_index, size_t sample_weight_index, bool use_sample_weights, int prediction_type, unsigned int num_threads, size_t num_failures);
-RcppExport SEXP _grf_survival_predict_oob(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP sparse_train_matrixSEXP, SEXP outcome_indexSEXP, SEXP censor_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP prediction_typeSEXP, SEXP num_threadsSEXP, SEXP num_failuresSEXP) {
+Rcpp::List survival_predict_oob(Rcpp::List forest_object, Rcpp::NumericMatrix train_matrix, Eigen::SparseMatrix<double> sparse_train_matrix, size_t outcome_index, size_t censor_index, int prediction_type, unsigned int num_threads, size_t num_failures);
+RcppExport SEXP _grf_survival_predict_oob(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP sparse_train_matrixSEXP, SEXP outcome_indexSEXP, SEXP censor_indexSEXP, SEXP prediction_typeSEXP, SEXP num_threadsSEXP, SEXP num_failuresSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -568,12 +566,10 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< Eigen::SparseMatrix<double> >::type sparse_train_matrix(sparse_train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type outcome_index(outcome_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type censor_index(censor_indexSEXP);
-    Rcpp::traits::input_parameter< size_t >::type sample_weight_index(sample_weight_indexSEXP);
-    Rcpp::traits::input_parameter< bool >::type use_sample_weights(use_sample_weightsSEXP);
     Rcpp::traits::input_parameter< int >::type prediction_type(prediction_typeSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     Rcpp::traits::input_parameter< size_t >::type num_failures(num_failuresSEXP);
-    rcpp_result_gen = Rcpp::wrap(survival_predict_oob(forest_object, train_matrix, sparse_train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, prediction_type, num_threads, num_failures));
+    rcpp_result_gen = Rcpp::wrap(survival_predict_oob(forest_object, train_matrix, sparse_train_matrix, outcome_index, censor_index, prediction_type, num_threads, num_failures));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -604,8 +600,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_grf_ll_regression_predict", (DL_FUNC) &_grf_ll_regression_predict, 11},
     {"_grf_ll_regression_predict_oob", (DL_FUNC) &_grf_ll_regression_predict_oob, 9},
     {"_grf_survival_train", (DL_FUNC) &_grf_survival_train, 21},
-    {"_grf_survival_predict", (DL_FUNC) &_grf_survival_predict, 12},
-    {"_grf_survival_predict_oob", (DL_FUNC) &_grf_survival_predict_oob, 10},
+    {"_grf_survival_predict", (DL_FUNC) &_grf_survival_predict, 10},
+    {"_grf_survival_predict_oob", (DL_FUNC) &_grf_survival_predict_oob, 8},
     {NULL, NULL, 0}
 };
 


### PR DESCRIPTION
Passing sample weights to `survival_predict` and `survival_predict_oob` is of course not needed, remove this.