### PR TITLE
Add option to split on guide variable

### DIFF
--- a/core/src/commons/Data.cpp
+++ b/core/src/commons/Data.cpp
@@ -172,6 +172,11 @@ void Data::set_weight_index(size_t index) {
   disallowed_split_variables.insert(index);
 }
 
+void Data::set_split_guide_index(size_t index) {
+  this->split_guide_index = index;
+  disallowed_split_variables.insert(index);
+}
+
 void Data::set_causal_survival_numerator_index(size_t index) {
   this->causal_survival_numerator_index = index;
   disallowed_split_variables.insert(index);
@@ -290,6 +295,10 @@ double Data::get_weight(size_t row) const {
   } else {
     return 1.0;
   }
+}
+
+double Data::get_split_guide(size_t row) const {
+  return get(row, split_guide_index.value());
 }
 
 double Data::get_causal_survival_numerator(size_t row) const {

--- a/core/src/commons/Data.cpp
+++ b/core/src/commons/Data.cpp
@@ -36,7 +36,8 @@ Data::Data() :
     weight_index(),
     causal_survival_numerator_index(),
     causal_survival_denominator_index(),
-    censor_index() {}
+    censor_index(),
+    response_length() {}
 
 bool Data::load_from_file(const std::string& filename) {
   bool result;
@@ -186,6 +187,10 @@ void Data::set_censor_index(size_t index) {
   disallowed_split_variables.insert(index);
 }
 
+void Data::set_response_length(size_t length) {
+  this->response_length = length;
+}
+
 void Data::get_all_values(std::vector<double>& all_values,
                           std::vector<size_t>& sorted_samples,
                           const std::vector<size_t>& samples,
@@ -238,6 +243,14 @@ size_t Data::get_num_outcomes() const {
 size_t Data::get_num_treatments() const {
   if (treatment_index.has_value()) {
     return treatment_index.value().size();
+  } else {
+    return 1;
+  }
+}
+
+size_t Data::get_response_length() const {
+  if (response_length.has_value()) {
+    return response_length.value();
   } else {
     return 1;
   }

--- a/core/src/commons/Data.h
+++ b/core/src/commons/Data.h
@@ -64,6 +64,8 @@ public:
 
   void set_censor_index(size_t index);
 
+  void set_response_length(size_t length);
+
   /**
    * Sorts and gets the unique values in `samples` at variable `var`.
    *
@@ -86,6 +88,16 @@ public:
   size_t get_num_outcomes() const;
 
   size_t get_num_treatments() const;
+
+  /**
+   * GRF can split on scalar or vector valued responses. The dimension of the data structure
+   * "responses_by_sample" used in the forest components is controlled by this method.
+   *
+   * Most forests split on scalar valued pseudo outcomes, and the default return value for this method
+   * is 1. To set it to another value, use the method `set_response_length`. For example, the Multi
+   * Regression Forest sets this to the number of outcomes.
+   */
+  size_t get_response_length() const;
 
   double get_outcome(size_t row) const;
 
@@ -119,6 +131,7 @@ protected:
   nonstd::optional<size_t> causal_survival_numerator_index;
   nonstd::optional<size_t> causal_survival_denominator_index;
   nonstd::optional<size_t> censor_index;
+  nonstd::optional<size_t> response_length;
 
 private:
   DISALLOW_COPY_AND_ASSIGN(Data);

--- a/core/src/commons/Data.h
+++ b/core/src/commons/Data.h
@@ -58,6 +58,8 @@ public:
 
   void set_weight_index(size_t index);
 
+  void set_split_guide_index(size_t index);
+
   void set_causal_survival_numerator_index(size_t index);
 
   void set_causal_survival_denominator_index(size_t index);
@@ -111,6 +113,8 @@ public:
 
   double get_weight(size_t row) const;
 
+  double get_split_guide(size_t row) const;
+
   double get_causal_survival_numerator(size_t row) const;
 
   double get_causal_survival_denominator(size_t row) const;
@@ -128,6 +132,7 @@ protected:
   nonstd::optional<std::vector<size_t>> treatment_index;
   nonstd::optional<size_t> instrument_index;
   nonstd::optional<size_t> weight_index;
+  nonstd::optional<size_t> split_guide_index;
   nonstd::optional<size_t> causal_survival_numerator_index;
   nonstd::optional<size_t> causal_survival_denominator_index;
   nonstd::optional<size_t> censor_index;

--- a/core/src/forest/ForestTrainers.cpp
+++ b/core/src/forest/ForestTrainers.cpp
@@ -54,11 +54,12 @@ ForestTrainer instrumental_trainer(double reduced_form_weight,
 }
 
 ForestTrainer multi_causal_trainer(size_t num_treatments,
-                                   size_t num_outcomes) {
+                                   size_t num_outcomes,
+                                   size_t response_length) {
 
   std::unique_ptr<RelabelingStrategy> relabeling_strategy(new MultiCausalRelabelingStrategy());
   std::unique_ptr<SplittingRuleFactory> splitting_rule_factory =
-   std::unique_ptr<SplittingRuleFactory>(new MultiRegressionSplittingRuleFactory(num_treatments * num_outcomes));
+   std::unique_ptr<SplittingRuleFactory>(new MultiRegressionSplittingRuleFactory(response_length));
   std::unique_ptr<OptimizedPredictionStrategy> prediction_strategy(new MultiCausalPredictionStrategy(num_treatments, num_outcomes));
 
   return ForestTrainer(std::move(relabeling_strategy),

--- a/core/src/forest/ForestTrainers.cpp
+++ b/core/src/forest/ForestTrainers.cpp
@@ -40,12 +40,13 @@
 namespace grf {
 
 ForestTrainer instrumental_trainer(double reduced_form_weight,
-                                   bool stabilize_splits) {
+                                   bool regression_split,
+                                   size_t response_length) {
 
   std::unique_ptr<RelabelingStrategy> relabeling_strategy(new InstrumentalRelabelingStrategy(reduced_form_weight));
-  std::unique_ptr<SplittingRuleFactory> splitting_rule_factory = stabilize_splits
-          ? std::unique_ptr<SplittingRuleFactory>(new InstrumentalSplittingRuleFactory())
-          : std::unique_ptr<SplittingRuleFactory>(new RegressionSplittingRuleFactory());
+  std::unique_ptr<SplittingRuleFactory> splitting_rule_factory = regression_split
+          ? std::unique_ptr<SplittingRuleFactory>(new MultiRegressionSplittingRuleFactory(response_length))
+          : std::unique_ptr<SplittingRuleFactory>(new InstrumentalSplittingRuleFactory());
   std::unique_ptr<OptimizedPredictionStrategy> prediction_strategy(new InstrumentalPredictionStrategy());
 
   return ForestTrainer(std::move(relabeling_strategy),

--- a/core/src/forest/ForestTrainers.h
+++ b/core/src/forest/ForestTrainers.h
@@ -23,7 +23,8 @@
 namespace grf {
 
 ForestTrainer instrumental_trainer(double reduced_form_weight,
-                                   bool stabilize_splits);
+                                   bool regression_split,
+                                   size_t response_length);
 
 ForestTrainer multi_causal_trainer(size_t num_treatments,
                                    size_t num_outcomes,

--- a/core/src/forest/ForestTrainers.h
+++ b/core/src/forest/ForestTrainers.h
@@ -26,7 +26,8 @@ ForestTrainer instrumental_trainer(double reduced_form_weight,
                                    bool stabilize_splits);
 
 ForestTrainer multi_causal_trainer(size_t num_treatments,
-                                   size_t num_outcomes);
+                                   size_t num_outcomes,
+                                   size_t response_length);
 
 ForestTrainer quantile_trainer(const std::vector<double>& quantiles);
 

--- a/core/src/relabeling/InstrumentalRelabelingStrategy.cpp
+++ b/core/src/relabeling/InstrumentalRelabelingStrategy.cpp
@@ -86,7 +86,10 @@ bool InstrumentalRelabelingStrategy::relabel(
     double regularized_instrument = (1 - reduced_form_weight) * instrument + reduced_form_weight * treatment;
 
     double residual = (response - average_outcome) - local_average_treatment_effect * (treatment - average_treatment);
-    responses_by_sample(sample) = (regularized_instrument - average_regularized_instrument) * residual;
+    responses_by_sample(sample, 0) = (regularized_instrument - average_regularized_instrument) * residual;
+    if (data.get_response_length() > 1) {
+      responses_by_sample(sample, 1) = data.get_split_guide(sample);
+    }
   }
   return false;
 }

--- a/core/src/relabeling/RelabelingStrategy.h
+++ b/core/src/relabeling/RelabelingStrategy.h
@@ -39,12 +39,12 @@ public:
    * samples: the subset of samples to relabel.
    * data: the training data matrix.
    * responses_by_sample: the output of the method, an array of relabelled response for each sample ID in `samples`.
-   * The dimension of this array is N * K where N is the total number of samples in the data, and K
-   * is equal to `data.get_num_outcomes() * data.get_num_treatments()`. I.e, in most cases, like a single-variable
-   * regression forest, K is 1, and `responses_by_sample` is a scalar for each sample. In other forests, like
-   * multi-output regression forest, K is equal to the number of outcomes, and `responses_by_sample` is a
-   * length K vector for each sample (working with a vector-valued splitting rule).
+   * The dimension of this array is N * K where N is the total number of samples in the data, and K the
+   * response length, given by data.get_response_length(), and set throughout the forest with `data.set_response_length`.
    *
+   * In most cases, like a single-variable regression forest, K is 1, and `responses_by_sample` is a scalar for each sample.
+   * In other forests, like multi-output regression forest, K is equal to the number of outcomes, and `responses_by_sample`
+   * is a length K vector for each sample (working with a vector-valued splitting rule).
    *
    * Note that for performance reasons (avoiding clearing out the array after each split) this array may
    * contain garbage values for indices outside of the given set of sample IDs.

--- a/core/src/tree/TreeTrainer.cpp
+++ b/core/src/tree/TreeTrainer.cpp
@@ -63,7 +63,7 @@ std::unique_ptr<Tree> TreeTrainer::train(const Data& data,
 
   size_t num_open_nodes = 1;
   size_t i = 0;
-  Eigen::ArrayXXd responses_by_sample(data.get_num_rows(), data.get_num_outcomes() * data.get_num_treatments());
+  Eigen::ArrayXXd responses_by_sample(data.get_num_rows(), data.get_response_length());
   while (num_open_nodes > 0) {
     bool is_leaf_node = split_node(i,
                                    data,

--- a/core/test/forest/CausalForestTest.cpp
+++ b/core/test/forest/CausalForestTest.cpp
@@ -44,7 +44,7 @@ TEST_CASE("causal forests are invariant to rescaling of the sample weights", "[c
     data->set(weight_index, r, weight, error);
   }
 
-  ForestTrainer trainer = instrumental_trainer(0, true);
+  ForestTrainer trainer = instrumental_trainer(0, true, 1);
   ForestOptions options = ForestTestUtilities::default_honest_options();
 
   Forest forest = trainer.train(*data, options);

--- a/core/test/forest/ForestCharacterizationTest.cpp
+++ b/core/test/forest/ForestCharacterizationTest.cpp
@@ -156,7 +156,7 @@ TEST_CASE("causal forest predictions have not changed", "[causal], [characteriza
   double reduced_form_weight = 0.0;
   bool stabilize_splits = false;
 
-  ForestTrainer trainer = instrumental_trainer(reduced_form_weight, stabilize_splits);
+  ForestTrainer trainer = instrumental_trainer(reduced_form_weight, stabilize_splits, 1);
   ForestOptions options = ForestTestUtilities::default_options();
 
   Forest forest = trainer.train(*data, options);
@@ -188,7 +188,7 @@ TEST_CASE("causal forest predictions with stable splitting have not changed", "[
   double reduced_form_weight = 0.0;
   bool stabilize_splits = true;
 
-  ForestTrainer trainer = instrumental_trainer(reduced_form_weight, stabilize_splits);
+  ForestTrainer trainer = instrumental_trainer(reduced_form_weight, stabilize_splits, 1);
   ForestOptions options = ForestTestUtilities::default_options();
 
   Forest forest = trainer.train(*data, options);
@@ -230,7 +230,7 @@ TEST_CASE("causal forest predictions with sample weights and stable splitting ha
   double reduced_form_weight = 0.0;
   bool stabilize_splits = true;
 
-  ForestTrainer trainer = instrumental_trainer(reduced_form_weight, stabilize_splits);
+  ForestTrainer trainer = instrumental_trainer(reduced_form_weight, stabilize_splits, 1);
   ForestOptions options = ForestTestUtilities::default_options();
 
   Forest forest = trainer.train(*data, options);
@@ -262,7 +262,7 @@ TEST_CASE("causal forest predictions with NaNs and stable splitting have not cha
   double reduced_form_weight = 0.0;
   bool stabilize_splits = true;
 
-  ForestTrainer trainer = instrumental_trainer(reduced_form_weight, stabilize_splits);
+  ForestTrainer trainer = instrumental_trainer(reduced_form_weight, stabilize_splits, 1);
   ForestOptions options = ForestTestUtilities::default_options();
 
   Forest forest = trainer.train(*data, options);

--- a/core/test/forest/ForestCharacterizationTest.cpp
+++ b/core/test/forest/ForestCharacterizationTest.cpp
@@ -156,7 +156,7 @@ TEST_CASE("causal forest predictions have not changed", "[causal], [characteriza
   double reduced_form_weight = 0.0;
   bool stabilize_splits = false;
 
-  ForestTrainer trainer = instrumental_trainer(reduced_form_weight, stabilize_splits, 1);
+  ForestTrainer trainer = instrumental_trainer(reduced_form_weight, !stabilize_splits, 1);
   ForestOptions options = ForestTestUtilities::default_options();
 
   Forest forest = trainer.train(*data, options);
@@ -188,7 +188,7 @@ TEST_CASE("causal forest predictions with stable splitting have not changed", "[
   double reduced_form_weight = 0.0;
   bool stabilize_splits = true;
 
-  ForestTrainer trainer = instrumental_trainer(reduced_form_weight, stabilize_splits, 1);
+  ForestTrainer trainer = instrumental_trainer(reduced_form_weight, !stabilize_splits, 1);
   ForestOptions options = ForestTestUtilities::default_options();
 
   Forest forest = trainer.train(*data, options);
@@ -230,7 +230,7 @@ TEST_CASE("causal forest predictions with sample weights and stable splitting ha
   double reduced_form_weight = 0.0;
   bool stabilize_splits = true;
 
-  ForestTrainer trainer = instrumental_trainer(reduced_form_weight, stabilize_splits, 1);
+  ForestTrainer trainer = instrumental_trainer(reduced_form_weight, !stabilize_splits, 1);
   ForestOptions options = ForestTestUtilities::default_options();
 
   Forest forest = trainer.train(*data, options);
@@ -262,7 +262,7 @@ TEST_CASE("causal forest predictions with NaNs and stable splitting have not cha
   double reduced_form_weight = 0.0;
   bool stabilize_splits = true;
 
-  ForestTrainer trainer = instrumental_trainer(reduced_form_weight, stabilize_splits, 1);
+  ForestTrainer trainer = instrumental_trainer(reduced_form_weight, !stabilize_splits, 1);
   ForestOptions options = ForestTestUtilities::default_options();
 
   Forest forest = trainer.train(*data, options);

--- a/core/test/forest/ForestCharacterizationTest.cpp
+++ b/core/test/forest/ForestCharacterizationTest.cpp
@@ -287,12 +287,13 @@ TEST_CASE("causal forest predictions with NaNs and stable splitting have not cha
 
 TEST_CASE("multi causal forest predictions with sample weights have not changed", "[multi causal], [characterization]") {
   std::unique_ptr<Data> data = load_data("test/forest/resources/multi_causal_data.csv");
+  size_t num_treatments = 2;
   data->set_outcome_index(5);
   data->set_treatment_index({6, 7});
   data->set_weight_index(8);
+  data->set_response_length(num_treatments);
 
-  size_t num_treatments = 2;
-  ForestTrainer trainer = multi_causal_trainer(num_treatments, 1);
+  ForestTrainer trainer = multi_causal_trainer(num_treatments, 1, num_treatments);
   ForestOptions options = ForestTestUtilities::default_options();
 
   Forest forest = trainer.train(*data, options);

--- a/core/test/forest/LocalLinearForestTest.cpp
+++ b/core/test/forest/LocalLinearForestTest.cpp
@@ -163,7 +163,7 @@ TEST_CASE("LLF causal predictions are unaffected by shifts in Y", "[local linear
   double reduced_form_weight = 0.0;
   bool stabilize_splits = false;
 
-  ForestTrainer trainer = instrumental_trainer(reduced_form_weight, stabilize_splits);
+  ForestTrainer trainer = instrumental_trainer(reduced_form_weight, stabilize_splits, 1);
   ForestOptions options = ForestTestUtilities::default_options();
 
   Forest forest = trainer.train(*data, options);

--- a/r-package/grf/R/RcppExports.R
+++ b/r-package/grf/R/RcppExports.R
@@ -17,8 +17,8 @@ merge <- function(forest_objects) {
     .Call('_grf_merge', PACKAGE = 'grf', forest_objects)
 }
 
-causal_train <- function(train_matrix, sparse_train_matrix, outcome_index, treatment_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, reduced_form_weight, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed) {
-    .Call('_grf_causal_train', PACKAGE = 'grf', train_matrix, sparse_train_matrix, outcome_index, treatment_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, reduced_form_weight, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed)
+causal_train <- function(train_matrix, sparse_train_matrix, outcome_index, treatment_index, sample_weight_index, split_guide_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, reduced_form_weight, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed) {
+    .Call('_grf_causal_train', PACKAGE = 'grf', train_matrix, sparse_train_matrix, outcome_index, treatment_index, sample_weight_index, split_guide_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, reduced_form_weight, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed)
 }
 
 causal_predict <- function(forest_object, train_matrix, sparse_train_matrix, outcome_index, treatment_index, test_matrix, sparse_test_matrix, num_threads, estimate_variance) {

--- a/r-package/grf/R/causal_forest.R
+++ b/r-package/grf/R/causal_forest.R
@@ -60,7 +60,7 @@
 #' @param imbalance.penalty A tuning parameter that controls how harshly imbalanced splits are penalized. Default is 0.
 #' @param stabilize.splits Whether or not the treatment should be taken into account when
 #'                         determining the imbalance of a split. Default is TRUE.
-#' @param split.guide Optional variable to include in splitting. If provided, the new regression splits at point i are
+#' @param split.guide.variable Optional variable to include in splitting. If provided, the new regression splits at point i are
 #'  are computed on [delta tau_i, split.guide_i] instead of on just [delta tau_i] (default, when split.guide = NULL).
 #'  Only supported for `stabilie.splits = FALSE`.
 #' @param ci.group.size The forest will grow ci.group.size trees on each subsample.

--- a/r-package/grf/R/input_utilities.R
+++ b/r-package/grf/R/input_utilities.R
@@ -190,6 +190,7 @@ create_train_matrices <- function(X,
                                   survival.numerator = NULL,
                                   survival.denominator = NULL,
                                   censor = NULL,
+                                  split.guide.variable = NULL,
                                   sample.weights = FALSE) {
   default.data <- matrix(nrow = 0, ncol = 0)
   sparse.data <- new("dgCMatrix", Dim = c(0L, 0L))
@@ -219,6 +220,15 @@ create_train_matrices <- function(X,
     out[["censor.index"]] <- offset + 1
     offset <- offset + 1
   }
+  if (!is.null(split.guide.variable)) {
+    if (isFALSE(split.guide.variable)) {
+      out[["split.guide.index"]] <- -1
+      split.guide.variable <- NULL
+    } else {
+      out[["split.guide.index"]] <- offset + 1
+      offset <- offset + 1
+    }
+  }
   # Forest bindings without sample weights: sample.weights = FALSE
   # Forest bindings with sample weights:
   # -sample.weights = NULL if no weights passed
@@ -235,10 +245,10 @@ create_train_matrices <- function(X,
   }
 
   if (inherits(X, "dgCMatrix") && ncol(X) > 1) {
-    sparse.data <- cbind(X, outcome, treatment, instrument, survival.numerator, survival.denominator, censor, sample.weights)
+    sparse.data <- cbind(X, outcome, treatment, instrument, survival.numerator, survival.denominator, censor, split.guide.variable, sample.weights)
   } else {
     X <- as.matrix(X)
-    default.data <- as.matrix(cbind(X, outcome, treatment, instrument, survival.numerator, survival.denominator, censor, sample.weights))
+    default.data <- as.matrix(cbind(X, outcome, treatment, instrument, survival.numerator, survival.denominator, censor, split.guide.variable, sample.weights))
   }
   out[["train.matrix"]] <- default.data
   out[["sparse.train.matrix"]] <- sparse.data

--- a/r-package/grf/bindings/InstrumentalForestBindings.cpp
+++ b/r-package/grf/bindings/InstrumentalForestBindings.cpp
@@ -36,7 +36,7 @@ Rcpp::List instrumental_train(Rcpp::NumericMatrix train_matrix,
                               bool compute_oob_predictions,
                               unsigned int num_threads,
                               unsigned int seed) {
-  ForestTrainer trainer = instrumental_trainer(reduced_form_weight, stabilize_splits);
+  ForestTrainer trainer = instrumental_trainer(reduced_form_weight, stabilize_splits, 1);
 
   std::unique_ptr<Data> data = RcppUtilities::convert_data(train_matrix, sparse_train_matrix);
   data->set_outcome_index(outcome_index);

--- a/r-package/grf/bindings/InstrumentalForestBindings.cpp
+++ b/r-package/grf/bindings/InstrumentalForestBindings.cpp
@@ -36,7 +36,7 @@ Rcpp::List instrumental_train(Rcpp::NumericMatrix train_matrix,
                               bool compute_oob_predictions,
                               unsigned int num_threads,
                               unsigned int seed) {
-  ForestTrainer trainer = instrumental_trainer(reduced_form_weight, stabilize_splits, 1);
+  ForestTrainer trainer = instrumental_trainer(reduced_form_weight, !stabilize_splits, 1);
 
   std::unique_ptr<Data> data = RcppUtilities::convert_data(train_matrix, sparse_train_matrix);
   data->set_outcome_index(outcome_index);

--- a/r-package/grf/bindings/MultiCausalForestBindings.cpp
+++ b/r-package/grf/bindings/MultiCausalForestBindings.cpp
@@ -33,11 +33,13 @@ Rcpp::List multi_causal_train(Rcpp::NumericMatrix train_matrix,
                               unsigned int seed) {
   size_t num_treatments = treatment_index.size();
   size_t num_outcomes = outcome_index.size();
-  ForestTrainer trainer = multi_causal_trainer(num_treatments, num_outcomes);
+  size_t response_length = num_treatments * num_outcomes;
+  ForestTrainer trainer = multi_causal_trainer(num_treatments, num_outcomes, response_length);
 
   std::unique_ptr<Data> data = RcppUtilities::convert_data(train_matrix, sparse_train_matrix);
   data->set_outcome_index(outcome_index);
   data->set_treatment_index(treatment_index);
+  data->set_response_length(response_length);
   if (use_sample_weights) {
     data->set_weight_index(sample_weight_index);
   }

--- a/r-package/grf/bindings/MultiRegressionForestBindings.cpp
+++ b/r-package/grf/bindings/MultiRegressionForestBindings.cpp
@@ -48,6 +48,7 @@ Rcpp::List multi_regression_train(Rcpp::NumericMatrix& train_matrix,
                                   unsigned int seed) {
   std::unique_ptr<Data> data = RcppUtilities::convert_data(train_matrix, sparse_train_matrix);
   data->set_outcome_index(outcome_index);
+  data->set_response_length(outcome_index.size());
   if (use_sample_weights) {
       data->set_weight_index(sample_weight_index);
   }

--- a/r-package/grf/man/causal_forest.Rd
+++ b/r-package/grf/man/causal_forest.Rd
@@ -105,6 +105,10 @@ Only applies if honesty is enabled. Default is TRUE.}
 \item{stabilize.splits}{Whether or not the treatment should be taken into account when
 determining the imbalance of a split. Default is TRUE.}
 
+\item{split.guide.variable}{Optional variable to include in splitting. If provided, the new regression splits at point i are
+are computed on [delta tau_i, split.guide_i] instead of on just [delta tau_i] (default, when split.guide = NULL).
+Only supported for `stabilie.splits = FALSE`.}
+
 \item{ci.group.size}{The forest will grow ci.group.size trees on each subsample.
 In order to provide confidence intervals, ci.group.size must
 be at least 2. Default is 2.}
@@ -132,10 +136,6 @@ The number of boosting steps is selected automatically. Default is FALSE.}
 to the maximum hardware concurrency.}
 
 \item{seed}{The seed of the C++ random number generator.}
-
-\item{split.guide}{Optional variable to include in splitting. If provided, the new regression splits at point i are
-are computed on [delta tau_i, split.guide_i] instead of on just [delta tau_i] (default, when split.guide = NULL).
-Only supported for `stabilie.splits = FALSE`.}
 }
 \value{
 A trained causal forest object. If tune.parameters is enabled,

--- a/r-package/grf/man/causal_forest.Rd
+++ b/r-package/grf/man/causal_forest.Rd
@@ -23,6 +23,7 @@ causal_forest(
   alpha = 0.05,
   imbalance.penalty = 0,
   stabilize.splits = TRUE,
+  split.guide.variable = NULL,
   ci.group.size = 2,
   tune.parameters = "none",
   tune.num.trees = 200,
@@ -131,6 +132,10 @@ The number of boosting steps is selected automatically. Default is FALSE.}
 to the maximum hardware concurrency.}
 
 \item{seed}{The seed of the C++ random number generator.}
+
+\item{split.guide}{Optional variable to include in splitting. If provided, the new regression splits at point i are
+are computed on [delta tau_i, split.guide_i] instead of on just [delta tau_i] (default, when split.guide = NULL).
+Only supported for `stabilie.splits = FALSE`.}
 }
 \value{
 A trained causal forest object. If tune.parameters is enabled,

--- a/r-package/grf/src/RcppExports.cpp
+++ b/r-package/grf/src/RcppExports.cpp
@@ -60,8 +60,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // causal_train
-Rcpp::List causal_train(Rcpp::NumericMatrix train_matrix, Eigen::SparseMatrix<double> sparse_train_matrix, size_t outcome_index, size_t treatment_index, size_t sample_weight_index, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double reduced_form_weight, double alpha, double imbalance_penalty, bool stabilize_splits, std::vector<size_t> clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, unsigned int num_threads, unsigned int seed);
-RcppExport SEXP _grf_causal_train(SEXP train_matrixSEXP, SEXP sparse_train_matrixSEXP, SEXP outcome_indexSEXP, SEXP treatment_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP ci_group_sizeSEXP, SEXP reduced_form_weightSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP stabilize_splitsSEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP compute_oob_predictionsSEXP, SEXP num_threadsSEXP, SEXP seedSEXP) {
+Rcpp::List causal_train(Rcpp::NumericMatrix train_matrix, Eigen::SparseMatrix<double> sparse_train_matrix, size_t outcome_index, size_t treatment_index, size_t sample_weight_index, int split_guide_index, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double reduced_form_weight, double alpha, double imbalance_penalty, bool stabilize_splits, std::vector<size_t> clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, unsigned int num_threads, unsigned int seed);
+RcppExport SEXP _grf_causal_train(SEXP train_matrixSEXP, SEXP sparse_train_matrixSEXP, SEXP outcome_indexSEXP, SEXP treatment_indexSEXP, SEXP sample_weight_indexSEXP, SEXP split_guide_indexSEXP, SEXP use_sample_weightsSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP ci_group_sizeSEXP, SEXP reduced_form_weightSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP stabilize_splitsSEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP compute_oob_predictionsSEXP, SEXP num_threadsSEXP, SEXP seedSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -70,6 +70,7 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< size_t >::type outcome_index(outcome_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type treatment_index(treatment_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type sample_weight_index(sample_weight_indexSEXP);
+    Rcpp::traits::input_parameter< int >::type split_guide_index(split_guide_indexSEXP);
     Rcpp::traits::input_parameter< bool >::type use_sample_weights(use_sample_weightsSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type mtry(mtrySEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_trees(num_treesSEXP);
@@ -88,7 +89,7 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type compute_oob_predictions(compute_oob_predictionsSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type seed(seedSEXP);
-    rcpp_result_gen = Rcpp::wrap(causal_train(train_matrix, sparse_train_matrix, outcome_index, treatment_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, reduced_form_weight, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed));
+    rcpp_result_gen = Rcpp::wrap(causal_train(train_matrix, sparse_train_matrix, outcome_index, treatment_index, sample_weight_index, split_guide_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, reduced_form_weight, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -838,7 +839,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_grf_compute_weights", (DL_FUNC) &_grf_compute_weights, 6},
     {"_grf_compute_weights_oob", (DL_FUNC) &_grf_compute_weights_oob, 4},
     {"_grf_merge", (DL_FUNC) &_grf_merge, 1},
-    {"_grf_causal_train", (DL_FUNC) &_grf_causal_train, 23},
+    {"_grf_causal_train", (DL_FUNC) &_grf_causal_train, 24},
     {"_grf_causal_predict", (DL_FUNC) &_grf_causal_predict, 9},
     {"_grf_causal_predict_oob", (DL_FUNC) &_grf_causal_predict_oob, 7},
     {"_grf_ll_causal_predict", (DL_FUNC) &_grf_ll_causal_predict, 12},

--- a/r-package/grf/tests/testthat/test_causal_forest.R
+++ b/r-package/grf/tests/testthat/test_causal_forest.R
@@ -377,3 +377,26 @@ test_that("a causal forest workflow with missing values works as expected", {
 
   expect_equal(which.max(varimp), 1)
 })
+
+test_that("split guide is...", {
+  n <- 500
+  p <- 5
+  X <- matrix(rnorm(n * p), n, p)
+  W <- rbinom(n, 1, 0.25 + 0.5 * (X[, 1] > 0))
+  Y <- pmax(X[, 1], 0) * W + X[, 2] + pmin(X[, 3], 0) + rnorm(n)
+
+  # internally consistent
+  cf <- causal_forest(X, Y, W, stabilize.splits = FALSE, seed = 42, num.trees = 250)
+  cf.guide.zero <- causal_forest(X, Y, W,
+     stabilize.splits = FALSE, split.guide.variable = rep(0, n), seed = 42, num.trees = 250)
+
+  expect_equal(predict(cf)$predictions, predict(cf.guide.zero)$predictions)
+
+  # sign doesnt matter
+  cf.plus <- causal_forest(X, Y, W,
+     stabilize.splits = FALSE, split.guide.variable = Y, seed = 42, num.trees = 250)
+  cf.minus <- causal_forest(X, Y, W,
+     stabilize.splits = FALSE, split.guide.variable = -Y, seed = 42, num.trees = 250)
+
+  expect_equal(predict(cf.plus)$predictions, predict(cf.minus)$predictions)
+})


### PR DESCRIPTION
(Just an experimental branch) Add option `split.guide.variable`, if added causal_forest splits on [delta tau_i, guide_i]. Only works with vector-valued regression splitting rule (i.e. stabilize.splits = FALSE). 

```
causal_forest(X, Y, W, split.guide.variable = 0.1 * Y.hat, stabilize.splits = FALSE)
```

To install
```
devtools::install_github("erikcs/grf", subdir = "r-package/grf", ref = "guided-split"))
```