### PR TITLE
Use Ubuntu 18.04 on Azure CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ trigger:
 - master
 
 pool:
-  vmImage: "ubuntu-latest"
+  vmImage: "ubuntu-18.04"
 
 jobs:
 - job: coreCPP


### PR DESCRIPTION
The only CI appears to be a bit flaky as the latest version of Ubuntu is rolling out. Try and peg the image version at the previous Ubuntu for now.