### PR TITLE
Fix two mini typos in roxygen section

### DIFF
--- a/r-package/grf/R/causal_survival_forest.R
+++ b/r-package/grf/R/causal_survival_forest.R
@@ -465,7 +465,7 @@ predict.causal_survival_forest <- function(object,
 #'
 #' Some useful properties:
 #' The expected survival time E[T] is the integral of the survival function S(t).
-#' The conditional expected survival time E[T | T >= y] is the integral of S(t + y) / S(y).
+#' The conditional expected survival time E[T | T >= y] is y + the integral of S(t + y) / S(y).
 #'
 #' @param S.hat Estimates of the conditional survival function S(t, x, w).
 #' @param C.hat Estimates of the conditional survival function for the censoring process S_C(t, x, w).

--- a/r-package/grf/R/tuning.R
+++ b/r-package/grf/R/tuning.R
@@ -1,4 +1,4 @@
-#' Tune a forests
+#' Tune a forest
 #'
 #' Finds the optimal parameters to be used in training a forest.
 #'

--- a/r-package/grf/man/compute_eta.Rd
+++ b/r-package/grf/man/compute_eta.Rd
@@ -53,6 +53,6 @@ lambda.C = -d/dt log(C.hat(t, x, w)) is the conditional hazard function of the c
 
 Some useful properties:
 The expected survival time E[T] is the integral of the survival function S(t).
-The conditional expected survival time E[T | T >= y] is the integral of S(t + y) / S(y).
+The conditional expected survival time E[T | T >= y] is y + the integral of S(t + y) / S(y).
 }
 \keyword{internal}

--- a/r-package/grf/man/tune_forest.Rd
+++ b/r-package/grf/man/tune_forest.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tuning.R
 \name{tune_forest}
 \alias{tune_forest}
-\title{Tune a forests}
+\title{Tune a forest}
 \usage{
 tune_forest(
   data,


### PR DESCRIPTION
This is just a two character fix to two docstrings.