### PR TITLE
Add a "Visualize trees" entry to vignettes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ matrix:
         - cp ../../DEVELOPING.md .
         - cp ../../releases/CHANGELOG.md .
         - Rscript -e 'install.packages("pkgdown")'
-        - Rscript -e 'install.packages(c("ggplot2", "glmnet"))'
+        - Rscript -e 'install.packages(c("ggplot2", "glmnet", "policytree"))'
         - Rscript -e 'pkgdown::build_site()'
         - cp pkgdown/favicon/* docs/
       deploy:

--- a/r-package/grf/pkgdown/_pkgdown.yml
+++ b/r-package/grf/pkgdown/_pkgdown.yml
@@ -20,6 +20,8 @@ navbar:
         href: articles/llf.html
       - text: "Sample weighting"
         href: articles/sample_weighting_examples.html
+      - text: "Visualize trees"
+        href: articles/visualize_tree.html
   - text: "Algorithm reference"
     href: REFERENCE.html
   - text: "Developing"

--- a/r-package/grf/vignettes/visualize_tree.Rmd
+++ b/r-package/grf/vignettes/visualize_tree.Rmd
@@ -39,8 +39,6 @@ print(tree)
 plot(tree)
 ```
 
-_Note_: if you wish to fit the forest with exactly one tree, you should set the confidence-interval argument `ci.group.size` to 1 as this takes precedence over `num.trees`.
-
 ## Visualizing tree-based treatment assignment rules
 
 The above approach is only a convenient way to inspect individual trees, it is not suggested as a way to evaluate or design treatment assignment rules. For this purpose we suggest the companion package [policytree](https://github.com/grf-labs/policytree) (Athey and Wager, 2017). The example below illustrates this by fitting a shallow tree on doubly robust treatment effect estimates obtained from a causal forest. The function `policy_tree` and `double_robust_scores` belong to the [policytree](https://github.com/grf-labs/policytree) package.

--- a/r-package/grf/vignettes/visualize_tree.Rmd
+++ b/r-package/grf/vignettes/visualize_tree.Rmd
@@ -1,0 +1,79 @@
+---
+title: "Visualize trees"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{visualize_tree}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+set.seed(123)
+```
+
+```{r setup}
+library(grf)
+```
+
+## Visualize trees in a random forest
+
+All GRF forest objects works with the tree extractor function `get_tree` which you can use to visually inspect trees with either `print` or `plot`. The example below demonstrates this for a regression forest.
+
+```{r}
+n <- 150
+p <- 5
+X <- matrix(rnorm(n * p), n, p)
+Y <- X[, 1] * rnorm(n)
+r.forest <- regression_forest(X, Y, num.trees = 100)
+
+# Extract the first tree from the fitted forest.
+tree <- get_tree(r.forest, 1)
+# Print the first tree.
+print(tree)
+
+# Plot the first tree.
+plot(tree)
+```
+
+_Note_: if you wish to fit the forest with exactly one tree, you should set the confidence-interval argument `ci.group.size` to 1 as this takes precedence over `num.trees`.
+
+## Visualizing tree-based treatment assignment rules
+
+The above approach is only a convenient way to inspect individual trees, it is not suggested as a way to evaluate or design treatment assignment rules. For this purpose we suggest the companion package [policytree](https://github.com/grf-labs/policytree) (Athey and Wager, 2017). The example below illustrates this by fitting a shallow tree on doubly robust treatment effect estimates obtained by a causal forest. The function `policy_tree` and `double_robust_scores` belong to the [policytree](https://github.com/grf-labs/policytree) package.
+
+```{r}
+library(policytree)
+
+# Fit a causal forest.
+n <- 15000
+p <- 5
+X <- round(matrix(rnorm(n * p), n, p), 2)
+W <- rbinom(n, 1, 1 / (1 + exp(X[, 3])))
+tau <- 1 / (1 + exp((X[, 1] + X[, 2]) / 2)) - 0.5
+Y <- X[, 3] + W * tau + rnorm(n)
+c.forest <- causal_forest(X, Y, W)
+
+# Compute doubly robust scores.
+dr.scores <- double_robust_scores(c.forest)
+# Fit a depth two tree on the doubly robust scores.
+tree <- policy_tree(X, dr.scores, 2)
+plot(tree)
+
+# Predict treatment assignment.
+predicted <- predict(tree, X)
+
+plot(X[, 1], X[, 2], col = predicted)
+legend("topright", c("control", "treat"), col = c(1, 2), pch = 19)
+abline(0, -1, lty = 2)
+```
+
+For more details please see the referenced package, and the references therein.
+
+## References
+Susan Athey and Stefan Wager. Efficient Policy Learning. 2017. [[arxiv](https://arxiv.org/abs/1702.02896)]
+
+Sverdrup, Erik, Ayush Kanodia, Zhengyuan Zhou, Susan Athey, and Stefan Wager. policytree: Policy learning via doubly robust empirical welfare maximization over trees. _Journal of Open Source Software 5, no. 50 (2020): 2232._ [[paper](https://joss.theoj.org/papers/10.21105/joss.02232.pdf)]

--- a/r-package/grf/vignettes/visualize_tree.Rmd
+++ b/r-package/grf/vignettes/visualize_tree.Rmd
@@ -43,7 +43,7 @@ _Note_: if you wish to fit the forest with exactly one tree, you should set the 
 
 ## Visualizing tree-based treatment assignment rules
 
-The above approach is only a convenient way to inspect individual trees, it is not suggested as a way to evaluate or design treatment assignment rules. For this purpose we suggest the companion package [policytree](https://github.com/grf-labs/policytree) (Athey and Wager, 2017). The example below illustrates this by fitting a shallow tree on doubly robust treatment effect estimates obtained by a causal forest. The function `policy_tree` and `double_robust_scores` belong to the [policytree](https://github.com/grf-labs/policytree) package.
+The above approach is only a convenient way to inspect individual trees, it is not suggested as a way to evaluate or design treatment assignment rules. For this purpose we suggest the companion package [policytree](https://github.com/grf-labs/policytree) (Athey and Wager, 2017). The example below illustrates this by fitting a shallow tree on doubly robust treatment effect estimates obtained from a causal forest. The function `policy_tree` and `double_robust_scores` belong to the [policytree](https://github.com/grf-labs/policytree) package.
 
 ```{r}
 library(policytree)


### PR DESCRIPTION
This PR adds a short vignette entry `Visualize trees` giving a short overview of the tree plotting functionality in GRF. @susanathey mentioned the documentation could be clarified in this area, hopefully this vignette will be useful for users.

We demonstrate `plot` and `print` with `get_tree`, and emphasize these are only simple visualization tools, and refer the user to the `policytree` package (with an example) for tree-based treatment assignment rules.

A printout of the rendered vignette is attached [here](https://github.com/grf-labs/grf/files/5253388/out.pdf) for convenience. 
