### PR TITLE
Add column names to multi_regression predictions

### DIFF
--- a/r-package/grf/R/multi_regression_forest.R
+++ b/r-package/grf/R/multi_regression_forest.R
@@ -4,7 +4,7 @@
 #' the conditional mean functions mu_i(x) = E[Y_i | X = x]
 #'
 #' @param X The covariates used in the regression.
-#' @param Y The outcomes.
+#' @param Y The outcomes (must be a numeric vector/matrix with no NAs).
 #' @param num.trees Number of trees grown in the forest. Note: Getting accurate
 #'                  confidence intervals generally requires more trees than
 #'                  getting accurate predictions. Default is 2000.

--- a/r-package/grf/R/multi_regression_forest.R
+++ b/r-package/grf/R/multi_regression_forest.R
@@ -167,7 +167,7 @@ predict.multi_regression_forest <- function(object,
   }
   # If possible, use pre-computed predictions.
   if (is.null(newdata) && !is.null(object$predictions)) {
-      colnames(object$predictions) <- outcome.names
+    colnames(object$predictions) <- outcome.names
     return(list(predictions = object$predictions))
   }
 

--- a/r-package/grf/R/multi_regression_forest.R
+++ b/r-package/grf/R/multi_regression_forest.R
@@ -160,8 +160,14 @@ predict.multi_regression_forest <- function(object,
                                             newdata = NULL,
                                             num.threads = NULL,
                                             ...) {
+  outcome.names <- if (is.null(colnames(object[["Y.orig"]]))) {
+    paste0("Y", 1:NCOL(object[["Y.orig"]]))
+  } else {
+    colnames(object[["Y.orig"]])
+  }
   # If possible, use pre-computed predictions.
   if (is.null(newdata) && !is.null(object$predictions)) {
+      colnames(object$predictions) <- outcome.names
     return(list(predictions = object$predictions))
   }
 
@@ -181,6 +187,7 @@ predict.multi_regression_forest <- function(object,
   } else {
     ret <- do.call.rcpp(multi_regression_predict_oob, c(train.data, args))
   }
+  colnames(ret$predictions) <- outcome.names
 
   list(predictions = ret$predictions)
 }

--- a/r-package/grf/man/multi_regression_forest.Rd
+++ b/r-package/grf/man/multi_regression_forest.Rd
@@ -27,7 +27,7 @@ multi_regression_forest(
 \arguments{
 \item{X}{The covariates used in the regression.}
 
-\item{Y}{The outcomes.}
+\item{Y}{The outcomes (must be a numeric vector/matrix with no NAs).}
 
 \item{num.trees}{Number of trees grown in the forest. Note: Getting accurate
 confidence intervals generally requires more trees than


### PR DESCRIPTION
This is just a minor convenience for consistency with other forests like `probability_forest`.
```
> mr.forest <- multi_regression_forest(X, Y)
> head(predict(mr.forest)$predictions)
               A         ABC
[1,] -0.81207945 -1.43273219
[2,] -0.04327326  0.06094848
[3,]  0.04231994  0.09658590
[4,]  0.10632419  0.18724158
[5,]  0.77469128  1.79975894
[6,] -0.56629942 -1.08416170
```