### PR TITLE
Adjust predictions for (variance, mse, mce) in case sample has no neighbors

### DIFF
--- a/core/src/prediction/collector/DefaultPredictionCollector.cpp
+++ b/core/src/prediction/collector/DefaultPredictionCollector.cpp
@@ -97,7 +97,7 @@ std::vector<Prediction> DefaultPredictionCollector::collect_predictions_batch(
     // that this can only occur when honesty is enabled, and is expected to be rare.
     if (weights_by_sample.empty()) {
       std::vector<double> nan(strategy->prediction_length(), NAN);
-      predictions.emplace_back(nan, nan, nan, nan);
+      predictions.emplace_back(nan, nan, std::vector<double>(), std::vector<double>());
       continue;
     }
 

--- a/core/src/prediction/collector/DefaultPredictionCollector.cpp
+++ b/core/src/prediction/collector/DefaultPredictionCollector.cpp
@@ -97,7 +97,8 @@ std::vector<Prediction> DefaultPredictionCollector::collect_predictions_batch(
     // that this can only occur when honesty is enabled, and is expected to be rare.
     if (weights_by_sample.empty()) {
       std::vector<double> nan(strategy->prediction_length(), NAN);
-      predictions.emplace_back(nan, nan, std::vector<double>(), std::vector<double>());
+      std::vector<double> empty;
+      predictions.emplace_back(nan, estimate_variance ? nan : empty, empty, empty);
       continue;
     }
 

--- a/core/src/prediction/collector/OptimizedPredictionCollector.cpp
+++ b/core/src/prediction/collector/OptimizedPredictionCollector.cpp
@@ -119,7 +119,8 @@ std::vector<Prediction> OptimizedPredictionCollector::collect_predictions_batch(
     // that this can only occur when honesty is enabled, and is expected to be rare.
     if (num_leaves == 0) {
       std::vector<double> nan(strategy->prediction_length(), NAN);
-      predictions.emplace_back(nan, nan, nan, nan);
+      std::vector<double> nan_error(1, NAN);
+      predictions.emplace_back(nan, nan, nan_error, nan_error);
       continue;
     }
 

--- a/core/src/prediction/collector/OptimizedPredictionCollector.cpp
+++ b/core/src/prediction/collector/OptimizedPredictionCollector.cpp
@@ -120,7 +120,7 @@ std::vector<Prediction> OptimizedPredictionCollector::collect_predictions_batch(
     if (num_leaves == 0) {
       std::vector<double> nan(strategy->prediction_length(), NAN);
       std::vector<double> nan_error(1, NAN);
-      predictions.emplace_back(nan, nan, nan_error, nan_error);
+      predictions.emplace_back(nan, estimate_variance ? nan : std::vector<double>(), nan_error, nan_error);
       continue;
     }
 


### PR DESCRIPTION
In case a sample as no neighbors `nan` placeholder predictions are returned, but these have the wrong dimensions for the last entries: `mse` and `mse` which should be two scalars. This simple PR updates these two entries.

After the recent https://github.com/grf-labs/grf/commit/46107bad75fede7ac87f681f11f88360d607d3bb#diff-3d3021388b0bbfacea7179beb0f48fcc4cc0d818bf979cdb8a5dc520cb4d8b20L181 the effect of this may be sinister and segfault because of differently-sized entries.

Before that commit, it would still be "awkward": if you run 

```R
n <- 50
p <- 10
X <- matrix(rnorm(n * p), n, p)
X.test <- matrix(0, 101, p)
X.test[, 1] <- seq(-2, 2, length.out = 101)
Y <- X[, 1] * rnorm(n)
qf <- quantile_forest(X, Y, quantiles = c(0.1, 0.5, 0.9), compute.oob.predictions = TRUE, num.trees = 2)
qf$debiased.error
```

a couple of times, the `qf$debiased.error` will either be an empty matrix, or a nX3 matrix with 0/NaNs, depending on whether the first sample had no neighbors or not.
