### PR TITLE
Clarify `multi_arm_causal_forest` docstring

### DIFF
--- a/r-package/grf/R/multi_arm_causal_forest.R
+++ b/r-package/grf/R/multi_arm_causal_forest.R
@@ -154,6 +154,7 @@
 #' colnames(mu.hat.matrix) <- levels(W)
 #'
 #' # The average treatment effect of the arms with "A" as baseline.
+#' (in the event the forest is fit with multiple Ys, specify the response variable with the `outcome` argument)
 #' average_treatment_effect(mc.forest)
 #'
 #' # The reference level for contrast prediction can be changed with `relevel`.
@@ -351,6 +352,7 @@ multi_arm_causal_forest <- function(X, Y, W,
 #' colnames(mu.hat.matrix) <- levels(W)
 #'
 #' # The average treatment effect of the arms with "A" as baseline.
+#' (in the event the forest is fit with multiple Ys, specify the response variable with the `outcome` argument)
 #' average_treatment_effect(mc.forest)
 #'
 #' # The reference level for contrast prediction can be changed with `relevel`.

--- a/r-package/grf/R/multi_arm_causal_forest.R
+++ b/r-package/grf/R/multi_arm_causal_forest.R
@@ -130,6 +130,11 @@
 #' abline(0, -1.5, col = "red")
 #' legend("topleft", c("B - A", "C - A"), col = c("black", "blue"), pch = 19)
 #'
+#' # The average treatment effect of the arms with "A" as baseline.
+#' # (in the event the forest is fit with multiple Ys, specify the
+#' # response variable with the `outcome` argument)
+#' average_treatment_effect(mc.forest)
+#'
 #' # The conditional response surfaces mu_k(X) can be reconstructed from the
 #' # contrasts tau_k(x), the treatment propensities e_k(x), and the conditional mean m(x).
 #' # Given treatment "A" as baseline we have:
@@ -152,16 +157,12 @@
 #' Y.hat.baseline <- Y.hat - rowSums(W.hat[, -1] * tau.hat)
 #' mu.hat.matrix <- cbind(Y.hat.baseline, Y.hat.baseline + tau.hat)
 #' colnames(mu.hat.matrix) <- levels(W)
-#'
-#' # The average treatment effect of the arms with "A" as baseline.
-#' # (in the event the forest is fit with multiple Ys, specify the
-#' # response variable with the `outcome` argument)
-#' average_treatment_effect(mc.forest)
+#' head(mu.hat.matrix)
 #'
 #' # The reference level for contrast prediction can be changed with `relevel`.
-#' # Predict with treatment B as baseline:
+#' # Fit and predict with treatment B as baseline:
 #' W <- relevel(W, ref = "B")
-#' mc.forest <- multi_arm_causal_forest(X, Y, W)
+#' mc.forest.B <- multi_arm_causal_forest(X, Y, W)
 #' }
 #'
 #' @export
@@ -329,6 +330,11 @@ multi_arm_causal_forest <- function(X, Y, W,
 #' abline(0, -1.5, col = "red")
 #' legend("topleft", c("B - A", "C - A"), col = c("black", "blue"), pch = 19)
 #'
+#' # The average treatment effect of the arms with "A" as baseline.
+#' # (in the event the forest is fit with multiple Ys, specify the
+#' # response variable with the `outcome` argument)
+#' average_treatment_effect(mc.forest)
+#'
 #' # The conditional response surfaces mu_k(X) can be reconstructed from the
 #' # contrasts tau_k(x), the treatment propensities e_k(x), and the conditional mean m(x).
 #' # Given treatment "A" as baseline we have:
@@ -351,16 +357,12 @@ multi_arm_causal_forest <- function(X, Y, W,
 #' Y.hat.baseline <- Y.hat - rowSums(W.hat[, -1] * tau.hat)
 #' mu.hat.matrix <- cbind(Y.hat.baseline, Y.hat.baseline + tau.hat)
 #' colnames(mu.hat.matrix) <- levels(W)
-#'
-#' # The average treatment effect of the arms with "A" as baseline.
-#' # (in the event the forest is fit with multiple Ys, specify the
-#' # response variable with the `outcome` argument)
-#' average_treatment_effect(mc.forest)
+#' head(mu.hat.matrix)
 #'
 #' # The reference level for contrast prediction can be changed with `relevel`.
-#' # Predict with treatment B as baseline:
+#' # Fit and predict with treatment B as baseline:
 #' W <- relevel(W, ref = "B")
-#' mc.forest <- multi_arm_causal_forest(X, Y, W)
+#' mc.forest.B <- multi_arm_causal_forest(X, Y, W)
 #' }
 #'
 #' @method predict multi_arm_causal_forest

--- a/r-package/grf/R/multi_arm_causal_forest.R
+++ b/r-package/grf/R/multi_arm_causal_forest.R
@@ -154,7 +154,8 @@
 #' colnames(mu.hat.matrix) <- levels(W)
 #'
 #' # The average treatment effect of the arms with "A" as baseline.
-#' (in the event the forest is fit with multiple Ys, specify the response variable with the `outcome` argument)
+#' # (in the event the forest is fit with multiple Ys, specify the
+#' # response variable with the `outcome` argument)
 #' average_treatment_effect(mc.forest)
 #'
 #' # The reference level for contrast prediction can be changed with `relevel`.
@@ -352,7 +353,8 @@ multi_arm_causal_forest <- function(X, Y, W,
 #' colnames(mu.hat.matrix) <- levels(W)
 #'
 #' # The average treatment effect of the arms with "A" as baseline.
-#' (in the event the forest is fit with multiple Ys, specify the response variable with the `outcome` argument)
+#' # (in the event the forest is fit with multiple Ys, specify the
+#' # response variable with the `outcome` argument)
 #' average_treatment_effect(mc.forest)
 #'
 #' # The reference level for contrast prediction can be changed with `relevel`.

--- a/r-package/grf/man/multi_arm_causal_forest.Rd
+++ b/r-package/grf/man/multi_arm_causal_forest.Rd
@@ -200,6 +200,7 @@ mu.hat.matrix <- cbind(Y.hat.baseline, Y.hat.baseline + tau.hat)
 colnames(mu.hat.matrix) <- levels(W)
 
 # The average treatment effect of the arms with "A" as baseline.
+(in the event the forest is fit with multiple Ys, specify the response variable with the `outcome` argument)
 average_treatment_effect(mc.forest)
 
 # The reference level for contrast prediction can be changed with `relevel`.

--- a/r-package/grf/man/multi_arm_causal_forest.Rd
+++ b/r-package/grf/man/multi_arm_causal_forest.Rd
@@ -200,7 +200,8 @@ mu.hat.matrix <- cbind(Y.hat.baseline, Y.hat.baseline + tau.hat)
 colnames(mu.hat.matrix) <- levels(W)
 
 # The average treatment effect of the arms with "A" as baseline.
-(in the event the forest is fit with multiple Ys, specify the response variable with the `outcome` argument)
+# (in the event the forest is fit with multiple Ys, specify the
+# response variable with the `outcome` argument)
 average_treatment_effect(mc.forest)
 
 # The reference level for contrast prediction can be changed with `relevel`.

--- a/r-package/grf/man/multi_arm_causal_forest.Rd
+++ b/r-package/grf/man/multi_arm_causal_forest.Rd
@@ -176,6 +176,11 @@ points(X[, 2], tau.hat[, "C - A"], col = "blue")
 abline(0, -1.5, col = "red")
 legend("topleft", c("B - A", "C - A"), col = c("black", "blue"), pch = 19)
 
+# The average treatment effect of the arms with "A" as baseline.
+# (in the event the forest is fit with multiple Ys, specify the
+# response variable with the `outcome` argument)
+average_treatment_effect(mc.forest)
+
 # The conditional response surfaces mu_k(X) can be reconstructed from the
 # contrasts tau_k(x), the treatment propensities e_k(x), and the conditional mean m(x).
 # Given treatment "A" as baseline we have:
@@ -198,16 +203,12 @@ muC <- Y.hat - W.hat[, "B"] * tau.hat[, "B - A"] + (1 - W.hat[, "C"]) * tau.hat[
 Y.hat.baseline <- Y.hat - rowSums(W.hat[, -1] * tau.hat)
 mu.hat.matrix <- cbind(Y.hat.baseline, Y.hat.baseline + tau.hat)
 colnames(mu.hat.matrix) <- levels(W)
-
-# The average treatment effect of the arms with "A" as baseline.
-# (in the event the forest is fit with multiple Ys, specify the
-# response variable with the `outcome` argument)
-average_treatment_effect(mc.forest)
+head(mu.hat.matrix)
 
 # The reference level for contrast prediction can be changed with `relevel`.
-# Predict with treatment B as baseline:
+# Fit and predict with treatment B as baseline:
 W <- relevel(W, ref = "B")
-mc.forest <- multi_arm_causal_forest(X, Y, W)
+mc.forest.B <- multi_arm_causal_forest(X, Y, W)
 }
 
 }

--- a/r-package/grf/man/predict.multi_arm_causal_forest.Rd
+++ b/r-package/grf/man/predict.multi_arm_causal_forest.Rd
@@ -89,6 +89,7 @@ mu.hat.matrix <- cbind(Y.hat.baseline, Y.hat.baseline + tau.hat)
 colnames(mu.hat.matrix) <- levels(W)
 
 # The average treatment effect of the arms with "A" as baseline.
+(in the event the forest is fit with multiple Ys, specify the response variable with the `outcome` argument)
 average_treatment_effect(mc.forest)
 
 # The reference level for contrast prediction can be changed with `relevel`.

--- a/r-package/grf/man/predict.multi_arm_causal_forest.Rd
+++ b/r-package/grf/man/predict.multi_arm_causal_forest.Rd
@@ -65,6 +65,11 @@ points(X[, 2], tau.hat[, "C - A"], col = "blue")
 abline(0, -1.5, col = "red")
 legend("topleft", c("B - A", "C - A"), col = c("black", "blue"), pch = 19)
 
+# The average treatment effect of the arms with "A" as baseline.
+# (in the event the forest is fit with multiple Ys, specify the
+# response variable with the `outcome` argument)
+average_treatment_effect(mc.forest)
+
 # The conditional response surfaces mu_k(X) can be reconstructed from the
 # contrasts tau_k(x), the treatment propensities e_k(x), and the conditional mean m(x).
 # Given treatment "A" as baseline we have:
@@ -87,16 +92,12 @@ muC <- Y.hat - W.hat[, "B"] * tau.hat[, "B - A"] + (1 - W.hat[, "C"]) * tau.hat[
 Y.hat.baseline <- Y.hat - rowSums(W.hat[, -1] * tau.hat)
 mu.hat.matrix <- cbind(Y.hat.baseline, Y.hat.baseline + tau.hat)
 colnames(mu.hat.matrix) <- levels(W)
-
-# The average treatment effect of the arms with "A" as baseline.
-# (in the event the forest is fit with multiple Ys, specify the
-# response variable with the `outcome` argument)
-average_treatment_effect(mc.forest)
+head(mu.hat.matrix)
 
 # The reference level for contrast prediction can be changed with `relevel`.
-# Predict with treatment B as baseline:
+# Fit and predict with treatment B as baseline:
 W <- relevel(W, ref = "B")
-mc.forest <- multi_arm_causal_forest(X, Y, W)
+mc.forest.B <- multi_arm_causal_forest(X, Y, W)
 }
 
 }

--- a/r-package/grf/man/predict.multi_arm_causal_forest.Rd
+++ b/r-package/grf/man/predict.multi_arm_causal_forest.Rd
@@ -89,7 +89,8 @@ mu.hat.matrix <- cbind(Y.hat.baseline, Y.hat.baseline + tau.hat)
 colnames(mu.hat.matrix) <- levels(W)
 
 # The average treatment effect of the arms with "A" as baseline.
-(in the event the forest is fit with multiple Ys, specify the response variable with the `outcome` argument)
+# (in the event the forest is fit with multiple Ys, specify the
+# response variable with the `outcome` argument)
 average_treatment_effect(mc.forest)
 
 # The reference level for contrast prediction can be changed with `relevel`.


### PR DESCRIPTION
Minor clarity improvement:
* Mention `average_treatment_effect` outcome argument in multi_arm_causal_forest docstring
* Move the detailed contrast example to end of docstring
