### PR TITLE
Add R test that regression/multi_regression are the same

### DIFF
--- a/core/src/splitting/MultiRegressionSplittingRule.h
+++ b/core/src/splitting/MultiRegressionSplittingRule.h
@@ -24,6 +24,11 @@
 
 namespace grf {
 
+/**
+ * This splitting rule is identical to `RegressionSplittingRule` with the extension
+ * that it allows for splits on vector valued Y (responses_by_sample) by considering
+ * the squared L2 norm of the response sums.
+*/
 class MultiRegressionSplittingRule final: public SplittingRule {
 public:
   MultiRegressionSplittingRule(size_t max_num_unique_values,

--- a/r-package/grf/tests/testthat/test_multi_regression_forest.R
+++ b/r-package/grf/tests/testthat/test_multi_regression_forest.R
@@ -68,6 +68,23 @@ test_that("multi_regression_forest is similar to two regression_forest", {
   expect_true(diff2 < 0.01)
 })
 
+test_that("multi_regression_forest is on parity with regression_forest", {
+  # Test that the R package implementation keeps a multi regression forest with one outcome
+  # identical to a regression forest.
+  n <- 500
+  p <- 5
+  X <- matrix(rnorm(n * p), n, p)
+  Y <-  X[, 1] * rnorm(n)
+  nmissing <- sample(c(1, 150, 400), size = 1)
+  X[cbind(sample(1:n, nmissing), sample(1:p, nmissing, replace = TRUE))] <- NaN
+
+  mrf <- multi_regression_forest(X, Y, num.trees = 500, seed = 42)
+  rf <- regression_forest(X, Y, num.trees = 500, ci.group.size = 1, seed = 42)
+
+  expect_equal(predict(mrf)$predictions[,], predict(rf)$predictions)
+  expect_equal(predict(mrf, X)$predictions[,], predict(rf, X)$predictions)
+})
+
 test_that("multi_regression_forest is well calibrated", {
   n <- 250
   p <- 25


### PR DESCRIPTION
The current C++ tests already lock in this behavior, but should have the same test in place in R as well to prevent an _unintentional_ change in R bindings/package to cause a regression forest to give slightly different results from a multi regression forest with one outcome. 