### PR TITLE
Rename `Data::is_censored` to `is_failure`

### DIFF
--- a/core/src/commons/Data.cpp
+++ b/core/src/commons/Data.cpp
@@ -287,7 +287,7 @@ double Data::get_causal_survival_denominator(size_t row) const {
   return get(row, causal_survival_denominator_index.value());
 }
 
-bool Data::is_censored(size_t row) const {
+bool Data::is_failure(size_t row) const {
   return get(row, censor_index.value()) > 0.0;
 }
 

--- a/core/src/commons/Data.h
+++ b/core/src/commons/Data.h
@@ -103,10 +103,6 @@ public:
 
   double get_causal_survival_denominator(size_t row) const;
 
-  /**
-   *
-   *
-   */
   bool is_failure(size_t row) const;
 
   const std::set<size_t>& get_disallowed_split_variables() const;

--- a/core/src/commons/Data.h
+++ b/core/src/commons/Data.h
@@ -103,7 +103,11 @@ public:
 
   double get_causal_survival_denominator(size_t row) const;
 
-  bool is_censored(size_t row) const;
+  /**
+   *
+   *
+   */
+  bool is_failure(size_t row) const;
 
   const std::set<size_t>& get_disallowed_split_variables() const;
 

--- a/core/src/prediction/SurvivalPredictionStrategy.cpp
+++ b/core/src/prediction/SurvivalPredictionStrategy.cpp
@@ -50,7 +50,7 @@ std::vector<double> SurvivalPredictionStrategy::predict(size_t prediction_sample
     double forest_weight = entry.second;
     size_t failure_time = train_data.get_outcome(sample);
     double sample_weight = train_data.get_weight(sample);
-    if (train_data.is_censored(sample)) {
+    if (train_data.is_failure(sample)) {
      count_failure[failure_time] += forest_weight * sample_weight;
     } else {
      count_censor[failure_time] += forest_weight * sample_weight;

--- a/core/src/splitting/CausalSurvivalSplittingRule.cpp
+++ b/core/src/splitting/CausalSurvivalSplittingRule.cpp
@@ -87,7 +87,7 @@ bool CausalSurvivalSplittingRule::find_best_split(const Data& data,
     sum_node_z += sample_weight * z;
     sum_node_z_squared += sample_weight * z * z;
 
-    if (data.is_censored(sample)) {
+    if (data.is_failure(sample)) {
       num_failures_node++;
     }
   }
@@ -191,7 +191,7 @@ void CausalSurvivalSplittingRule::find_best_split_value(const Data& data,
       if (z < mean_node_z) {
         ++num_small_z_missing;
       }
-      if (data.is_censored(sample)) {
+      if (data.is_failure(sample)) {
         num_failures_missing++;
       }
     } else {
@@ -204,7 +204,7 @@ void CausalSurvivalSplittingRule::find_best_split_value(const Data& data,
       if (z < mean_node_z) {
         ++num_small_z[split_index];
       }
-      if (data.is_censored(sample)) {
+      if (data.is_failure(sample)) {
         ++failure_count[split_index];
       }
     }

--- a/core/src/splitting/SurvivalSplittingRule.cpp
+++ b/core/src/splitting/SurvivalSplittingRule.cpp
@@ -70,7 +70,7 @@ void SurvivalSplittingRule::find_best_split_internal(const Data& data,
   // Get the failure values t1, ..., tm in this node
   std::vector<double> failure_values;
   for (auto& sample : samples) {
-    if (data.is_censored(sample)) {
+    if (data.is_failure(sample)) {
       failure_values.push_back(responses_by_sample(sample));
     }
   }
@@ -109,7 +109,7 @@ void SurvivalSplittingRule::find_best_split_internal(const Data& data,
     size_t new_failure_value = std::upper_bound(failure_values.begin(), failure_values.end(),
                                                 failure_value) - failure_values.begin();
     relabeled_failures[sample] = new_failure_value;
-    if (data.is_censored(sample)) {
+    if (data.is_failure(sample)) {
       ++count_failure[new_failure_value];
     } else {
       ++count_censor[new_failure_value];
@@ -180,7 +180,7 @@ void SurvivalSplittingRule::find_best_split_value(const Data& data,
     size_t sample_time = relabeled_failures[sample];
 
     if (std::isnan(sample_value)) {
-      if (data.is_censored(sample)) {
+      if (data.is_failure(sample)) {
         ++left_count_failure[sample_time];
         ++num_failures_missing;
       } else {
@@ -228,7 +228,7 @@ void SurvivalSplittingRule::find_best_split_value(const Data& data,
       }
 
       if (!split_on_missing) {
-        if (data.is_censored(sample)) {
+        if (data.is_failure(sample)) {
           ++left_count_failure[sample_time];
           ++num_failures_left;
         } else {


### PR DESCRIPTION
This is just an old naming "quirk" left over in the code: we should call this `is_failure` to avoid future confusion (0: censor, 1: failure )