### PR TITLE
Add an option to split on intercept influence

### DIFF
--- a/core/src/commons/Data.h
+++ b/core/src/commons/Data.h
@@ -107,6 +107,15 @@ public:
 
   const std::set<size_t>& get_disallowed_split_variables() const;
 
+  size_t get_num_responses() const {
+    if (num_responses.has_value()) {
+      return num_responses.value();
+    } else {
+      return get_num_outcomes() * get_num_treatments();
+    }
+  }
+  nonstd::optional<size_t> num_responses;
+
 protected:
   size_t num_rows;
   size_t num_cols;

--- a/core/src/forest/ForestTrainers.cpp
+++ b/core/src/forest/ForestTrainers.cpp
@@ -54,10 +54,12 @@ ForestTrainer instrumental_trainer(double reduced_form_weight,
 }
 
 ForestTrainer multi_causal_trainer(size_t num_treatments,
-                                   size_t num_outcomes) {
+                                   size_t num_outcomes,
+                                   bool intercept) {
 
   std::unique_ptr<RelabelingStrategy> relabeling_strategy(new MultiCausalRelabelingStrategy());
-  std::unique_ptr<SplittingRuleFactory> splitting_rule_factory =
+  std::unique_ptr<SplittingRuleFactory> splitting_rule_factory = intercept ? 
+   std::unique_ptr<SplittingRuleFactory>(new MultiRegressionSplittingRuleFactory(num_treatments * num_outcomes + 1)) :
    std::unique_ptr<SplittingRuleFactory>(new MultiRegressionSplittingRuleFactory(num_treatments * num_outcomes));
   std::unique_ptr<OptimizedPredictionStrategy> prediction_strategy(new MultiCausalPredictionStrategy(num_treatments, num_outcomes));
 

--- a/core/src/forest/ForestTrainers.h
+++ b/core/src/forest/ForestTrainers.h
@@ -26,7 +26,8 @@ ForestTrainer instrumental_trainer(double reduced_form_weight,
                                    bool stabilize_splits);
 
 ForestTrainer multi_causal_trainer(size_t num_treatments,
-                                   size_t num_outcomes);
+                                   size_t num_outcomes,
+                                   bool intercept);
 
 ForestTrainer quantile_trainer(const std::vector<double>& quantiles);
 

--- a/core/src/relabeling/MultiCausalRelabelingStrategy.cpp
+++ b/core/src/relabeling/MultiCausalRelabelingStrategy.cpp
@@ -29,6 +29,9 @@ bool MultiCausalRelabelingStrategy::relabel(
   size_t num_samples = samples.size();
   size_t num_treatments = data.get_num_treatments();
   size_t num_outcomes = data.get_num_outcomes();
+  if (data.num_responses.has_value()) {
+    num_treatments++;
+  }
   if (num_samples <= num_treatments) {
     return true;
   }
@@ -39,22 +42,46 @@ bool MultiCausalRelabelingStrategy::relabel(
   Eigen::VectorXd Y_mean = Eigen::VectorXd::Zero(num_outcomes);
   Eigen::VectorXd W_mean = Eigen::VectorXd::Zero(num_treatments);
   double sum_weight = 0;
-  for (size_t i = 0; i < num_samples; i++) {
-    size_t sample = samples[i];
-    double weight = data.get_weight(sample);
-    Eigen::VectorXd outcome = data.get_outcomes(sample);
-    Eigen::VectorXd treatment = data.get_treatments(sample);
-    Y_centered.row(i) = outcome;
-    W_centered.row(i) = treatment;
-    weights(i) = weight;
-    Y_mean += weight * outcome;
-    W_mean += weight * treatment;
-    sum_weight += weight;
+
+  if (data.num_responses.has_value()) {
+    for (size_t i = 0; i < num_samples; i++) {
+      size_t sample = samples[i];
+      double weight = data.get_weight(sample);
+      Eigen::VectorXd outcome = data.get_outcomes(sample);
+      Eigen::VectorXd treatment = data.get_treatments(sample);
+      // double treatment = data.get_treatments(sample)(0);
+      Eigen::VectorXd one = Eigen::VectorXd::Ones(1);
+      Eigen::VectorXd one_treatment(one.size()+treatment.size());
+      one_treatment << one, treatment;
+      Y_centered.row(i) = outcome;
+      W_centered.row(i) = one_treatment;
+      weights(i) = weight;
+      // Y_mean += weight * outcome;
+      // W_mean += weight * treatment;
+      sum_weight += weight;
+    }
+    // Y_mean = Y_mean / sum_weight;
+    // W_mean = W_mean / sum_weight;
+    // Y_centered.rowwise() -= Y_mean.transpose();
+    // W_centered.rowwise() -= W_mean.transpose();
+  } else {
+    for (size_t i = 0; i < num_samples; i++) {
+      size_t sample = samples[i];
+      double weight = data.get_weight(sample);
+      Eigen::VectorXd outcome = data.get_outcomes(sample);
+      Eigen::VectorXd treatment = data.get_treatments(sample);
+      Y_centered.row(i) = outcome;
+      W_centered.row(i) = treatment;
+      weights(i) = weight;
+      Y_mean += weight * outcome;
+      W_mean += weight * treatment;
+      sum_weight += weight;
+    }
+    Y_mean = Y_mean / sum_weight;
+    W_mean = W_mean / sum_weight;
+    Y_centered.rowwise() -= Y_mean.transpose();
+    W_centered.rowwise() -= W_mean.transpose();
   }
-  Y_mean = Y_mean / sum_weight;
-  W_mean = W_mean / sum_weight;
-  Y_centered.rowwise() -= Y_mean.transpose();
-  W_centered.rowwise() -= W_mean.transpose();
 
   if (std::abs(sum_weight) <= 1e-16) {
     return true;

--- a/core/src/tree/TreeTrainer.cpp
+++ b/core/src/tree/TreeTrainer.cpp
@@ -63,7 +63,7 @@ std::unique_ptr<Tree> TreeTrainer::train(const Data& data,
 
   size_t num_open_nodes = 1;
   size_t i = 0;
-  Eigen::ArrayXXd responses_by_sample(data.get_num_rows(), data.get_num_outcomes() * data.get_num_treatments());
+  Eigen::ArrayXXd responses_by_sample(data.get_num_rows(), data.get_num_responses());
   while (num_open_nodes > 0) {
     bool is_leaf_node = split_node(i,
                                    data,

--- a/r-package/grf/R/RcppExports.R
+++ b/r-package/grf/R/RcppExports.R
@@ -73,8 +73,8 @@ instrumental_predict_oob <- function(forest_object, train_matrix, sparse_train_m
     .Call('_grf_instrumental_predict_oob', PACKAGE = 'grf', forest_object, train_matrix, sparse_train_matrix, outcome_index, treatment_index, instrument_index, num_threads, estimate_variance)
 }
 
-multi_causal_train <- function(train_matrix, sparse_train_matrix, outcome_index, treatment_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed) {
-    .Call('_grf_multi_causal_train', PACKAGE = 'grf', train_matrix, sparse_train_matrix, outcome_index, treatment_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed)
+multi_causal_train <- function(train_matrix, sparse_train_matrix, outcome_index, treatment_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed, intercept) {
+    .Call('_grf_multi_causal_train', PACKAGE = 'grf', train_matrix, sparse_train_matrix, outcome_index, treatment_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed, intercept)
 }
 
 multi_causal_predict <- function(forest_object, train_matrix, sparse_train_matrix, test_matrix, sparse_test_matrix, num_outcomes, num_treatments, num_threads, estimate_variance) {

--- a/r-package/grf/R/multi_arm_causal_forest.R
+++ b/r-package/grf/R/multi_arm_causal_forest.R
@@ -52,6 +52,7 @@
 #' @param num.trees Number of trees grown in the forest. Note: Getting accurate
 #'                  confidence intervals generally requires more trees than
 #'                  getting accurate predictions. Default is 2000.
+#' @param split.on.intercept ...
 #' @param sample.weights Weights given to each sample in estimation.
 #'                       If NULL, each observation receives the same weight.
 #'                       Note: To avoid introducing confounding, weights should be
@@ -167,6 +168,7 @@ multi_arm_causal_forest <- function(X, Y, W,
                                     Y.hat = NULL,
                                     W.hat = NULL,
                                     num.trees = 2000,
+                                    split.on.intercept = FALSE,
                                     sample.weights = NULL,
                                     clusters = NULL,
                                     equalize.cluster.weights = FALSE,
@@ -248,6 +250,7 @@ multi_arm_causal_forest <- function(X, Y, W,
                                 treatment = W.centered[, -1],
                                 sample.weights = sample.weights)
   args <- list(num.trees = num.trees,
+               intercept = split.on.intercept,
                clusters = clusters,
                samples.per.cluster = samples.per.cluster,
                sample.fraction = sample.fraction,

--- a/r-package/grf/bindings/MultiCausalForestBindings.cpp
+++ b/r-package/grf/bindings/MultiCausalForestBindings.cpp
@@ -30,16 +30,20 @@ Rcpp::List multi_causal_train(Rcpp::NumericMatrix train_matrix,
                               unsigned int samples_per_cluster,
                               bool compute_oob_predictions,
                               unsigned int num_threads,
-                              unsigned int seed) {
+                              unsigned int seed,
+                              bool intercept) {
   size_t num_treatments = treatment_index.size();
   size_t num_outcomes = outcome_index.size();
-  ForestTrainer trainer = multi_causal_trainer(num_treatments, num_outcomes);
+  ForestTrainer trainer = multi_causal_trainer(num_treatments, num_outcomes, intercept);
 
   std::unique_ptr<Data> data = RcppUtilities::convert_data(train_matrix, sparse_train_matrix);
   data->set_outcome_index(outcome_index);
   data->set_treatment_index(treatment_index);
   if (use_sample_weights) {
     data->set_weight_index(sample_weight_index);
+  }
+  if (intercept) {
+    data->num_responses = num_outcomes * num_treatments + 1;
   }
 
   ForestOptions options(num_trees, ci_group_size, sample_fraction, mtry, min_node_size, honesty,

--- a/r-package/grf/man/multi_arm_causal_forest.Rd
+++ b/r-package/grf/man/multi_arm_causal_forest.Rd
@@ -11,6 +11,7 @@ multi_arm_causal_forest(
   Y.hat = NULL,
   W.hat = NULL,
   num.trees = 2000,
+  split.on.intercept = FALSE,
   sample.weights = NULL,
   clusters = NULL,
   equalize.cluster.weights = FALSE,
@@ -48,6 +49,8 @@ If W.hat = NULL, these are estimated using a probability forest.}
 \item{num.trees}{Number of trees grown in the forest. Note: Getting accurate
 confidence intervals generally requires more trees than
 getting accurate predictions. Default is 2000.}
+
+\item{split.on.intercept}{...}
 
 \item{sample.weights}{Weights given to each sample in estimation.
 If NULL, each observation receives the same weight.

--- a/r-package/grf/src/RcppExports.cpp
+++ b/r-package/grf/src/RcppExports.cpp
@@ -369,8 +369,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // multi_causal_train
-Rcpp::List multi_causal_train(Rcpp::NumericMatrix train_matrix, Eigen::SparseMatrix<double> sparse_train_matrix, const std::vector<size_t>& outcome_index, const std::vector<size_t>& treatment_index, size_t sample_weight_index, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double alpha, double imbalance_penalty, std::vector<size_t> clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, unsigned int num_threads, unsigned int seed);
-RcppExport SEXP _grf_multi_causal_train(SEXP train_matrixSEXP, SEXP sparse_train_matrixSEXP, SEXP outcome_indexSEXP, SEXP treatment_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP ci_group_sizeSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP compute_oob_predictionsSEXP, SEXP num_threadsSEXP, SEXP seedSEXP) {
+Rcpp::List multi_causal_train(Rcpp::NumericMatrix train_matrix, Eigen::SparseMatrix<double> sparse_train_matrix, const std::vector<size_t>& outcome_index, const std::vector<size_t>& treatment_index, size_t sample_weight_index, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double alpha, double imbalance_penalty, std::vector<size_t> clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, unsigned int num_threads, unsigned int seed, bool intercept);
+RcppExport SEXP _grf_multi_causal_train(SEXP train_matrixSEXP, SEXP sparse_train_matrixSEXP, SEXP outcome_indexSEXP, SEXP treatment_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP ci_group_sizeSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP compute_oob_predictionsSEXP, SEXP num_threadsSEXP, SEXP seedSEXP, SEXP interceptSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -395,7 +395,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type compute_oob_predictions(compute_oob_predictionsSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type seed(seedSEXP);
-    rcpp_result_gen = Rcpp::wrap(multi_causal_train(train_matrix, sparse_train_matrix, outcome_index, treatment_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed));
+    Rcpp::traits::input_parameter< bool >::type intercept(interceptSEXP);
+    rcpp_result_gen = Rcpp::wrap(multi_causal_train(train_matrix, sparse_train_matrix, outcome_index, treatment_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed, intercept));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -852,7 +853,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_grf_instrumental_train", (DL_FUNC) &_grf_instrumental_train, 24},
     {"_grf_instrumental_predict", (DL_FUNC) &_grf_instrumental_predict, 10},
     {"_grf_instrumental_predict_oob", (DL_FUNC) &_grf_instrumental_predict_oob, 8},
-    {"_grf_multi_causal_train", (DL_FUNC) &_grf_multi_causal_train, 21},
+    {"_grf_multi_causal_train", (DL_FUNC) &_grf_multi_causal_train, 22},
     {"_grf_multi_causal_predict", (DL_FUNC) &_grf_multi_causal_predict, 9},
     {"_grf_multi_causal_predict_oob", (DL_FUNC) &_grf_multi_causal_predict_oob, 7},
     {"_grf_multi_regression_train", (DL_FUNC) &_grf_multi_regression_train, 19},


### PR DESCRIPTION
(Just an experimental branch, only works for one outcome and binary treatment) Add `split.on.intercept` (default = FALSE) option to `multi_arm_causal_forest`: let Yc and Wc be centered outcomes and treatments, and Yc = c + tau * W + error.

If `split.on.intercept` is true we split on pseudo_outcomes_i = [delta c_i, delta tau_i]
If `split.on.intercept` is false we split on pseudo_outcomes_i = delta tau_i

Example (multi_arm_causal forest with binary treatment is in principle the same as causal_forest with `stabilize.splits=FALSE`)

```
n = 500
p = 5
summary(replicate(50, {
 # Setup D from Nie-Wager
  X <- matrix(rnorm(n * p), n, p)
  tau <- pmax(X[, 1] + X[, 2] + X[, 3], 0) - pmax(X[, 4] + X[, 5], 0)
  e <- 1 / (1 + exp(-X[, 1]) + exp(-X[, 2]))
  W <- rbinom(n = n, size = 1, prob = e)
  Y <- (pmax(X[, 1] + X[, 2] + X[, 3], 0) + pmax(X[, 4] + X[, 5], 0)) / 2 + W * tau + rnorm(n)

  cf1 = multi_arm_causal_forest(X, Y, as.factor(W), split.on.intercept = FALSE, seed = 42)
  cf2 = multi_arm_causal_forest(X, Y, as.factor(W), split.on.intercept = TRUE, seed = 42)
  mse1 = mean((predict(cf1)$predictions[,,] - tau)^2)
  mse2 = mean((predict(cf2)$predictions[,,] - tau)^2)

  mse1 / mse2
}))
# Min. 1st Qu.  Median    Mean 3rd Qu.    Max. 
# 0.9839  0.9984  1.0055  1.0064  1.0150  1.0307 
# Setup A from Nie-Wager:
 Min. 1st Qu.  Median    Mean 3rd Qu.    Max. 
 0.8976  0.9749  1.0013  0.9997  1.0226  1.0848 
```

To install:
```
devtools::install_github("erikcs/grf", subdir = "r-package/grf", ref = "split-with-intercept"))
```