### PR TITLE
Add `vcov.type` to `test_calibration/best_linear_projection`

### DIFF
--- a/r-package/grf/R/forest_summary.R
+++ b/r-package/grf/R/forest_summary.R
@@ -15,9 +15,13 @@
 #' @param vcov.type Optional covariance type for standard errors. The possible
 #'  options are HC0, ..., HC3. The default is "HC3", which is recommended in small
 #'  samples and corresponds to the "shortcut formula" for the jackknife
-#'  (see MacKinnon & White for more discussion). For large data sets with clusters,
-#'  "HC0" or "HC1" are significantly faster to compute.
+#'  (see MacKinnon & White for more discussion, and Colin & Miller for a review).
+#'  For large data sets with clusters, "HC0" or "HC1" are significantly faster to compute.
 #' @return A heteroskedasticity-consistent test of calibration.
+#'
+#' @references Cameron, A. Colin, and Douglas L. Miller. "A practitioner's guide to
+#'  cluster-robust inference." Journal of human resources 50, no. 2 (2015): 317-372.
+#'
 #' @references Chernozhukov, Victor, Mert Demirer, Esther Duflo, and Ivan Fernandez-Val.
 #'             "Generic Machine Learning Inference on Heterogenous Treatment Effects in
 #'             Randomized Experiments." arXiv preprint arXiv:1712.04802 (2017).
@@ -123,8 +127,11 @@ test_calibration <- function(forest, vcov.type = "HC3") {
 #' @param vcov.type Optional covariance type for standard errors. The possible
 #'  options are HC0, ..., HC3. The default is "HC3", which is recommended in small
 #'  samples and corresponds to the "shortcut formula" for the jackknife
-#'  (see MacKinnon & White for more discussion). For large data sets with clusters,
-#'  "HC0" or "HC1" are significantly faster to compute.
+#'  (see MacKinnon & White for more discussion, and Colin & Miller for a review).
+#'  For large data sets with clusters, "HC0" or "HC1" are significantly faster to compute.
+#'
+#' @references Cameron, A. Colin, and Douglas L. Miller. "A practitioner's guide to
+#'  cluster-robust inference." Journal of human resources 50, no. 2 (2015): 317-372.
 #'
 #' @references Chernozhukov, Victor, and Vira Semenova. "Simultaneous inference for
 #'             Best Linear Predictor of the Conditional Average Treatment Effect and

--- a/r-package/grf/R/forest_summary.R
+++ b/r-package/grf/R/forest_summary.R
@@ -12,13 +12,19 @@
 #' no heterogeneity.
 #'
 #' @param forest The trained forest.
-#' @param vcov.type Optional covariance type for standard errors. The default is "HC3".
-#'  For large data sets with clusters, "HC0" or "HC1" are significantly faster to compute
-#'  (for details see the `sandwich` package).
+#' @param vcov.type Optional covariance type for standard errors. The possible
+#'  options are HC0, ..., HC3. The default is "HC3", which is recommended in small
+#'  samples and corresponds to the "shortcut formula" for the jackknife
+#'  (see MacKinnon & White for more discussion). For large data sets with clusters,
+#'  "HC0" or "HC1" are significantly faster to compute.
 #' @return A heteroskedasticity-consistent test of calibration.
 #' @references Chernozhukov, Victor, Mert Demirer, Esther Duflo, and Ivan Fernandez-Val.
 #'             "Generic Machine Learning Inference on Heterogenous Treatment Effects in
 #'             Randomized Experiments." arXiv preprint arXiv:1712.04802 (2017).
+#'
+#' @references MacKinnon, James G., and Halbert White. "Some heteroskedasticity-consistent
+#'  covariance matrix estimators with improved finite sample properties."
+#'  Journal of Econometrics 29.3 (1985): 305-325.
 #'
 #' @examples
 #' \donttest{
@@ -114,14 +120,19 @@ test_calibration <- function(forest, vcov.type = "HC3") {
 #'               treatment), we need to train auxiliary forests to learn debiasing weights.
 #'               This is the number of trees used for this task. Note: this argument is only
 #'               used when debiasing.weights = NULL.
-#'
-#' @param vcov.type Optional covariance type for standard errors. The default is "HC3".
-#'  For large data sets with clusters, "HC0" or "HC1" are significantly faster to compute
-#'  (for details see the `sandwich` package).
+#' @param vcov.type Optional covariance type for standard errors. The possible
+#'  options are HC0, ..., HC3. The default is "HC3", which is recommended in small
+#'  samples and corresponds to the "shortcut formula" for the jackknife
+#'  (see MacKinnon & White for more discussion). For large data sets with clusters,
+#'  "HC0" or "HC1" are significantly faster to compute.
 #'
 #' @references Chernozhukov, Victor, and Vira Semenova. "Simultaneous inference for
 #'             Best Linear Predictor of the Conditional Average Treatment Effect and
 #'             other structural functions." arXiv preprint arXiv:1702.06240 (2017).
+#'
+#' @references MacKinnon, James G., and Halbert White. "Some heteroskedasticity-consistent
+#'  covariance matrix estimators with improved finite sample properties."
+#'  Journal of Econometrics 29.3 (1985): 305-325.
 #'
 #' @examples
 #' \donttest{

--- a/r-package/grf/R/forest_summary.R
+++ b/r-package/grf/R/forest_summary.R
@@ -12,6 +12,9 @@
 #' no heterogeneity.
 #'
 #' @param forest The trained forest.
+#' @param vcov.type Optional covariance type for standard errors. The default is "HC3".
+#'  For large data sets with clusters, "HC0" or "HC1" are significantly faster to compute
+#'  (for details see the `sandwich` package).
 #' @return A heteroskedasticity-consistent test of calibration.
 #' @references Chernozhukov, Victor, Mert Demirer, Esther Duflo, and Ivan Fernandez-Val.
 #'             "Generic Machine Learning Inference on Heterogenous Treatment Effects in
@@ -29,7 +32,7 @@
 #' }
 #'
 #' @export
-test_calibration <- function(forest) {
+test_calibration <- function(forest, vcov.type = "HC3") {
   observation.weight <- observation_weights(forest)
   clusters <- if (length(forest$clusters) > 0) {
     forest$clusters
@@ -64,14 +67,14 @@ test_calibration <- function(forest) {
     )
   blp.summary <- lmtest::coeftest(best.linear.predictor,
     vcov = sandwich::vcovCL,
-    type = "HC3",
+    type = vcov.type,
     cluster = clusters
   )
   attr(blp.summary, "method") <-
-    paste("Best linear fit using forest predictions (on held-out data)",
-      "as well as the mean forest prediction as regressors, along",
-      "with one-sided heteroskedasticity-robust (HC3) SEs",
-      sep = "\n"
+    paste0("Best linear fit using forest predictions (on held-out data)\n",
+      "as well as the mean forest prediction as regressors, along\n",
+      "with one-sided heteroskedasticity-robust ",
+      "(", vcov.type, ") SEs"
     )
   # convert to one-sided p-values
   dimnames(blp.summary)[[2]][4] <- gsub("[|]", "", dimnames(blp.summary)[[2]][4])
@@ -112,6 +115,10 @@ test_calibration <- function(forest) {
 #'               This is the number of trees used for this task. Note: this argument is only
 #'               used when debiasing.weights = NULL.
 #'
+#' @param vcov.type Optional covariance type for standard errors. The default is "HC3".
+#'  For large data sets with clusters, "HC0" or "HC1" are significantly faster to compute
+#'  (for details see the `sandwich` package).
+#'
 #' @references Chernozhukov, Victor, and Vira Semenova. "Simultaneous inference for
 #'             Best Linear Predictor of the Conditional Average Treatment Effect and
 #'             other structural functions." arXiv preprint arXiv:1702.06240 (2017).
@@ -134,7 +141,8 @@ best_linear_projection <- function(forest,
                                    A = NULL,
                                    subset = NULL,
                                    debiasing.weights = NULL,
-                                   num.trees.for.weights = 500) {
+                                   num.trees.for.weights = 500,
+                                   vcov.type = "HC3") {
   clusters <- if (length(forest$clusters) > 0) {
     forest$clusters
   } else {
@@ -198,13 +206,13 @@ best_linear_projection <- function(forest,
   blp.ols <- lm(target ~ ., weights = subset.weights, data = DF)
   blp.summary <- lmtest::coeftest(blp.ols,
                                   vcov = sandwich::vcovCL,
-                                  type = "HC3",
+                                  type = vcov.type,
                                   cluster = subset.clusters
   )
   attr(blp.summary, "method") <-
-    paste("Best linear projection of the conditional average treatment effect.",
-          "Confidence intervals are cluster- and heteroskedasticity-robust (HC3)",
-          sep="\n")
+    paste0("Best linear projection of the conditional average treatment effect.\n",
+          "Confidence intervals are cluster- and heteroskedasticity-robust ",
+          "(", vcov.type, ")")
 
   blp.summary
 }

--- a/r-package/grf/R/forest_summary.R
+++ b/r-package/grf/R/forest_summary.R
@@ -15,7 +15,7 @@
 #' @param vcov.type Optional covariance type for standard errors. The possible
 #'  options are HC0, ..., HC3. The default is "HC3", which is recommended in small
 #'  samples and corresponds to the "shortcut formula" for the jackknife
-#'  (see MacKinnon & White for more discussion, and Colin & Miller for a review).
+#'  (see MacKinnon & White for more discussion, and Cameron & Miller for a review).
 #'  For large data sets with clusters, "HC0" or "HC1" are significantly faster to compute.
 #' @return A heteroskedasticity-consistent test of calibration.
 #'
@@ -127,7 +127,7 @@ test_calibration <- function(forest, vcov.type = "HC3") {
 #' @param vcov.type Optional covariance type for standard errors. The possible
 #'  options are HC0, ..., HC3. The default is "HC3", which is recommended in small
 #'  samples and corresponds to the "shortcut formula" for the jackknife
-#'  (see MacKinnon & White for more discussion, and Colin & Miller for a review).
+#'  (see MacKinnon & White for more discussion, and Cameron & Miller for a review).
 #'  For large data sets with clusters, "HC0" or "HC1" are significantly faster to compute.
 #'
 #' @references Cameron, A. Colin, and Douglas L. Miller. "A practitioner's guide to

--- a/r-package/grf/man/best_linear_projection.Rd
+++ b/r-package/grf/man/best_linear_projection.Rd
@@ -37,8 +37,8 @@ used when debiasing.weights = NULL.}
 \item{vcov.type}{Optional covariance type for standard errors. The possible
 options are HC0, ..., HC3. The default is "HC3", which is recommended in small
 samples and corresponds to the "shortcut formula" for the jackknife
-(see MacKinnon & White for more discussion). For large data sets with clusters,
-"HC0" or "HC1" are significantly faster to compute.}
+(see MacKinnon & White for more discussion, and Colin & Miller for a review).
+For large data sets with clusters, "HC0" or "HC1" are significantly faster to compute.}
 }
 \value{
 An estimate of the best linear projection, along with coefficient standard errors.
@@ -71,6 +71,9 @@ best_linear_projection(forest, X[,1:2])
 
 }
 \references{
+Cameron, A. Colin, and Douglas L. Miller. "A practitioner's guide to
+ cluster-robust inference." Journal of human resources 50, no. 2 (2015): 317-372.
+
 Chernozhukov, Victor, and Vira Semenova. "Simultaneous inference for
             Best Linear Predictor of the Conditional Average Treatment Effect and
             other structural functions." arXiv preprint arXiv:1702.06240 (2017).

--- a/r-package/grf/man/best_linear_projection.Rd
+++ b/r-package/grf/man/best_linear_projection.Rd
@@ -34,9 +34,11 @@ treatment), we need to train auxiliary forests to learn debiasing weights.
 This is the number of trees used for this task. Note: this argument is only
 used when debiasing.weights = NULL.}
 
-\item{vcov.type}{Optional covariance type for standard errors. The default is "HC3".
-For large data sets with clusters, "HC0" or "HC1" are significantly faster to compute
-(for details see the `sandwich` package).}
+\item{vcov.type}{Optional covariance type for standard errors. The possible
+options are HC0, ..., HC3. The default is "HC3", which is recommended in small
+samples and corresponds to the "shortcut formula" for the jackknife
+(see MacKinnon & White for more discussion). For large data sets with clusters,
+"HC0" or "HC1" are significantly faster to compute.}
 }
 \value{
 An estimate of the best linear projection, along with coefficient standard errors.
@@ -72,4 +74,8 @@ best_linear_projection(forest, X[,1:2])
 Chernozhukov, Victor, and Vira Semenova. "Simultaneous inference for
             Best Linear Predictor of the Conditional Average Treatment Effect and
             other structural functions." arXiv preprint arXiv:1702.06240 (2017).
+
+MacKinnon, James G., and Halbert White. "Some heteroskedasticity-consistent
+ covariance matrix estimators with improved finite sample properties."
+ Journal of Econometrics 29.3 (1985): 305-325.
 }

--- a/r-package/grf/man/best_linear_projection.Rd
+++ b/r-package/grf/man/best_linear_projection.Rd
@@ -37,7 +37,7 @@ used when debiasing.weights = NULL.}
 \item{vcov.type}{Optional covariance type for standard errors. The possible
 options are HC0, ..., HC3. The default is "HC3", which is recommended in small
 samples and corresponds to the "shortcut formula" for the jackknife
-(see MacKinnon & White for more discussion, and Colin & Miller for a review).
+(see MacKinnon & White for more discussion, and Cameron & Miller for a review).
 For large data sets with clusters, "HC0" or "HC1" are significantly faster to compute.}
 }
 \value{

--- a/r-package/grf/man/best_linear_projection.Rd
+++ b/r-package/grf/man/best_linear_projection.Rd
@@ -10,7 +10,8 @@ best_linear_projection(
   A = NULL,
   subset = NULL,
   debiasing.weights = NULL,
-  num.trees.for.weights = 500
+  num.trees.for.weights = 500,
+  vcov.type = "HC3"
 )
 }
 \arguments{
@@ -32,6 +33,10 @@ are obtained via inverse-propensity weighting.}
 treatment), we need to train auxiliary forests to learn debiasing weights.
 This is the number of trees used for this task. Note: this argument is only
 used when debiasing.weights = NULL.}
+
+\item{vcov.type}{Optional covariance type for standard errors. The default is "HC3".
+For large data sets with clusters, "HC0" or "HC1" are significantly faster to compute
+(for details see the `sandwich` package).}
 }
 \value{
 An estimate of the best linear projection, along with coefficient standard errors.

--- a/r-package/grf/man/test_calibration.Rd
+++ b/r-package/grf/man/test_calibration.Rd
@@ -12,7 +12,7 @@ test_calibration(forest, vcov.type = "HC3")
 \item{vcov.type}{Optional covariance type for standard errors. The possible
 options are HC0, ..., HC3. The default is "HC3", which is recommended in small
 samples and corresponds to the "shortcut formula" for the jackknife
-(see MacKinnon & White for more discussion, and Colin & Miller for a review).
+(see MacKinnon & White for more discussion, and Cameron & Miller for a review).
 For large data sets with clusters, "HC0" or "HC1" are significantly faster to compute.}
 }
 \value{

--- a/r-package/grf/man/test_calibration.Rd
+++ b/r-package/grf/man/test_calibration.Rd
@@ -4,10 +4,14 @@
 \alias{test_calibration}
 \title{Omnibus evaluation of the quality of the random forest estimates via calibration.}
 \usage{
-test_calibration(forest)
+test_calibration(forest, vcov.type = "HC3")
 }
 \arguments{
 \item{forest}{The trained forest.}
+
+\item{vcov.type}{Optional covariance type for standard errors. The default is "HC3".
+For large data sets with clusters, "HC0" or "HC1" are significantly faster to compute
+(for details see the `sandwich` package).}
 }
 \value{
 A heteroskedasticity-consistent test of calibration.

--- a/r-package/grf/man/test_calibration.Rd
+++ b/r-package/grf/man/test_calibration.Rd
@@ -9,9 +9,11 @@ test_calibration(forest, vcov.type = "HC3")
 \arguments{
 \item{forest}{The trained forest.}
 
-\item{vcov.type}{Optional covariance type for standard errors. The default is "HC3".
-For large data sets with clusters, "HC0" or "HC1" are significantly faster to compute
-(for details see the `sandwich` package).}
+\item{vcov.type}{Optional covariance type for standard errors. The possible
+options are HC0, ..., HC3. The default is "HC3", which is recommended in small
+samples and corresponds to the "shortcut formula" for the jackknife
+(see MacKinnon & White for more discussion). For large data sets with clusters,
+"HC0" or "HC1" are significantly faster to compute.}
 }
 \value{
 A heteroskedasticity-consistent test of calibration.
@@ -44,4 +46,8 @@ test_calibration(forest)
 Chernozhukov, Victor, Mert Demirer, Esther Duflo, and Ivan Fernandez-Val.
             "Generic Machine Learning Inference on Heterogenous Treatment Effects in
             Randomized Experiments." arXiv preprint arXiv:1712.04802 (2017).
+
+MacKinnon, James G., and Halbert White. "Some heteroskedasticity-consistent
+ covariance matrix estimators with improved finite sample properties."
+ Journal of Econometrics 29.3 (1985): 305-325.
 }

--- a/r-package/grf/man/test_calibration.Rd
+++ b/r-package/grf/man/test_calibration.Rd
@@ -12,8 +12,8 @@ test_calibration(forest, vcov.type = "HC3")
 \item{vcov.type}{Optional covariance type for standard errors. The possible
 options are HC0, ..., HC3. The default is "HC3", which is recommended in small
 samples and corresponds to the "shortcut formula" for the jackknife
-(see MacKinnon & White for more discussion). For large data sets with clusters,
-"HC0" or "HC1" are significantly faster to compute.}
+(see MacKinnon & White for more discussion, and Colin & Miller for a review).
+For large data sets with clusters, "HC0" or "HC1" are significantly faster to compute.}
 }
 \value{
 A heteroskedasticity-consistent test of calibration.
@@ -43,6 +43,9 @@ test_calibration(forest)
 
 }
 \references{
+Cameron, A. Colin, and Douglas L. Miller. "A practitioner's guide to
+ cluster-robust inference." Journal of human resources 50, no. 2 (2015): 317-372.
+
 Chernozhukov, Victor, Mert Demirer, Esther Duflo, and Ivan Fernandez-Val.
             "Generic Machine Learning Inference on Heterogenous Treatment Effects in
             Randomized Experiments." arXiv preprint arXiv:1712.04802 (2017).


### PR DESCRIPTION
Closes #786. Thanks to @adeldaoud for reporting and @zeileis for the help with `sandwich`.