### PR TITLE
Remove an `isFALSE` in input_utilities.R

### DIFF
--- a/r-package/grf/R/input_utilities.R
+++ b/r-package/grf/R/input_utilities.R
@@ -196,7 +196,13 @@ create_train_matrices <- function(X, outcome = NULL, treatment = NULL,
     i <- i + 1
     out[["censor.index"]] <- ncol(X) + i
   }
-  if (!isFALSE(sample.weights)) {
+  # Forest bindings without sample weights: sample.weights = FALSE
+  # Forest bindings with sample weights:
+  # -sample.weights = NULL if no weights passed
+  # -sample.weights = numeric vector if passed
+  if (is.logical(sample.weights)) {
+    sample.weights <- NULL
+  } else {
     i <- i + 1
     out[["sample.weight.index"]] <- ncol(X) + i
     if (is.null(sample.weights)) {
@@ -204,8 +210,6 @@ create_train_matrices <- function(X, outcome = NULL, treatment = NULL,
     } else {
       out[["use.sample.weights"]] <- TRUE
     }
-  } else {
-    sample.weights = NULL
   }
 
   if (inherits(X, "dgCMatrix") && ncol(X) > 1) {


### PR DESCRIPTION
`isFALSE` was introduced in [R 3.5](https://cran.r-project.org/bin/windows/base/old/3.5.0/NEWS.R-3.5.0.html) and is strictly not needed for this check.

This check is a bit convoluted because of how sample weighting was implemented with two arguments instead of one.