### PR TITLE
Simplify setting the dimension of `responses_by_sample`

### DIFF
--- a/core/src/forest/ForestTrainers.cpp
+++ b/core/src/forest/ForestTrainers.cpp
@@ -54,11 +54,12 @@ ForestTrainer instrumental_trainer(double reduced_form_weight,
 }
 
 ForestTrainer multi_causal_trainer(size_t num_treatments,
-                                   size_t num_outcomes) {
+                                   size_t num_outcomes,
+                                   size_t response_length) {
 
-  std::unique_ptr<RelabelingStrategy> relabeling_strategy(new MultiCausalRelabelingStrategy());
+  std::unique_ptr<RelabelingStrategy> relabeling_strategy(new MultiCausalRelabelingStrategy(response_length));
   std::unique_ptr<SplittingRuleFactory> splitting_rule_factory =
-   std::unique_ptr<SplittingRuleFactory>(new MultiRegressionSplittingRuleFactory(num_treatments * num_outcomes));
+   std::unique_ptr<SplittingRuleFactory>(new MultiRegressionSplittingRuleFactory(response_length));
   std::unique_ptr<OptimizedPredictionStrategy> prediction_strategy(new MultiCausalPredictionStrategy(num_treatments, num_outcomes));
 
   return ForestTrainer(std::move(relabeling_strategy),
@@ -97,7 +98,7 @@ ForestTrainer regression_trainer() {
 }
 
 ForestTrainer multi_regression_trainer(size_t num_outcomes) {
-  std::unique_ptr<RelabelingStrategy> relabeling_strategy(new MultiNoopRelabelingStrategy());
+  std::unique_ptr<RelabelingStrategy> relabeling_strategy(new MultiNoopRelabelingStrategy(num_outcomes));
   std::unique_ptr<SplittingRuleFactory> splitting_rule_factory(new MultiRegressionSplittingRuleFactory(num_outcomes));
   std::unique_ptr<OptimizedPredictionStrategy> prediction_strategy(new MultiRegressionPredictionStrategy(num_outcomes));
 

--- a/core/src/forest/ForestTrainers.h
+++ b/core/src/forest/ForestTrainers.h
@@ -26,7 +26,8 @@ ForestTrainer instrumental_trainer(double reduced_form_weight,
                                    bool stabilize_splits);
 
 ForestTrainer multi_causal_trainer(size_t num_treatments,
-                                   size_t num_outcomes);
+                                   size_t num_outcomes,
+                                   size_t response_length);
 
 ForestTrainer quantile_trainer(const std::vector<double>& quantiles);
 

--- a/core/src/relabeling/MultiCausalRelabelingStrategy.cpp
+++ b/core/src/relabeling/MultiCausalRelabelingStrategy.cpp
@@ -20,6 +20,9 @@
 
 namespace grf {
 
+MultiCausalRelabelingStrategy::MultiCausalRelabelingStrategy(size_t response_length) :
+  response_length(response_length) {}
+
 bool MultiCausalRelabelingStrategy::relabel(
     const std::vector<size_t>& samples,
     const Data& data,
@@ -86,6 +89,10 @@ bool MultiCausalRelabelingStrategy::relabel(
     }
   }
   return false;
+}
+
+size_t MultiCausalRelabelingStrategy::get_response_length() const {
+  return response_length;
 }
 
 } // namespace grf

--- a/core/src/relabeling/MultiCausalRelabelingStrategy.h
+++ b/core/src/relabeling/MultiCausalRelabelingStrategy.h
@@ -28,10 +28,17 @@ namespace grf {
 
 class MultiCausalRelabelingStrategy final: public RelabelingStrategy {
 public:
+  MultiCausalRelabelingStrategy(size_t response_length);
+
   bool relabel(
       const std::vector<size_t>& samples,
       const Data& data,
       Eigen::ArrayXXd& responses_by_sample) const;
+
+  size_t get_response_length() const;
+
+private:
+  size_t response_length;
 };
 
 } // namespace grf

--- a/core/src/relabeling/MultiNoopRelabelingStrategy.cpp
+++ b/core/src/relabeling/MultiNoopRelabelingStrategy.cpp
@@ -19,6 +19,9 @@
 
  namespace grf {
 
+ MultiNoopRelabelingStrategy::MultiNoopRelabelingStrategy(size_t num_outcomes) :
+  num_outcomes(num_outcomes) {}
+
  bool MultiNoopRelabelingStrategy::relabel(
      const std::vector<size_t>& samples,
      const Data& data,
@@ -30,5 +33,9 @@
    }
    return false;
  }
+
+size_t MultiNoopRelabelingStrategy::get_response_length() const {
+  return num_outcomes;
+}
 
  } // namespace grf

--- a/core/src/relabeling/MultiNoopRelabelingStrategy.h
+++ b/core/src/relabeling/MultiNoopRelabelingStrategy.h
@@ -24,10 +24,17 @@ namespace grf {
 
 class MultiNoopRelabelingStrategy final: public RelabelingStrategy {
 public:
+  MultiNoopRelabelingStrategy(size_t num_outcomes);
+
   bool relabel(
       const std::vector<size_t>& samples,
       const Data& data,
       Eigen::ArrayXXd& responses_by_sample) const;
+
+  size_t get_response_length() const;
+
+private:
+  size_t num_outcomes;
 };
 
 } // namespace grf

--- a/core/src/relabeling/RelabelingStrategy.h
+++ b/core/src/relabeling/RelabelingStrategy.h
@@ -29,6 +29,9 @@ namespace grf {
 /**
  * Produces a relabelled set of outcomes for a set of training samples. These outcomes
  * will then be used in calculating a standard regression (or classification) split.
+ *
+ * The optional override `get_response_length()` is used for forests splitting on
+ * vector-valued outcomes.
  */
 class RelabelingStrategy {
 public:
@@ -39,12 +42,12 @@ public:
    * samples: the subset of samples to relabel.
    * data: the training data matrix.
    * responses_by_sample: the output of the method, an array of relabelled response for each sample ID in `samples`.
-   * The dimension of this array is N * K where N is the total number of samples in the data, and K
-   * is equal to `data.get_num_outcomes() * data.get_num_treatments()`. I.e, in most cases, like a single-variable
-   * regression forest, K is 1, and `responses_by_sample` is a scalar for each sample. In other forests, like
-   * multi-output regression forest, K is equal to the number of outcomes, and `responses_by_sample` is a
-   * length K vector for each sample (working with a vector-valued splitting rule).
+   * The dimension of this array is N * K where N is the total number of samples in the data, and K is given
+   * by `get_response_length()`.
    *
+   * In most cases, like a single-variable regression forest, K is 1, and `responses_by_sample` is a scalar for
+   * each sample. In other forests, like multi-output regression forest, K is equal to the number of outcomes,
+   * and `responses_by_sample` is a length K vector for each sample (working with a vector-valued splitting rule).
    *
    * Note that for performance reasons (avoiding clearing out the array after each split) this array may
    * contain garbage values for indices outside of the given set of sample IDs.
@@ -54,6 +57,11 @@ public:
   virtual bool relabel(const std::vector<size_t>& samples,
                        const Data& data,
                        Eigen::ArrayXXd& responses_by_sample) const = 0;
+ /**
+   * Override to specify the column dimension of `responses_by_sample`.
+   * The default value of 1 is used for most forest splitting on scalar values.
+   */
+  virtual size_t get_response_length() const { return 1; };
 };
 
 } // namespace grf

--- a/core/src/relabeling/RelabelingStrategy.h
+++ b/core/src/relabeling/RelabelingStrategy.h
@@ -57,6 +57,7 @@ public:
   virtual bool relabel(const std::vector<size_t>& samples,
                        const Data& data,
                        Eigen::ArrayXXd& responses_by_sample) const = 0;
+
  /**
    * Override to specify the column dimension of `responses_by_sample`.
    * The default value of 1 is used for most forests splitting on scalar values.

--- a/core/src/relabeling/RelabelingStrategy.h
+++ b/core/src/relabeling/RelabelingStrategy.h
@@ -59,7 +59,7 @@ public:
                        Eigen::ArrayXXd& responses_by_sample) const = 0;
  /**
    * Override to specify the column dimension of `responses_by_sample`.
-   * The default value of 1 is used for most forest splitting on scalar values.
+   * The default value of 1 is used for most forests splitting on scalar values.
    */
   virtual size_t get_response_length() const { return 1; };
 };

--- a/core/src/tree/TreeTrainer.cpp
+++ b/core/src/tree/TreeTrainer.cpp
@@ -63,7 +63,7 @@ std::unique_ptr<Tree> TreeTrainer::train(const Data& data,
 
   size_t num_open_nodes = 1;
   size_t i = 0;
-  Eigen::ArrayXXd responses_by_sample(data.get_num_rows(), data.get_num_outcomes() * data.get_num_treatments());
+  Eigen::ArrayXXd responses_by_sample(data.get_num_rows(), relabeling_strategy->get_response_length());
   while (num_open_nodes > 0) {
     bool is_leaf_node = split_node(i,
                                    data,

--- a/core/test/forest/ForestCharacterizationTest.cpp
+++ b/core/test/forest/ForestCharacterizationTest.cpp
@@ -292,7 +292,7 @@ TEST_CASE("multi causal forest predictions with sample weights have not changed"
   data->set_weight_index(8);
 
   size_t num_treatments = 2;
-  ForestTrainer trainer = multi_causal_trainer(num_treatments, 1);
+  ForestTrainer trainer = multi_causal_trainer(num_treatments, 1, num_treatments);
   ForestOptions options = ForestTestUtilities::default_options();
 
   Forest forest = trainer.train(*data, options);

--- a/core/test/relabeling/MultiCausalRelabelingStrategyTest.cpp
+++ b/core/test/relabeling/MultiCausalRelabelingStrategyTest.cpp
@@ -36,7 +36,7 @@ Eigen::ArrayXXd get_relabeled_outcomes(
     samples.push_back(i);
   }
 
-  std::unique_ptr<RelabelingStrategy> relabeling_strategy(new MultiCausalRelabelingStrategy());
+  std::unique_ptr<RelabelingStrategy> relabeling_strategy(new MultiCausalRelabelingStrategy(num_treatments));
 
   Eigen::ArrayXXd relabeled_observations(num_samples, num_treatments);
   bool stop = relabeling_strategy->relabel(samples, data, relabeled_observations);

--- a/r-package/grf/bindings/MultiCausalForestBindings.cpp
+++ b/r-package/grf/bindings/MultiCausalForestBindings.cpp
@@ -33,7 +33,7 @@ Rcpp::List multi_causal_train(Rcpp::NumericMatrix train_matrix,
                               unsigned int seed) {
   size_t num_treatments = treatment_index.size();
   size_t num_outcomes = outcome_index.size();
-  ForestTrainer trainer = multi_causal_trainer(num_treatments, num_outcomes);
+  ForestTrainer trainer = multi_causal_trainer(num_treatments, num_outcomes, num_treatments * num_outcomes);
 
   std::unique_ptr<Data> data = RcppUtilities::convert_data(train_matrix, sparse_train_matrix);
   data->set_outcome_index(outcome_index);


### PR DESCRIPTION
This is just an aesthetic suggestion to simplify how the dimension of `responses_by_sample` is handled.

Recall `responses_by_sample(i, )` is typically length 1 for most forests, but with the introduction of a vector valued splitting rule, it may be longer, like `num_outcomes * num_treatments` for the `multi_arm_causal_forest`. 

Now TreeTrainer initializes this array with the general and more future friendly

```C++
Eigen::ArrayXXd responses_by_sample(data.get_num_rows(), relabeling_strategy->get_response_length());
```

instead of

```C++
Eigen::ArrayXXd responses_by_sample(data.get_num_rows(), data.get_num_outcomes() * data.get_num_treatments());
```

with `get_response_length()` delegated to the `RelabelingStrategy` (default value of 1, overriden by forests which wants to)

