### PR TITLE
Fix an inconsistent capitalization in the function reference

### DIFF
--- a/r-package/grf/pkgdown/_pkgdown.yml
+++ b/r-package/grf/pkgdown/_pkgdown.yml
@@ -78,7 +78,7 @@ reference:
       - survival_forest
       - predict.survival_forest
 
-  - title: Causal Survival forest
+  - title: Causal survival forest
     contents:
       - causal_survival_forest
       - predict.causal_survival_forest


### PR DESCRIPTION
This is only a minor fix to the online reference: only the first word should be capitalized.