### PR TITLE
Remove "experimental" tag in `sample.weight` docstring

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -278,11 +278,11 @@ Note that when clusters are provided, standard errors from `average_treatment_ef
 
 ### Sample Weighting
 
-**Note:** this feature is currently marked 'experimental'. Its implementation may change in future releases.
-
 When the distribution of data that you observe is not representative of the population you are interested in scientifically, it can be important to adjust for this. We can pass `sample.weights` to specify that in our population of interest, we observe Xi with probability proportional to `sample.weights[i]`. By default, these weights are constant, meaning that our population of interest is the population from which X1 ... Xn are sampled. For causal validity, the weights we use should not be confounded with the potential outcomes --- typically this is done by having them be a function of Xi. One common example is inverse probability of complete case weighting to adjust for missing data, which allows us to work with only the complete cases (the units with nothing missing) to estimate properties of the full data distribution (all units as if nothing were missing).
 
 The impact these weights have depends on what we are estimating. When our estimand is a function of x, e.g. `r(x) = E[Y | X=x]` in `regression_forest` or `tau(x)=E[Y(1)-Y(0)| X=x]` in `causal_forest`, passing weights that are a function of x does not change our estimand. It instead prioritizes fit on our population of interest. In `regression_forest`, this means minimizing weighted mean squared error, i.e. mean squared error over the population specified by the sample weights. In `causal_forest`, this means minimizing weighted R-loss (Nie and Wager (2017), Equations 4/5). When our estimand is an average of such a function, as in `average_treatment_effect` and `average_partial_effect`, it does change the estimand. Our estimand will be the average treatment/partial effect over the population specified by our sample weights.
+
+Currently the following forest types takes `sample.weights` into account during splitting and prediction: `regression_forest`, `causal_forest`, `instrumental_forest`, `causal_survival_forest`, `ll_regression_forest`. The following forests only takes `sample.weights` into account during prediction: `probability_forest`, `survival_forest`.
 
 ### Categorical inputs
 

--- a/r-package/grf/R/causal_forest.R
+++ b/r-package/grf/R/causal_forest.R
@@ -21,7 +21,7 @@
 #' @param num.trees Number of trees grown in the forest. Note: Getting accurate
 #'                  confidence intervals generally requires more trees than
 #'                  getting accurate predictions. Default is 2000.
-#' @param sample.weights (experimental) Weights given to each sample in estimation.
+#' @param sample.weights Weights given to each sample in estimation.
 #'                       If NULL, each observation receives the same weight.
 #'                       Note: To avoid introducing confounding, weights should be
 #'                       independent of the potential outcomes given X. Default is NULL.

--- a/r-package/grf/R/instrumental_forest.R
+++ b/r-package/grf/R/instrumental_forest.R
@@ -21,7 +21,7 @@
 #' @param num.trees Number of trees grown in the forest. Note: Getting accurate
 #'                  confidence intervals generally requires more trees than
 #'                  getting accurate predictions. Default is 2000.
-#' @param sample.weights (experimental) Weights given to each observation in estimation.
+#' @param sample.weights Weights given to each observation in estimation.
 #'                       If NULL, each observation receives equal weight. Default is NULL.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
 #'  Default is NULL (ignored).

--- a/r-package/grf/R/local_linear_forest.R
+++ b/r-package/grf/R/local_linear_forest.R
@@ -18,7 +18,7 @@
 #' @param num.trees Number of trees grown in the forest. Note: Getting accurate
 #'                  confidence intervals generally requires more trees than
 #'                  getting accurate predictions. Default is 2000.
-#' @param sample.weights (experimental) Weights given to an observation in estimation.
+#' @param sample.weights Weights given to an observation in estimation.
 #'                       If NULL, each observation is given the same weight. Default is NULL.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
 #'  Default is NULL (ignored).

--- a/r-package/grf/R/probability_forest.R
+++ b/r-package/grf/R/probability_forest.R
@@ -8,7 +8,7 @@
 #' @param num.trees Number of trees grown in the forest. Note: Getting accurate
 #'                  confidence intervals generally requires more trees than
 #'                  getting accurate predictions. Default is 2000.
-#' @param sample.weights (experimental) Weights given to an observation in prediction.
+#' @param sample.weights Weights given to an observation in prediction.
 #'                       If NULL, each observation is given the same weight. Default is NULL.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
 #'  Default is NULL (ignored).

--- a/r-package/grf/R/regression_forest.R
+++ b/r-package/grf/R/regression_forest.R
@@ -8,7 +8,7 @@
 #' @param num.trees Number of trees grown in the forest. Note: Getting accurate
 #'                  confidence intervals generally requires more trees than
 #'                  getting accurate predictions. Default is 2000.
-#' @param sample.weights (experimental) Weights given to an observation in estimation.
+#' @param sample.weights Weights given to an observation in estimation.
 #'                       If NULL, each observation is given the same weight. Default is NULL.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
 #'  Default is NULL (ignored).

--- a/r-package/grf/R/survival_forest.R
+++ b/r-package/grf/R/survival_forest.R
@@ -11,7 +11,7 @@
 #'  times are rounded down to the last sorted occurance less than or equal to the specified failure time.
 #'  The time points should be in increasing order. Default is NULL.
 #' @param num.trees Number of trees grown in the forest. Default is 1000.
-#' @param sample.weights (experimental) Weights given to an observation in prediction.
+#' @param sample.weights Weights given to an observation in prediction.
 #'                       If NULL, each observation is given the same weight. Default is NULL.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
 #'  Default is NULL (ignored).

--- a/r-package/grf/R/tune_causal_forest.R
+++ b/r-package/grf/R/tune_causal_forest.R
@@ -8,7 +8,7 @@
 #'              over treatment. See section 6.1.1 of the GRF paper for
 #'              further discussion of this quantity.
 #' @param W.hat Estimates of the treatment propensities E[W | Xi].
-#' @param sample.weights (experimental) Weights given to an observation in estimation.
+#' @param sample.weights Weights given to an observation in estimation.
 #'                       If NULL, each observation is given the same weight. Default is NULL.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
 #'  Default is NULL (ignored).

--- a/r-package/grf/R/tune_instrumental_forest.R
+++ b/r-package/grf/R/tune_instrumental_forest.R
@@ -10,7 +10,7 @@
 #'              further discussion of this quantity.
 #' @param W.hat Estimates of the treatment propensities E[W | Xi].
 #' @param Z.hat Estimates of the instrument propensities E[Z | Xi].
-#' @param sample.weights (experimental) Weights given to an observation in estimation.
+#' @param sample.weights Weights given to an observation in estimation.
 #'                       If NULL, each observation is given the same weight. Default is NULL.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
 #'  Default is NULL (ignored).

--- a/r-package/grf/R/tune_regression_forest.R
+++ b/r-package/grf/R/tune_regression_forest.R
@@ -5,7 +5,7 @@
 #'
 #' @param X The covariates used in the regression.
 #' @param Y The outcome.
-#' @param sample.weights (experimental) Weights given to an observation in estimation.
+#' @param sample.weights Weights given to an observation in estimation.
 #'                       If NULL, each observation is given the same weight. Default is NULL.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
 #'  Default is NULL (ignored).

--- a/r-package/grf/man/causal_forest.Rd
+++ b/r-package/grf/man/causal_forest.Rd
@@ -53,7 +53,7 @@ these are estimated using a separate regression forest. Default is NULL.}
 confidence intervals generally requires more trees than
 getting accurate predictions. Default is 2000.}
 
-\item{sample.weights}{(experimental) Weights given to each sample in estimation.
+\item{sample.weights}{Weights given to each sample in estimation.
 If NULL, each observation receives the same weight.
 Note: To avoid introducing confounding, weights should be
 independent of the potential outcomes given X. Default is NULL.}

--- a/r-package/grf/man/instrumental_forest.Rd
+++ b/r-package/grf/man/instrumental_forest.Rd
@@ -59,7 +59,7 @@ these are estimated using a separate regression forest. Default is NULL.}
 confidence intervals generally requires more trees than
 getting accurate predictions. Default is 2000.}
 
-\item{sample.weights}{(experimental) Weights given to each observation in estimation.
+\item{sample.weights}{Weights given to each observation in estimation.
 If NULL, each observation receives equal weight. Default is NULL.}
 
 \item{clusters}{Vector of integers or factors specifying which cluster each observation corresponds to.

--- a/r-package/grf/man/ll_regression_forest.Rd
+++ b/r-package/grf/man/ll_regression_forest.Rd
@@ -57,7 +57,7 @@ regulation (i.e., using the leaf betas at each step) by setting this parameter t
 confidence intervals generally requires more trees than
 getting accurate predictions. Default is 2000.}
 
-\item{sample.weights}{(experimental) Weights given to an observation in estimation.
+\item{sample.weights}{Weights given to an observation in estimation.
 If NULL, each observation is given the same weight. Default is NULL.}
 
 \item{clusters}{Vector of integers or factors specifying which cluster each observation corresponds to.

--- a/r-package/grf/man/probability_forest.Rd
+++ b/r-package/grf/man/probability_forest.Rd
@@ -34,7 +34,7 @@ probability_forest(
 confidence intervals generally requires more trees than
 getting accurate predictions. Default is 2000.}
 
-\item{sample.weights}{(experimental) Weights given to an observation in prediction.
+\item{sample.weights}{Weights given to an observation in prediction.
 If NULL, each observation is given the same weight. Default is NULL.}
 
 \item{clusters}{Vector of integers or factors specifying which cluster each observation corresponds to.

--- a/r-package/grf/man/regression_forest.Rd
+++ b/r-package/grf/man/regression_forest.Rd
@@ -38,7 +38,7 @@ regression_forest(
 confidence intervals generally requires more trees than
 getting accurate predictions. Default is 2000.}
 
-\item{sample.weights}{(experimental) Weights given to an observation in estimation.
+\item{sample.weights}{Weights given to an observation in estimation.
 If NULL, each observation is given the same weight. Default is NULL.}
 
 \item{clusters}{Vector of integers or factors specifying which cluster each observation corresponds to.

--- a/r-package/grf/man/survival_forest.Rd
+++ b/r-package/grf/man/survival_forest.Rd
@@ -40,7 +40,7 @@ The time points should be in increasing order. Default is NULL.}
 
 \item{num.trees}{Number of trees grown in the forest. Default is 1000.}
 
-\item{sample.weights}{(experimental) Weights given to an observation in prediction.
+\item{sample.weights}{Weights given to an observation in prediction.
 If NULL, each observation is given the same weight. Default is NULL.}
 
 \item{clusters}{Vector of integers or factors specifying which cluster each observation corresponds to.

--- a/r-package/grf/man/tune_causal_forest.Rd
+++ b/r-package/grf/man/tune_causal_forest.Rd
@@ -44,7 +44,7 @@ further discussion of this quantity.}
 
 \item{W.hat}{Estimates of the treatment propensities E[W | Xi].}
 
-\item{sample.weights}{(experimental) Weights given to an observation in estimation.
+\item{sample.weights}{Weights given to an observation in estimation.
 If NULL, each observation is given the same weight. Default is NULL.}
 
 \item{clusters}{Vector of integers or factors specifying which cluster each observation corresponds to.

--- a/r-package/grf/man/tune_instrumental_forest.Rd
+++ b/r-package/grf/man/tune_instrumental_forest.Rd
@@ -51,7 +51,7 @@ further discussion of this quantity.}
 
 \item{Z.hat}{Estimates of the instrument propensities E[Z | Xi].}
 
-\item{sample.weights}{(experimental) Weights given to an observation in estimation.
+\item{sample.weights}{Weights given to an observation in estimation.
 If NULL, each observation is given the same weight. Default is NULL.}
 
 \item{clusters}{Vector of integers or factors specifying which cluster each observation corresponds to.

--- a/r-package/grf/man/tune_regression_forest.Rd
+++ b/r-package/grf/man/tune_regression_forest.Rd
@@ -32,7 +32,7 @@ tune_regression_forest(
 
 \item{Y}{The outcome.}
 
-\item{sample.weights}{(experimental) Weights given to an observation in estimation.
+\item{sample.weights}{Weights given to an observation in estimation.
 If NULL, each observation is given the same weight. Default is NULL.}
 
 \item{clusters}{Vector of integers or factors specifying which cluster each observation corresponds to.


### PR DESCRIPTION
`sample.weights` are now out of the experimental phase. Also update the reference with details on which forests use `sample.weights` for both splitting and prediction, or just prediction.