### PR TITLE
Add `-run-donttest` to Rstudio build config

### DIFF
--- a/r-package/grf/grf.Rproj
+++ b/r-package/grf/grf.Rproj
@@ -18,4 +18,5 @@ StripTrailingWhitespace: Yes
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
+PackageCheckArgs: --run-donttest
 PackageRoxygenize: rd,collate,namespace


### PR DESCRIPTION
Depending on R version this is not always performed when running the package check from the IDE.