### PR TITLE
Add missing `clusters` argument to `get_ACLATE`

### DIFF
--- a/r-package/grf/R/get_scores.R
+++ b/r-package/grf/R/get_scores.R
@@ -190,6 +190,11 @@ get_scores_ACLATE = function(forest,
   if (is.null(debiasing.weights)) {
   # The compliance forest estimates the effect of the "treatment" Z on the "outcome" W.
     if (is.null(compliance.score)) {
+      clusters <- if (length(forest$clusters) > 0) {
+        forest$clusters
+      } else {
+        1:length(forest$Y.orig)
+      }
       compliance.forest <- causal_forest(forest$X.orig,
                                          Y=forest$W.orig,
                                          W=forest$Z.orig,


### PR DESCRIPTION
#723 accidentally omitted the `clusters` for the compliance forest. This did not cause a test error since all tests where passed with a pre-computed `compliance.score`.