### PR TITLE
Use `NROW(forest$Y.orig)` instead of `length(forest$Y.orig)`

### DIFF
--- a/r-package/grf/R/average_treatment_effect.R
+++ b/r-package/grf/R/average_treatment_effect.R
@@ -146,7 +146,7 @@ average_treatment_effect <- function(forest,
   clusters <- if (cluster.se) {
     forest$clusters
   } else {
-    1:length(forest$Y.orig)
+    1:NROW(forest$Y.orig)
   }
   observation.weight <- observation_weights(forest)
 
@@ -159,7 +159,7 @@ average_treatment_effect <- function(forest,
   }
 
   if (!is.null(debiasing.weights)) {
-    if (length(debiasing.weights) == length(forest$Y.orig)) {
+    if (length(debiasing.weights) == NROW(forest$Y.orig)) {
       debiasing.weights <- debiasing.weights[subset]
     } else if (length(debiasing.weights) != length(subset)) {
       stop("If specified, debiasing.weights must be a vector of length n or the subset length.")

--- a/r-package/grf/R/forest_summary.R
+++ b/r-package/grf/R/forest_summary.R
@@ -160,7 +160,7 @@ best_linear_projection <- function(forest,
   clusters <- if (length(forest$clusters) > 0) {
     forest$clusters
   } else {
-    1:length(forest$Y.orig)
+    1:NROW(forest$Y.orig)
   }
   observation.weight <- observation_weights(forest)
 
@@ -173,7 +173,7 @@ best_linear_projection <- function(forest,
   }
 
   if (!is.null(debiasing.weights)) {
-    if (length(debiasing.weights) == length(forest$Y.orig)) {
+    if (length(debiasing.weights) == NROW(forest$Y.orig)) {
       debiasing.weights <- debiasing.weights[subset]
     } else if (length(debiasing.weights) != length(subset)) {
       stop("If specified, debiasing.weights must be a vector of length n or the subset length.")
@@ -202,7 +202,7 @@ best_linear_projection <- function(forest,
 
   if (!is.null(A)) {
     A <- as.matrix(A)
-    if (nrow(A) == length(forest$Y.orig)) {
+    if (nrow(A) == NROW(forest$Y.orig)) {
       A.subset <- A[subset, , drop = FALSE]
     } else if (nrow(A) == length(subset)) {
       A.subset <- A

--- a/r-package/grf/R/input_utilities.R
+++ b/r-package/grf/R/input_utilities.R
@@ -267,7 +267,7 @@ observation_weights <- function(forest) {
   # Case 1: No sample.weights
   if (is.null(forest$sample.weights)) {
     if (length(forest$clusters) == 0 || !forest$equalize.cluster.weights) {
-      raw.weights <- rep(1, length(forest$Y.orig))
+      raw.weights <- rep(1, NROW(forest$Y.orig))
     } else {
       # If clustering with no sample.weights provided and equalize.cluster.weights = TRUE, then
       # give each observation weight 1/cluster size, so that the total weight of each cluster is the same.


### PR DESCRIPTION
After `multi_arm_causal_forest` `Y.orig` may be a matrix and any generic code (that might end up touching a multi arm causal forest object) relying on retrieving the number of samples should do so with `NROW` for robustness. (`length` of a 2d matrix is not the number of rows).