### PR TITLE
Allow data.frame in validate_observations

### DIFF
--- a/r-package/grf/R/input_utilities.R
+++ b/r-package/grf/R/input_utilities.R
@@ -37,6 +37,12 @@ validate_observations <- function(V, X, allow.matrix = FALSE) {
     } else if (!is.vector(V)) {
       stop(paste("Observations (W, Y, Z or D) must be vectors."))
     }
+  } else {
+    if (is.matrix(V) || is.data.frame(V) || is.vector(V)) {
+      V <- as.matrix(V)
+    } else {
+      stop("Observations Y must be either a vector/matrix/data.frame.")
+    }
   }
 
   if (!is.numeric(V) && !is.logical(V)) {

--- a/r-package/grf/R/input_utilities.R
+++ b/r-package/grf/R/input_utilities.R
@@ -35,7 +35,7 @@ validate_observations <- function(V, X, allow.matrix = FALSE) {
     if (is.matrix(V) && ncol(V) == 1) {
       V <- as.vector(V)
     } else if (!is.vector(V)) {
-      stop(paste("Observations (W, Y, Z or D) must be vectors."))
+      stop("Observations (W, Y, Z or D) must be vectors.")
     }
   } else {
     if (is.matrix(V) || is.data.frame(V) || is.vector(V)) {


### PR DESCRIPTION
`multi_regression_forest(X, Y)` allows:

X: matrix, data.frame, sparse matrix
Y: matrix/vector

Update `validate_observations` to be consistent and accept data.frame as well.