### PR TITLE
Treat warnings as errors in `build_package.R`

### DIFF
--- a/r-package/build_package.R
+++ b/r-package/build_package.R
@@ -34,4 +34,6 @@ build(package.name)
 # Test installation and run some smoke tests.
 install(package.name)
 library(package.name, character.only = TRUE)
+# Treat warnings as errors.
+options(warn = 2)
 test_package(package.name)


### PR DESCRIPTION
In the R package tests we enabled treating warnings as errors in #595, but since `build_package.R` invokes the test suite differently, this option was not respected (it is respected when running R CMD check). Address this by adding a `options(warn = 2)` before `test_package` is run (currently all tests pass without warnings).