### PR TITLE
Update causal_survival_forest docstring with details on follow-up time

### DIFF
--- a/r-package/grf/R/causal_survival_forest.R
+++ b/r-package/grf/R/causal_survival_forest.R
@@ -15,7 +15,7 @@
 #'
 #' This means that the individual censoring probabilities (by default estimated using a
 #' survival_forest on D' = 1 - D) should not get too low. This function provides a warning
-#' if these estimates gets below 0.2, if they drop all the way down to below 0.05, we emit a
+#' if these estimates get below 0.2, if they drop all the way down to below 0.05, we emit a
 #' stronger warning that you can not expect causal survival forest to deliver reliable
 #' estimates.
 #'

--- a/r-package/grf/R/causal_survival_forest.R
+++ b/r-package/grf/R/causal_survival_forest.R
@@ -9,7 +9,7 @@
 #'
 #' @section Statistical details:
 #' An important assumption for identifying the conditional average treatment effect theta(X)
-#' is that there exist a fixed positive constant M such that the probability of observing an
+#' is that there exists a fixed positive constant M such that the probability of observing an
 #' event time past the maximum follow-up time Y.max is at least M (formally, we assume: P(Y
 #' >= Y.max | X) > M).
 #'
@@ -316,14 +316,14 @@ causal_survival_forest <- function(X, Y, W, D,
 
  if (any(C.hat <= 0.05)) {
   warning(paste("Estimated censoring probabilites go as low as:", min(C.hat),
-                "- an identifying assumption is that there exist a fixed positve constant M",
+                "- an identifying assumption is that there exists a fixed positve constant M",
                 "such that the probability of observing an event time past the maximum follow-up time tau",
                 "is at least M. Formally, we assume: P(Y >= tau | X) > M.",
                 "This warning appears when M is less than 0.05, at which point causal survival forest",
                 "can not be expected to deliver reliable estimates."))
   } else if (any(C.hat < 0.2 & C.hat > 0.05)) {
     warning(paste("Estimated censoring probabilites are lower than 0.2.",
-                  "An identifying assumption is that there exist a fixed positve constant M",
+                  "An identifying assumption is that there exists a fixed positve constant M",
                   "such that the probability of observing an event time past the maximum follow-up time tau",
                   "is at least M. Formally, we assume: P(Y >= tau | X) > M."))
   }

--- a/r-package/grf/R/causal_survival_forest.R
+++ b/r-package/grf/R/causal_survival_forest.R
@@ -7,6 +7,25 @@
 #' T(1) and T(0) are potental outcomes corresponding to the two possible
 #' treatment states.
 #'
+#' @section Statistical details:
+#' An important assumption for identifying the conditional average treatment effect theta(X)
+#' is that there exist a fixed positive constant M such that the probability of observing an
+#' event time past the maximum follow-up time Y.max is at least M (formally, we assume: P(Y
+#' >= Y.max | X) > M).
+#'
+#' This means that the individual censoring probabilities (by default estimated using a
+#' survival_forest on D' = 1 - D) should not get too low. This function provides a warning
+#' if these estimates gets below 0.2, if they drop all the way down to below 0.05, we emit a
+#' stronger warning that you can not expect causal survival forest to deliver reliable
+#' estimates.
+#'
+#' The practical issue is that we can not reliably extrapolate the survival curves
+#' sufficiently far into the future (where most observations will be censored). A workaround
+#' is to re-define the estimand as the treatment effect up to some suitable maximum
+#' follow-up time Y.max. One can do this in practice by thresholding Y before running
+#' causal_survival_forest: D[Y >= Y.max] = 1 and Y[Y >= Y.max] = Y.max. The online vignette on
+#' survival data has more details.
+#'
 #' @param X The covariates.
 #' @param Y The event time (may be negative).
 #' @param W The treatment assignment (must be a binary vector with no NAs).

--- a/r-package/grf/R/causal_survival_forest.R
+++ b/r-package/grf/R/causal_survival_forest.R
@@ -317,15 +317,15 @@ causal_survival_forest <- function(X, Y, W, D,
  if (any(C.hat <= 0.05)) {
   warning(paste("Estimated censoring probabilites go as low as:", min(C.hat),
                 "- an identifying assumption is that there exists a fixed positve constant M",
-                "such that the probability of observing an event time past the maximum follow-up time tau",
-                "is at least M. Formally, we assume: P(Y >= tau | X) > M.",
+                "such that the probability of observing an event time past the maximum follow-up time Y.max",
+                "is at least M. Formally, we assume: P(Y >= Y.max | X) > M.",
                 "This warning appears when M is less than 0.05, at which point causal survival forest",
                 "can not be expected to deliver reliable estimates."))
   } else if (any(C.hat < 0.2 & C.hat > 0.05)) {
     warning(paste("Estimated censoring probabilites are lower than 0.2.",
                   "An identifying assumption is that there exists a fixed positve constant M",
-                  "such that the probability of observing an event time past the maximum follow-up time tau",
-                  "is at least M. Formally, we assume: P(Y >= tau | X) > M."))
+                  "such that the probability of observing an event time past the maximum follow-up time Y.max",
+                  "is at least M. Formally, we assume: P(Y >= Y.max | X) > M."))
   }
 
   # Compute the pseudo outcomes

--- a/r-package/grf/man/causal_survival_forest.Rd
+++ b/r-package/grf/man/causal_survival_forest.Rd
@@ -172,7 +172,7 @@ event time past the maximum follow-up time Y.max is at least M (formally, we ass
 
 This means that the individual censoring probabilities (by default estimated using a
 survival_forest on D' = 1 - D) should not get too low. This function provides a warning
-if these estimates gets below 0.2, if they drop all the way down to below 0.05, we emit a
+if these estimates get below 0.2, if they drop all the way down to below 0.05, we emit a
 stronger warning that you can not expect causal survival forest to deliver reliable
 estimates.
 

--- a/r-package/grf/man/causal_survival_forest.Rd
+++ b/r-package/grf/man/causal_survival_forest.Rd
@@ -166,7 +166,7 @@ treatment states.
 \section{Statistical details}{
 
 An important assumption for identifying the conditional average treatment effect theta(X)
-is that there exist a fixed positive constant M such that the probability of observing an
+is that there exists a fixed positive constant M such that the probability of observing an
 event time past the maximum follow-up time Y.max is at least M (formally, we assume: P(Y
 >= Y.max | X) > M).
 

--- a/r-package/grf/man/causal_survival_forest.Rd
+++ b/r-package/grf/man/causal_survival_forest.Rd
@@ -163,6 +163,27 @@ where T is the survival time up to a fixed maximum follow-up time.
 T(1) and T(0) are potental outcomes corresponding to the two possible
 treatment states.
 }
+\section{Statistical details}{
+
+An important assumption for identifying the conditional average treatment effect theta(X)
+is that there exist a fixed positive constant M such that the probability of observing an
+event time past the maximum follow-up time Y.max is at least M (formally, we assume: P(Y
+>= Y.max | X) > M).
+
+This means that the individual censoring probabilities (by default estimated using a
+survival_forest on D' = 1 - D) should not get too low. This function provides a warning
+if these estimates gets below 0.2, if they drop all the way down to below 0.05, we emit a
+stronger warning that you can not expect causal survival forest to deliver reliable
+estimates.
+
+The practical issue is that we can not reliably extrapolate the survival curves
+sufficiently far into the future (where most observations will be censored). A workaround
+is to re-define the estimand as the treatment effect up to some suitable maximum
+follow-up time Y.max. One can do this in practice by thresholding Y before running
+causal_survival_forest: D[Y >= Y.max] = 1 and Y[Y >= Y.max] = Y.max. The online vignette on
+survival data has more details.
+}
+
 \examples{
 \donttest{
 # Train a standard causal survival forest.


### PR DESCRIPTION
`causal_survival_forest` already warns about this identifying issue, but R warnings may be easy to ignore, so here is a suggested explicit section in the docstring to document the matter:

![Screen Shot 2020-11-21 at 19 01 38](https://user-images.githubusercontent.com/7185264/99892727-b7df9b00-2c2c-11eb-8016-eb2c1175ab9a.png)

We have not made an online vignette yet, but it is tracked in #652 and can be completed once the paper is finished. There we can provide a worked example of this + more.

Do you think this wording is OK @yifan-cui @swager?