### PR TITLE
Increase n in analysis tools docstring example

### DIFF
--- a/r-package/grf/R/analysis_tools.R
+++ b/r-package/grf/R/analysis_tools.R
@@ -115,7 +115,7 @@ get_tree <- function(forest, index) {
 #' @examples
 #' \donttest{
 #' # Train a quantile forest.
-#' n <- 50
+#' n <- 250
 #' p <- 10
 #' X <- matrix(rnorm(n * p), n, p)
 #' Y <- X[, 1] * rnorm(n)
@@ -145,7 +145,7 @@ split_frequencies <- function(forest, max.depth = 4) {
 #' @examples
 #' \donttest{
 #' # Train a quantile forest.
-#' n <- 50
+#' n <- 250
 #' p <- 10
 #' X <- matrix(rnorm(n * p), n, p)
 #' Y <- X[, 1] * rnorm(n)

--- a/r-package/grf/man/split_frequencies.Rd
+++ b/r-package/grf/man/split_frequencies.Rd
@@ -21,7 +21,7 @@ Calculate which features the forest split on at each depth.
 \examples{
 \donttest{
 # Train a quantile forest.
-n <- 50
+n <- 250
 p <- 10
 X <- matrix(rnorm(n * p), n, p)
 Y <- X[, 1] * rnorm(n)

--- a/r-package/grf/man/variable_importance.Rd
+++ b/r-package/grf/man/variable_importance.Rd
@@ -22,7 +22,7 @@ A simple weighted sum of how many times feature i was split on at each depth in 
 \examples{
 \donttest{
 # Train a quantile forest.
-n <- 50
+n <- 250
 p <- 10
 X <- matrix(rnorm(n * p), n, p)
 Y <- X[, 1] * rnorm(n)


### PR DESCRIPTION
With n equal to only 50 the docstring example variable importance is naturally not very precise

https://grf-labs.github.io/grf/reference/variable_importance.html

Increasing n to 250 looks more reasonable and does not increase build time significantly. 