### PR TITLE
Fix broadcasting error in multi_arm_causal_forest ATE se

### DIFF
--- a/r-package/grf/R/average_treatment_effect.R
+++ b/r-package/grf/R/average_treatment_effect.R
@@ -217,7 +217,7 @@ average_treatment_effect <- function(forest,
       correction.clust <- Matrix::sparse.model.matrix(
         ~ factor(subset.clusters) + 0,
         transpose = TRUE
-      ) %*% ((DR.scores - tau.hat) * subset.weights)
+      ) %*% (sweep(DR.scores, 2, tau.hat, "-") * subset.weights)
       sigma2.hat <- Matrix::colSums(correction.clust^2) / sum(subset.weights)^2 *
         nrow(correction.clust) / (nrow(correction.clust) - 1)
       return(cbind(estimate = tau.hat, std.err = sqrt(sigma2.hat)))


### PR DESCRIPTION
`matrix - vector` does not do what was intended here. Net effect was very small, added test would only fail at 1e-3 tolerance.