### PR TITLE
Add sample weights to ProbabilitySplittingRule

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -165,3 +165,7 @@ for each i=1:n
 A label of 0 is given to all samples with response less than the first failure time, a value of 1 is given to all samples with failure value greater or equal to the first failure value and less than the second failure value, etc.
 
 The algorithm proceeds in the same manner as outlined above for RegressionSplitting: iterate over all possible splits and calculate the logrank statistic, one with all missing values on the left, and one with all missing on the right. Then select the split that yielded the maximum logrank test, subject to a constraint that there are a sufficient amount of failures on both sides of the split.
+
+---
+
+***Algorithm*** (`ProbabilitySplittingRule`): This splitting rule uses the Gini impurity measure from CART for categorical data. Sample weights are incorporated by counting the sample weight of an observation when forming class counts. The missing values adjustment is the same as for the other splitting rules.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -282,7 +282,7 @@ When the distribution of data that you observe is not representative of the popu
 
 The impact these weights have depends on what we are estimating. When our estimand is a function of x, e.g. `r(x) = E[Y | X=x]` in `regression_forest` or `tau(x)=E[Y(1)-Y(0)| X=x]` in `causal_forest`, passing weights that are a function of x does not change our estimand. It instead prioritizes fit on our population of interest. In `regression_forest`, this means minimizing weighted mean squared error, i.e. mean squared error over the population specified by the sample weights. In `causal_forest`, this means minimizing weighted R-loss (Nie and Wager (2020), Equations 1/2). When our estimand is an average of such a function, as in `average_treatment_effect` and `average_partial_effect`, it does change the estimand. Our estimand will be the average treatment/partial effect over the population specified by our sample weights.
 
-Currently the following forest types takes `sample.weights` into account during splitting and prediction: `regression_forest`, `causal_forest`, `instrumental_forest`, `causal_survival_forest`, `ll_regression_forest`. The following forests only takes `sample.weights` into account during prediction: `probability_forest`, `survival_forest`.
+Currently most forest types takes `sample.weights` into account during splitting and prediction. The exception is `quantile_forest` where sample weighting is not a feature, `survival_forest` which only takes `sample.weights` into account during prediction (due to properties of the log-rank splitting criterion not being "amendable" to sample weights), and `causal_forest` with local linear (`ll_causal)` predictions, which does not take the weights into account during prediction.
 
 ### Categorical inputs
 

--- a/core/src/splitting/ProbabilitySplittingRule.cpp
+++ b/core/src/splitting/ProbabilitySplittingRule.cpp
@@ -32,7 +32,7 @@ ProbabilitySplittingRule::ProbabilitySplittingRule(size_t max_num_unique_values,
   this->imbalance_penalty = imbalance_penalty;
 
   this->counter = new size_t[max_num_unique_values];
-  this->counter_per_class = new size_t[num_classes * max_num_unique_values];
+  this->counter_per_class = new double[num_classes * max_num_unique_values];
 }
 
 ProbabilitySplittingRule::~ProbabilitySplittingRule() {
@@ -55,11 +55,12 @@ bool ProbabilitySplittingRule::find_best_split(const Data& data,
   size_t size_node = samples[node].size();
   size_t min_child_size = std::max<size_t>(std::ceil(size_node * alpha), 1uL);
 
-  size_t* class_counts = new size_t[num_classes]();
+  double* class_counts = new double[num_classes]();
   for (size_t i = 0; i < size_node; ++i) {
     size_t sample = samples[node][i];
     uint sample_class = (uint) std::round(responses_by_sample(sample));
-    ++class_counts[sample_class];
+    double sample_weight = data.get_weight(sample);
+    class_counts[sample_class] += sample_weight;
   }
 
   // Initialize the variables to track the best split variable.
@@ -92,7 +93,7 @@ bool ProbabilitySplittingRule::find_best_split(const Data& data,
 void ProbabilitySplittingRule::find_best_split_value(const Data& data,
                                                      size_t node, size_t var,
                                                      size_t num_classes,
-                                                     size_t* class_counts,
+                                                     double* class_counts,
                                                      size_t size_node,
                                                      size_t min_child_size,
                                                      double& best_value,
@@ -116,7 +117,7 @@ void ProbabilitySplittingRule::find_best_split_value(const Data& data,
   std::fill(counter_per_class, counter_per_class + num_splits * num_classes, 0);
   std::fill(counter, counter + num_splits, 0);
   size_t n_missing = 0;
-  size_t* class_counts_missing = new size_t[num_classes]();
+  double* class_counts_missing = new double[num_classes]();
 
   size_t split_index = 0;
   for (size_t i = 0; i < size_node - 1; i++) {
@@ -124,13 +125,15 @@ void ProbabilitySplittingRule::find_best_split_value(const Data& data,
     size_t next_sample = sorted_samples[i + 1];
     double sample_value = data.get(sample, var);
     uint sample_class = responses_by_sample(sample);
+    double sample_weight = data.get_weight(sample);
 
     if (std::isnan(sample_value)) {
-      ++class_counts_missing[sample_class];
+      class_counts_missing[sample_class] += sample_weight;
       ++n_missing;
     } else {
       ++counter[split_index];
-      ++counter_per_class[split_index * num_classes + sample_class];
+      // ++counter_per_class[split_index * num_classes + sample_class];
+      counter_per_class[split_index * num_classes + sample_class] += sample_weight;
     }
 
     double next_sample_value = data.get(next_sample, var);
@@ -142,7 +145,7 @@ void ProbabilitySplittingRule::find_best_split_value(const Data& data,
   }
 
   size_t n_left = n_missing;
-  size_t* class_counts_left = class_counts_missing;
+  double* class_counts_left = class_counts_missing;
 
   // Compute decrease of impurity for each possible split
   for (bool send_left : {true, false}) {
@@ -178,7 +181,7 @@ void ProbabilitySplittingRule::find_best_split_value(const Data& data,
       double sum_right = 0;
       for (size_t cls = 0; cls < num_classes; ++cls) {
         class_counts_left[cls] += counter_per_class[i * num_classes + cls];
-        size_t class_count_right = class_counts[cls] - class_counts_left[cls];
+        double class_count_right = class_counts[cls] - class_counts_left[cls];
 
         sum_left += class_counts_left[cls] * class_counts_left[cls];
         sum_right += class_count_right * class_count_right;

--- a/core/src/splitting/ProbabilitySplittingRule.cpp
+++ b/core/src/splitting/ProbabilitySplittingRule.cpp
@@ -132,7 +132,6 @@ void ProbabilitySplittingRule::find_best_split_value(const Data& data,
       ++n_missing;
     } else {
       ++counter[split_index];
-      // ++counter_per_class[split_index * num_classes + sample_class];
       counter_per_class[split_index * num_classes + sample_class] += sample_weight;
     }
 

--- a/core/src/splitting/ProbabilitySplittingRule.cpp
+++ b/core/src/splitting/ProbabilitySplittingRule.cpp
@@ -111,7 +111,6 @@ void ProbabilitySplittingRule::find_best_split_value(const Data& data,
     return;
   }
 
-  // Initialize with 0, if not in memory efficient mode, use pre-allocated space
   size_t num_splits = possible_split_values.size() - 1;
 
   std::fill(counter_per_class, counter_per_class + num_splits * num_classes, 0);

--- a/core/src/splitting/ProbabilitySplittingRule.h
+++ b/core/src/splitting/ProbabilitySplittingRule.h
@@ -45,7 +45,7 @@ public:
 
 private:
   void find_best_split_value(const Data& data,
-                             size_t node, size_t var, size_t num_classes, size_t* class_counts,
+                             size_t node, size_t var, size_t num_classes, double* class_counts,
                              size_t size_node,
                              size_t min_child_size,
                              double& best_value,
@@ -61,7 +61,7 @@ private:
   double imbalance_penalty;
 
   size_t* counter;
-  size_t* counter_per_class;
+  double* counter_per_class;
 
   DISALLOW_COPY_AND_ASSIGN(ProbabilitySplittingRule);
 };

--- a/r-package/grf/tests/testthat/test_probability_forest.R
+++ b/r-package/grf/tests/testthat/test_probability_forest.R
@@ -83,3 +83,22 @@ test_that("sample weighted probability forest is invariant to scaling", {
 
   expect_true(all(v1$variance.estimates - v2$variance.estimates == 0))
 })
+
+test_that("sample weighted probability forest improves complete-data MSE", {
+  n <- 500
+  p <- 5
+  X <- matrix(rnorm(n * p), n, p)
+  e <- 1 / (1 + exp(-X[, 1]))
+  Y <- as.factor(rbinom(n, 1, e))
+  cc <- runif(n) < e
+  sample.weights <- 1 / e[cc]
+  pp.true <- cbind(1 - e, e)
+
+  pf <- probability_forest(X[cc, ], Y[cc], num.trees = 500)
+  pf.weighted <- probability_forest(X[cc, ], Y[cc], sample.weights = sample.weights, num.trees = 500)
+
+  mse <- mean((predict(pf, X)$predictions - pp.true)^2)
+  mse.weighted <- mean((predict(pf.weighted, X)$predictions - pp.true)^2)
+
+  expect_lt(mse.weighted / mse, 0.9)
+})


### PR DESCRIPTION
Modify the Gini impurity measure used in splitting to count the sample_weight of sample j instead of just sample j. In the code this amounts to adjusting `class_counts` by the sample weight of each sample.

With this addition sample weighting in GRF is implemented "consistently" in the sense that the Split/Predict columns in the following table of sample weight support is either Yes/Yes or No/No for a given forest (except local linear)

| Forest                                                                  	| Relabeling                      	| Splitting 	| Predict 	| SplittingClass               	| PredictionClass                   	|
|-------------------------------------------------------------------------	|---------------------------------	|-----------	|---------	|------------------------------	|-----------------------------------	|
| regression_forest                                                       	| -                               	| Yes       	| Yes     	| RegressionSplittingRule      	| RegressionPredictionStrategy      	|
| multi_regression_forest                                                 	| -                               	| Yes       	| Yes     	| MultiRegressionSplittingRule 	| MultiRegressionPredictionStrategy 	|
| quantile_forest                                                         	| -                               	| No        	| No      	| ProbabilitySplittingRule     	| QuantilePredictionStrategy        	|
| probability_forest                                                      	| -                               	| Yes       	| Yes     	| ProbabilitySplittingRule     	| ProbabilityPredictionStrategy     	|
| causal_forest                                                           	| Yes                             	| Yes       	| Yes     	| InstrumentalSplittingRule    	| InstrumentalPredictionStrategy    	|
| instrumental_forest                                                     	| Yes                             	| Yes       	| Yes     	| InstrumentalSplittingRule    	| InstrumentalPredictionStrategy    	|
| multi_arm_causal_forest                                                 	| Yes                             	| Yes       	| Yes     	| MultiRegressionSplittingRule 	| MultiCausalPredictionStrategy     	|
| survival_forest (weighted splitting not sensible for logrank statistic) 	| -                               	| No        	| Yes     	| SurvivalSplittingRule        	| SurvivalPredictionStrategy        	|
| causal_survival_forest                                                  	| No (to revisit with @yifan-cui) 	| Yes       	| Yes     	| CausalSurvivalSplittingRule  	| CausalSurvivalPredictionStrategy  	|
| ll_regression_forest                                                    	| No                              	| Yes       	| Yes     	| RegressionSplittingRule      	| RegressionSplittingRule           	|
| causal_forest with ll_causal_predict                                    	| Yes                             	| Yes       	| No      	| InstrumentalSplittingRule    	| LLCausalPredictionStrategy        	|