### PR TITLE
Add causal survival forest support to `average_treatment_effect`

### DIFF
--- a/r-package/grf/R/average_treatment_effect.R
+++ b/r-package/grf/R/average_treatment_effect.R
@@ -203,7 +203,8 @@ average_treatment_effect <- function(forest,
     # This is the most general workflow, that shares codepaths with best linear projection
     # and other average effect estimators.
 
-    if (any(c("causal_forest", "instrumental_forest", "multi_arm_causal_forest") %in% class(forest))) {
+    if (any(c("causal_forest", "instrumental_forest", "multi_arm_causal_forest", "causal_survival_forest")
+            %in% class(forest))) {
       DR.scores <- get_scores(forest, subset = subset, debiasing.weights = debiasing.weights,
                               compliance.score = compliance.score, num.trees.for.weights = num.trees.for.weights,
                               outcome = outcome)

--- a/r-package/grf/R/causal_survival_forest.R
+++ b/r-package/grf/R/causal_survival_forest.R
@@ -159,6 +159,9 @@
 #' lines(X.test[, 1], cs.pred$predictions + 2 * sqrt(cs.pred$variance.estimates), lty = 2)
 #' lines(X.test[, 1], cs.pred$predictions - 2 * sqrt(cs.pred$variance.estimates), lty = 2)
 #'
+#' # Compute a doubly robust estimate of the average treatment effect.
+#' average_treatment_effect(cs.forest)
+#'
 #' # Compute the best linear projection on the first covariate.
 #' best_linear_projection(cs.forest, X[, 1])
 #'
@@ -440,6 +443,9 @@ causal_survival_forest <- function(X, Y, W, D,
 #' points(X.test[, 1], cs.pred$predictions)
 #' lines(X.test[, 1], cs.pred$predictions + 2 * sqrt(cs.pred$variance.estimates), lty = 2)
 #' lines(X.test[, 1], cs.pred$predictions - 2 * sqrt(cs.pred$variance.estimates), lty = 2)
+#'
+#' # Compute a doubly robust estimate of the average treatment effect.
+#' average_treatment_effect(cs.forest)
 #'
 #' # Compute the best linear projection on the first covariate.
 #' best_linear_projection(cs.forest, X[, 1])

--- a/r-package/grf/R/get_scores.R
+++ b/r-package/grf/R/get_scores.R
@@ -253,7 +253,7 @@ get_scores.multi_arm_causal_forest <- function(forest,
     max <- apply(W.hat, 2, max)
     warning(paste0(
       "Estimated treatment propensities take values very close to 0 or 1",
-      " meaning estimates may not be well identified.",
+      " meaning some estimates may not be well identified.",
       " In particular, the minimum propensity estimates for each arm is ",
       paste0(treatment.names, ": ", round(min, 3), collapse = " "),
       " and the maximum is ",
@@ -293,6 +293,16 @@ get_scores.causal_survival_forest <- function(forest,
                                               subset = NULL,
                                               ...) {
   subset <- validate_subset(forest, subset)
+
+  if (min(forest$W.hat[subset]) <= 0.05 || max(forest$W.hat[subset]) >= 0.95) {
+    rng <- range(forest$W.hat[subset])
+    warning(paste0(
+      "Estimated treatment propensities take values very close to 0 or 1.",
+      " The estimated propensities are between ",
+      round(rng[1], 3), " and ", round(rng[2], 3),
+      ", meaning some estimates may not be well identified."
+    ))
+  }
 
   eta <- forest$eta
   numerator.one <- eta$numerator.one[subset]

--- a/r-package/grf/R/get_scores.R
+++ b/r-package/grf/R/get_scores.R
@@ -276,7 +276,9 @@ get_scores.multi_arm_causal_forest <- function(forest,
   out
 }
 
-#' Compute doubly robust for a causal survival forest.
+#' Compute doubly robust scores for a causal survival forest.
+#'
+#' For details see section 3.2 and equation (20) in the causal survival forest paper.
 #'
 #' @param forest A trained causal survival forest.
 #' @param subset Specifies subset of the training examples over which we

--- a/r-package/grf/man/causal_survival_forest.Rd
+++ b/r-package/grf/man/causal_survival_forest.Rd
@@ -230,6 +230,9 @@ points(X.test[, 1], cs.pred$predictions)
 lines(X.test[, 1], cs.pred$predictions + 2 * sqrt(cs.pred$variance.estimates), lty = 2)
 lines(X.test[, 1], cs.pred$predictions - 2 * sqrt(cs.pred$variance.estimates), lty = 2)
 
+# Compute a doubly robust estimate of the average treatment effect.
+average_treatment_effect(cs.forest)
+
 # Compute the best linear projection on the first covariate.
 best_linear_projection(cs.forest, X[, 1])
 

--- a/r-package/grf/man/get_scores.causal_survival_forest.Rd
+++ b/r-package/grf/man/get_scores.causal_survival_forest.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/get_scores.R
 \name{get_scores.causal_survival_forest}
 \alias{get_scores.causal_survival_forest}
-\title{Compute doubly robust for a causal survival forest.}
+\title{Compute doubly robust scores for a causal survival forest.}
 \usage{
 \method{get_scores}{causal_survival_forest}(forest, subset = NULL, ...)
 }
@@ -17,5 +17,5 @@ the treatment Wi or the outcome Yi.}
 \item{...}{Additional arguments (currently ignored).}
 }
 \description{
-Compute doubly robust for a causal survival forest.
+For details see section 3.2 and equation (20) in the causal survival forest paper.
 }

--- a/r-package/grf/man/predict.causal_survival_forest.Rd
+++ b/r-package/grf/man/predict.causal_survival_forest.Rd
@@ -66,6 +66,9 @@ points(X.test[, 1], cs.pred$predictions)
 lines(X.test[, 1], cs.pred$predictions + 2 * sqrt(cs.pred$variance.estimates), lty = 2)
 lines(X.test[, 1], cs.pred$predictions - 2 * sqrt(cs.pred$variance.estimates), lty = 2)
 
+# Compute a doubly robust estimate of the average treatment effect.
+average_treatment_effect(cs.forest)
+
 # Compute the best linear projection on the first covariate.
 best_linear_projection(cs.forest, X[, 1])
 

--- a/r-package/grf/tests/testthat/test_causal_survival_forest.R
+++ b/r-package/grf/tests/testthat/test_causal_survival_forest.R
@@ -204,11 +204,11 @@ test_that("causal survival forest summary functions works as expected", {
   blp.subset <- best_linear_projection(cs.forest, subset = X[, 1] > 0.5)
   ate.subset <- average_treatment_effect(cs.forest, subset = X[, 1] > 0.5)
 
-  expect_equal(coef(blp), ate[["estimate"]])
+  expect_equal(blp[1], ate[["estimate"]])
   expect_equal(blp[2], ate[["std.err"]], tol = 1e-4)
   expect_equal(ate[["estimate"]], mean(tau), tol = 3 * ate[["std.err"]])
 
-  expect_equal(coef(blp.subset), ate.subset[["estimate"]])
+  expect_equal(blp.subset[1], ate.subset[["estimate"]])
   expect_equal(blp.subset[2], ate.subset[["std.err"]], tol = 1e-4)
   expect_equal(ate.subset[["estimate"]], mean(tau[X[, 1] > 0.5]), tol = 3 * ate.subset[["std.err"]])
 })

--- a/r-package/grf/tests/testthat/test_causal_survival_forest.R
+++ b/r-package/grf/tests/testthat/test_causal_survival_forest.R
@@ -187,3 +187,28 @@ test_that("causal survival forest has not changed ", {
   expect_equal(predict(cs.forest.grid)$predictions, expected.predictions.oob.grid)
   expect_equal(predict(cs.forest.grid, round(data$X, 2))$predictions, expected.predictions.grid)
 })
+
+test_that("causal survival forest summary functions works as expected", {
+  n <- 500
+  p <- 5
+  data <- generate_survival_data(n, p, Y.max = 1, dgp = "simple1")
+  X <- data$X
+  W <- data$W
+  Y <- data$Y
+  D <- data$D
+  tau <- data$cate
+  cs.forest <- causal_survival_forest(X, Y, W, D, num.trees = 500)
+
+  blp <- best_linear_projection(cs.forest)
+  ate <- average_treatment_effect(cs.forest)
+  blp.subset <- best_linear_projection(cs.forest, subset = X[, 1] > 0.5)
+  ate.subset <- average_treatment_effect(cs.forest, subset = X[, 1] > 0.5)
+
+  expect_equal(coef(blp), ate[["estimate"]])
+  expect_equal(blp[2], ate[["std.err"]], tol = 1e-4)
+  expect_equal(ate[["estimate"]], mean(tau), tol = 3 * ate[["std.err"]])
+
+  expect_equal(coef(blp.subset), ate.subset[["estimate"]])
+  expect_equal(blp.subset[2], ate.subset[["std.err"]], tol = 1e-4)
+  expect_equal(ate.subset[["estimate"]], mean(tau[X[, 1] > 0.5]), tol = 3 * ate.subset[["std.err"]])
+})


### PR DESCRIPTION
Finishes the summary function integration in #652.