### PR TITLE
Set `PKG_CPPFLAGS=-UNDEBUG` in CI R test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ matrix:
         - cd r-package/grf
       script:
         - cd ..
-        - export PKG_CPPFLAGS="-UNDEBUG"
+        - export PKG_CPPFLAGS="-UNDEBUG" # Compile C++ extensions with debug assertions enabled 
         - Rscript build_package.R
       # Render the examples under vignettes/ and build the package documentation with 'pkgdown'.
       # Also install required packages for vignette examples, like glmnet.

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,7 @@ matrix:
         - cd r-package/grf
       script:
         - cd ..
+        - export PKG_CPPFLAGS="-UNDEBUG"
         - Rscript build_package.R
       # Render the examples under vignettes/ and build the package documentation with 'pkgdown'.
       # Also install required packages for vignette examples, like glmnet.

--- a/core/src/relabeling/LLRegressionRelabelingStrategy.cpp
+++ b/core/src/relabeling/LLRegressionRelabelingStrategy.cpp
@@ -52,6 +52,10 @@ bool LLRegressionRelabelingStrategy::relabel(
 
   Eigen::MatrixXd leaf_predictions (num_data_points, 1);
 
+  Eigen::MatrixXf a(3,3);
+  Eigen::MatrixXf b(4,4);
+  Eigen::MatrixXf x = a*b;
+
   if (num_data_points < ll_split_cutoff) {
     // use overall beta for ridge predictions
 

--- a/core/src/relabeling/LLRegressionRelabelingStrategy.cpp
+++ b/core/src/relabeling/LLRegressionRelabelingStrategy.cpp
@@ -52,10 +52,6 @@ bool LLRegressionRelabelingStrategy::relabel(
 
   Eigen::MatrixXd leaf_predictions (num_data_points, 1);
 
-  Eigen::MatrixXf a(3,3);
-  Eigen::MatrixXf b(4,4);
-  Eigen::MatrixXf x = a*b;
-
   if (num_data_points < ll_split_cutoff) {
     // use overall beta for ridge predictions
 


### PR DESCRIPTION
GRF contains several `Eigen` computations involving matrix products, since the dimensionality of these are determined at runtime, bugs (unlikely but not impossible) may creep in from non-conformable expressions. 

This PR sets the environment variable `PKG_CPPFLAGS="-UNDEBUG"` in the R package test which makes `Eigen` check the dimensionality of all matrix products at runtime. (This compiler flag only affects the R tests). 

From [Writing R Extensions](https://cran.r-project.org/doc/manuals/r-devel/R-exts.html): "If you wish to use assert during development. you can include -UNDEBUG in PKG_CPPFLAGS."

Check of this suggested addition:

- f1b2ac4 adds a change that should fail, but the CI passes
- 6aba480 adds the above flag to .travis.yml, causing the build to fail (as it should)

