### PR TITLE
Fix a pairwise comparison in old test

### DIFF
--- a/r-package/grf/tests/testthat/test_analysis_tools.R
+++ b/r-package/grf/tests/testthat/test_analysis_tools.R
@@ -17,7 +17,7 @@ test_that("examining a tree gives reasonable results", {
   expect_lt(num.nodes, n)
 
   split.vars <- unlist(sapply(quantile.tree$nodes, function(node) node$split_variable))
-  expect_true(all(split.vars >= 0 && split.vars <= 40))
+  expect_true(all(split.vars >= 0 & split.vars <= 40))
 
   left.children <- unlist(sapply(quantile.tree$nodes, function(node) node$left_child))
   expect_equal(seq(2, num.nodes, 2), left.children)


### PR DESCRIPTION
This is only a minor fix, the comparison should be pairwise (`&` not `&&`). 