### PR TITLE
Use consistent symbol for event time in causal survival forest docstring

### DIFF
--- a/r-package/grf/R/causal_survival_forest.R
+++ b/r-package/grf/R/causal_survival_forest.R
@@ -2,9 +2,9 @@
 #'
 #' Trains a causal survival forest that can be used to estimate
 #' conditional average treatment effects tau(X). When the treatment assignment
-#' is unconfounded, we have tau(X) = E[T(1) - T(0) | X = x],
-#' where T is the survival time up to a fixed maximum follow-up time.
-#' T(1) and T(0) are potental outcomes corresponding to the two possible
+#' is unconfounded, we have tau(X) = E[Y(1) - Y(0) | X = x],
+#' where Y is the survival time up to a fixed maximum follow-up time.
+#' Y(1) and Y(0) are potental outcomes corresponding to the two possible
 #' treatment states.
 #'
 #' @param X The covariates.

--- a/r-package/grf/man/causal_survival_forest.Rd
+++ b/r-package/grf/man/causal_survival_forest.Rd
@@ -158,9 +158,9 @@ A trained causal_survival_forest forest object.
 \description{
 Trains a causal survival forest that can be used to estimate
 conditional average treatment effects tau(X). When the treatment assignment
-is unconfounded, we have tau(X) = E[T(1) - T(0) | X = x],
-where T is the survival time up to a fixed maximum follow-up time.
-T(1) and T(0) are potental outcomes corresponding to the two possible
+is unconfounded, we have tau(X) = E[Y(1) - Y(0) | X = x],
+where Y is the survival time up to a fixed maximum follow-up time.
+Y(1) and Y(0) are potental outcomes corresponding to the two possible
 treatment states.
 }
 \examples{


### PR DESCRIPTION
`causal_survival_forest(X, Y, W, D)` takes an event time `Y` but the function docstring was defined in terms of `T`: rename this to `Y`.

(the paper uses `T` for the event time but it seems better for package harmony/consistency to stick with always using `Y` as the response variable argument name, which is also the argument name for `survival_forest`)