### PR TITLE
Rename `theta` and `tau` in causal_survival_forest

### DIFF
--- a/r-package/grf/R/causal_survival_forest.R
+++ b/r-package/grf/R/causal_survival_forest.R
@@ -1,8 +1,8 @@
 #' Causal survival forest (experimental)
 #'
 #' Trains a causal survival forest that can be used to estimate
-#' conditional average treatment effects theta(X). When the treatment assigment
-#' is unconfounded, we have theta(X) = E[T(1) - T(0) | X = x],
+#' conditional average treatment effects tau(X). When the treatment assignment
+#' is unconfounded, we have tau(X) = E[T(1) - T(0) | X = x],
 #' where T is the survival time up to a fixed maximum follow-up time.
 #' T(1) and T(0) are potental outcomes corresponding to the two possible
 #' treatment states.
@@ -356,7 +356,7 @@ causal_survival_forest <- function(X, Y, W, D,
 
 #' Predict with a causal survival forest forest
 #'
-#' Gets estimates of theta(X) using a trained causal survival forest.
+#' Gets estimates of tau(X) using a trained causal survival forest.
 #'
 #' @param object The trained forest.
 #' @param newdata Points at which predictions should be made. If NULL, makes out-of-bag
@@ -366,7 +366,7 @@ causal_survival_forest <- function(X, Y, W, D,
 #'                matrix, and that the columns must appear in the same order.
 #' @param num.threads Number of threads used in training. If set to NULL, the software
 #'                    automatically selects an appropriate amount.
-#' @param estimate.variance Whether variance estimates for hat{theta}(x) are desired
+#' @param estimate.variance Whether variance estimates for hat{tau}(x) are desired
 #'                          (for confidence intervals).
 #' @param ... Additional arguments (currently ignored).
 #'
@@ -450,7 +450,7 @@ predict.causal_survival_forest <- function(object,
   do.call(cbind.data.frame, ret[!empty])
 }
 
-#' Compute pseudo outcomes (based on the influence function of theta(X) for each unit)
+#' Compute pseudo outcomes (based on the influence function of tau(X) for each unit)
 #' used for CART splitting.
 #'
 #' We compute:

--- a/r-package/grf/man/causal_survival_forest.Rd
+++ b/r-package/grf/man/causal_survival_forest.Rd
@@ -157,8 +157,8 @@ A trained causal_survival_forest forest object.
 }
 \description{
 Trains a causal survival forest that can be used to estimate
-conditional average treatment effects theta(X). When the treatment assigment
-is unconfounded, we have theta(X) = E[T(1) - T(0) | X = x],
+conditional average treatment effects tau(X). When the treatment assignment
+is unconfounded, we have tau(X) = E[T(1) - T(0) | X = x],
 where T is the survival time up to a fixed maximum follow-up time.
 T(1) and T(0) are potental outcomes corresponding to the two possible
 treatment states.

--- a/r-package/grf/man/compute_eta.Rd
+++ b/r-package/grf/man/compute_eta.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/causal_survival_forest.R
 \name{compute_eta}
 \alias{compute_eta}
-\title{Compute pseudo outcomes (based on the influence function of theta(X) for each unit)
+\title{Compute pseudo outcomes (based on the influence function of tau(X) for each unit)
 used for CART splitting.}
 \usage{
 compute_eta(

--- a/r-package/grf/man/generate_survival_data.Rd
+++ b/r-package/grf/man/generate_survival_data.Rd
@@ -7,7 +7,7 @@
 generate_survival_data(
   n,
   p,
-  tau = NULL,
+  Y.max = NULL,
   X = NULL,
   n.mc = 10000,
   dgp = c("simple1", "type1", "type2", "type3", "type4", "type5")
@@ -18,7 +18,7 @@ generate_survival_data(
 
 \item{p}{The number of covariates.}
 
-\item{tau}{The maximum follow-up time (optional).}
+\item{Y.max}{The maximum follow-up time (optional).}
 
 \item{X}{The covariates (optional).}
 
@@ -30,13 +30,13 @@ generate_survival_data(
 A list with entries:
  `X`: the covariates, `Y`: the event times, `W`: the treatment indicator, `D`: the censoring indicator,
  `cate`: the treatment effect estimated by monte carlo, `cate.sign`: the true sign of the cate for ITR comparison,
- `dgp`: the dgp name, `tau`: the maximum follow-up time.
+ `dgp`: the dgp name, `Y.max`: the maximum follow-up time.
 }
 \description{
 The following DGPs are available for benchmarking purposes, T is the failure time
 and C the censoring time:
 \itemize{
-  \item "simple1": T = X1*eps + W, C ~ U(0, 2) where eps ~ Exp(1) and tau = 1.
+  \item "simple1": T = X1*eps + W, C ~ U(0, 2) where eps ~ Exp(1) and Y.max = 1.
   \item  "type1": T is drawn from an accelerated failure time model and C from a Cox model (scenario 1 in https://arxiv.org/abs/2001.09887)
   \item  "type2": T is drawn from a proportional hazard model and C from a accelerated failure time (scenario 2 in https://arxiv.org/abs/2001.09887)
   \item  "type3": T and C are drawn from a Poisson distribution  (scenario 3 in https://arxiv.org/abs/2001.09887)

--- a/r-package/grf/man/predict.causal_survival_forest.Rd
+++ b/r-package/grf/man/predict.causal_survival_forest.Rd
@@ -24,7 +24,7 @@ matrix, and that the columns must appear in the same order.}
 \item{num.threads}{Number of threads used in training. If set to NULL, the software
 automatically selects an appropriate amount.}
 
-\item{estimate.variance}{Whether variance estimates for hat{theta}(x) are desired
+\item{estimate.variance}{Whether variance estimates for hat{tau}(x) are desired
 (for confidence intervals).}
 
 \item{...}{Additional arguments (currently ignored).}
@@ -33,7 +33,7 @@ automatically selects an appropriate amount.}
 Vector of predictions.
 }
 \description{
-Gets estimates of theta(X) using a trained causal survival forest.
+Gets estimates of tau(X) using a trained causal survival forest.
 }
 \examples{
 \donttest{

--- a/r-package/grf/tests/testthat/test_causal_survival_forest.R
+++ b/r-package/grf/tests/testthat/test_causal_survival_forest.R
@@ -3,7 +3,7 @@ library(grf)
 test_that("causal survival forest is well-calibrated", {
   n <- 1000
   p <- 5
-  data <- generate_survival_data(n, p, tau = 1, n.mc = 5000, dgp = "simple1")
+  data <- generate_survival_data(n, p, Y.max = 1, n.mc = 5000, dgp = "simple1")
   cs.forest <- causal_survival_forest(data$X, data$Y, data$W, data$D, num.trees = 500)
   cs.pred <- predict(cs.forest)
 
@@ -11,7 +11,7 @@ test_that("causal survival forest is well-calibrated", {
 
   X.test <- matrix(0.5, 10, p)
   X.test[, 1] <- seq(0, 1, length.out = 10)
-  true.effect.test <- generate_survival_data(10, p, tau = 1, X = X.test, n.mc = 5000, dgp = "simple1")$cate
+  true.effect.test <- generate_survival_data(10, p, Y.max = 1, X = X.test, n.mc = 5000, dgp = "simple1")$cate
   cs.pred.test <- predict(cs.forest, X.test)
   mse.test <- mean((cs.pred.test$predictions - true.effect.test)^2)
 
@@ -22,7 +22,7 @@ test_that("causal survival forest is well-calibrated", {
 test_that("causal survival forest variance estimates are decent", {
   n <- 1000
   p <- 5
-  data <- generate_survival_data(n, p, tau = 1, n.mc = 5000, dgp = "simple1")
+  data <- generate_survival_data(n, p, Y.max = 1, n.mc = 5000, dgp = "simple1")
   true.effect <- data$cate
   cs.forest <- causal_survival_forest(data$X, data$Y, data$W, data$D, num.trees = 500)
   cs.pred <- predict(cs.forest, estimate.variance = TRUE)
@@ -34,7 +34,7 @@ test_that("causal survival forest variance estimates are decent", {
   X.test <- matrix(0.5, 10, p)
   X.test[, 1] <- seq(0, 1, length.out = 10)
   true.effect.test <- rep(NA, 10)
-  true.effect.test <- generate_survival_data(10, p, tau = 1, X = X.test, n.mc = 5000, dgp = "simple1")$cate
+  true.effect.test <- generate_survival_data(10, p, Y.max = 1, X = X.test, n.mc = 5000, dgp = "simple1")$cate
   cs.pred.test <- predict(cs.forest, X.test, estimate.variance = TRUE)
 
   ub.test <- cs.pred.test$predictions + 2 * sqrt(cs.pred.test$variance.estimates)


### PR DESCRIPTION
The notation in the CSF paper is updated, this PR reflects that in the code.

Should take care of bullet point 2.viii. in #652 