### PR TITLE
Require that the class labels in `probability_forest` is a factor

### DIFF
--- a/r-package/grf/R/probability_forest.R
+++ b/r-package/grf/R/probability_forest.R
@@ -4,7 +4,7 @@
 #' the conditional class probabilities P[Y = k | X = x]
 #'
 #' @param X The covariates.
-#' @param Y The class label.
+#' @param Y The class label (must be a factor vector with no NAs).
 #' @param num.trees Number of trees grown in the forest. Note: Getting accurate
 #'                  confidence intervals generally requires more trees than
 #'                  getting accurate predictions. Default is 2000.
@@ -58,7 +58,7 @@
 #' n <- 2000
 #' X <- matrix(rnorm(n*p), n, p)
 #' prob <- 1 / (1 + exp(-X[, 1] - X[, 2]))
-#' Y <- rbinom(n, 1, prob)
+#' Y <- as.factor(rbinom(n, 1, prob))
 #' p.forest <- probability_forest(X, Y)
 #'
 #' # Predict using the forest.
@@ -107,9 +107,11 @@ probability_forest <- function(X, Y,
   if (any(is.na(Y))) {
     stop("The vector of observations contains at least one NA.")
   }
-  Y.factor <- as.factor(Y)
-  Y.relabeled <- as.numeric(Y.factor) - 1 # convert to integers between 0 and num_classes
-  class.names <- levels(Y.factor)
+  if (!is.factor(Y)) {
+    stop("The class labels must be a factor vector.")
+  }
+  Y.relabeled <- as.numeric(Y) - 1 # convert to integers between 0 and num_classes
+  class.names <- levels(Y)
   num.classes <- length(class.names)
 
   data <- create_train_matrices(X, outcome = Y.relabeled, sample.weights = sample.weights)
@@ -170,7 +172,7 @@ probability_forest <- function(X, Y,
 #' n <- 2000
 #' X <- matrix(rnorm(n*p), n, p)
 #' prob <- 1 / (1 + exp(-X[, 1] - X[, 2]))
-#' Y <- rbinom(n, 1, prob)
+#' Y <- as.factor(rbinom(n, 1, prob))
 #' p.forest <- probability_forest(X, Y)
 #'
 #' # Predict using the forest.

--- a/r-package/grf/man/predict.probability_forest.Rd
+++ b/r-package/grf/man/predict.probability_forest.Rd
@@ -42,7 +42,7 @@ p <- 5
 n <- 2000
 X <- matrix(rnorm(n*p), n, p)
 prob <- 1 / (1 + exp(-X[, 1] - X[, 2]))
-Y <- rbinom(n, 1, prob)
+Y <- as.factor(rbinom(n, 1, prob))
 p.forest <- probability_forest(X, Y)
 
 # Predict using the forest.

--- a/r-package/grf/man/probability_forest.Rd
+++ b/r-package/grf/man/probability_forest.Rd
@@ -28,7 +28,7 @@ probability_forest(
 \arguments{
 \item{X}{The covariates.}
 
-\item{Y}{The class label.}
+\item{Y}{The class label (must be a factor vector with no NAs).}
 
 \item{num.trees}{Number of trees grown in the forest. Note: Getting accurate
 confidence intervals generally requires more trees than
@@ -103,7 +103,7 @@ p <- 5
 n <- 2000
 X <- matrix(rnorm(n*p), n, p)
 prob <- 1 / (1 + exp(-X[, 1] - X[, 2]))
-Y <- rbinom(n, 1, prob)
+Y <- as.factor(rbinom(n, 1, prob))
 p.forest <- probability_forest(X, Y)
 
 # Predict using the forest.

--- a/r-package/grf/tests/testthat/test_probability_forest.R
+++ b/r-package/grf/tests/testthat/test_probability_forest.R
@@ -4,7 +4,7 @@ test_that("probability forest works as expected", {
   p <- 5
   n <- 200
   X <- matrix(rnorm(n * p), n, p)
-  Y <- sample(c(0, 1, 5, 8), n, T)
+  Y <- as.factor(sample(c(0, 1, 5, 8), n, T))
   class.names <- sort(unique(Y))
 
   prf <- probability_forest(X, Y, num.trees = 50)
@@ -22,7 +22,8 @@ test_that("probability forest works as expected", {
   expect_true(all(abs(rowSums(pred.oob$predictions) - 1) < 1e-10))
 
   Y <- sample(c("A", "B", "C"), n, T)
-  class.names <- sort(unique(Y))
+  Y <- as.factor(Y)
+  class.names <- levels(Y)
   prf <- probability_forest(X, Y, num.trees = 50)
   pred.oob <- predict(prf)
   expect_true(all(colnames(pred.oob$predictions) == class.names))
@@ -35,6 +36,7 @@ test_that("probability forest is well-calibrated", {
   X <- sweep(X, 1, rowSums(X), "/")
   prob.true <- X[, 1:4]
   Y <- sapply(1:n, function(i) sample(c("a", "b", "c", "d"), 1, prob = prob.true[i, ]))
+  Y <- as.factor(Y)
 
   prf <- probability_forest(X, Y, num.trees = 500)
   p.hat <- predict(prf, estimate.variance = TRUE)
@@ -53,6 +55,7 @@ test_that("sample weighted probability forest is invariant to scaling", {
   p <- 5
   X <- matrix(rnorm(n * p), n, p)
   Y <- rbinom(n, 1, 1 / (1 + exp(-X[, 1] - X[, 2])))
+  Y <- as.factor(Y)
   weights <- runif(n)
 
   # Predictions are invariant to sample weight scaling


### PR DESCRIPTION
This is just to ensure robustness and limit potential confusion by restricting the input class labels to be a factor. This way the class labels and ordering is unambiguous, it is given by the levels of the factor Y.

The upcoming addition in #748 will have the same restriction on the input treatment vector.