### PR TITLE
Remove `@examples` from internal function

### DIFF
--- a/r-package/grf/R/tune_local_linear_causal_forest.R
+++ b/r-package/grf/R/tune_local_linear_causal_forest.R
@@ -12,23 +12,6 @@
 #' @param lambda.path Optional list of lambdas to use for cross-validation.
 #' @return A list of lambdas tried, corresponding errors, and optimal ridge penalty lambda.
 #'
-#' @examples
-#' \donttest{
-#' # Find the optimal tuning parameters.
-#' n <- 50
-#' p <- 10
-#' X <- matrix(rnorm(n * p), n, p)
-#' W <- rbinom(n, 1, 0.5)
-#' Y <- pmax(X[, 1], 0) * W + X[, 2] + pmin(X[, 3], 0) + rnorm(n)
-#'
-#' forest <- causal_forest(X, Y, W)
-#' tuned.lambda <- tune_ll_causal_forest(forest)
-#'
-#' # Use this parameter to predict from a local linear causal forest.
-#' predictions <- predict(forest, linear.correction.variables = 1:p,
-#'                        ll.lambda = tuned.lambda$lambda.min)
-#' }
-#'
 #' @keywords internal
 tune_ll_causal_forest <- function(forest,
                                   linear.correction.variables = NULL,

--- a/r-package/grf/R/tune_local_linear_forest.R
+++ b/r-package/grf/R/tune_local_linear_forest.R
@@ -12,21 +12,6 @@
 #' @param lambda.path Optional list of lambdas to use for cross-validation.
 #' @return A list of lambdas tried, corresponding errors, and optimal ridge penalty lambda.
 #'
-#' @examples
-#' \donttest{
-#' # Find the optimal tuning parameters.
-#' n <- 500
-#' p <- 10
-#' X <- matrix(rnorm(n * p), n, p)
-#' Y <- X[, 1] * rnorm(n)
-#' forest <- regression_forest(X, Y)
-#' tuned.lambda <- tune_ll_regression_forest(forest)
-#'
-#' # Use this parameter to predict from a local linear forest.
-#' predictions <- predict(forest, linear.correction.variables = 1:p,
-#'                        ll.lambda = tuned.lambda$lambda.min)
-#' }
-#'
 #' @keywords internal
 tune_ll_regression_forest <- function(forest,
                                       linear.correction.variables = NULL,

--- a/r-package/grf/man/tune_ll_causal_forest.Rd
+++ b/r-package/grf/man/tune_ll_causal_forest.Rd
@@ -32,22 +32,4 @@ A list of lambdas tried, corresponding errors, and optimal ridge penalty lambda.
 \description{
 Finds the optimal ridge penalty for local linear causal prediction.
 }
-\examples{
-\donttest{
-# Find the optimal tuning parameters.
-n <- 50
-p <- 10
-X <- matrix(rnorm(n * p), n, p)
-W <- rbinom(n, 1, 0.5)
-Y <- pmax(X[, 1], 0) * W + X[, 2] + pmin(X[, 3], 0) + rnorm(n)
-
-forest <- causal_forest(X, Y, W)
-tuned.lambda <- tune_ll_causal_forest(forest)
-
-# Use this parameter to predict from a local linear causal forest.
-predictions <- predict(forest, linear.correction.variables = 1:p,
-                       ll.lambda = tuned.lambda$lambda.min)
-}
-
-}
 \keyword{internal}

--- a/r-package/grf/man/tune_ll_regression_forest.Rd
+++ b/r-package/grf/man/tune_ll_regression_forest.Rd
@@ -32,20 +32,4 @@ A list of lambdas tried, corresponding errors, and optimal ridge penalty lambda.
 \description{
 Finds the optimal ridge penalty for local linear prediction.
 }
-\examples{
-\donttest{
-# Find the optimal tuning parameters.
-n <- 500
-p <- 10
-X <- matrix(rnorm(n * p), n, p)
-Y <- X[, 1] * rnorm(n)
-forest <- regression_forest(X, Y)
-tuned.lambda <- tune_ll_regression_forest(forest)
-
-# Use this parameter to predict from a local linear forest.
-predictions <- predict(forest, linear.correction.variables = 1:p,
-                       ll.lambda = tuned.lambda$lambda.min)
-}
-
-}
 \keyword{internal}


### PR DESCRIPTION
These functions are not exported anymore so running R CMD check with "-run-dontest" will cause an error since the function is not found.