### PR TITLE
Do `--run-donttest` on CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ jobs:
   - name: _R_CHECK_FORCE_SUGGESTS_
     value: false
   - name: _R_CHECK_DONTTEST_EXAMPLES_
-    value: false
+    value: true
   - name: USE_BSPM
     value: true
   - name: WARNINGS_ARE_ERRORS


### PR DESCRIPTION
With this flag all docstring `@examples` are run on a PR build - but it adds ~3 more minutes to the build time. Do you think it is worth having this done on every PR @jtibshirani @halflearned?