### PR TITLE
Extend probability forest test coverage

### DIFF
--- a/r-package/grf/tests/testthat/test_regression_forest.R
+++ b/r-package/grf/tests/testthat/test_regression_forest.R
@@ -203,7 +203,7 @@ test_that("inverse propensity weighting in the training of a regression forest w
   expect_true(ipw.mse.forest.weighted < ipw.mse.forest)
 })
 
-test_that("sample weighting is identical to replicating samples", {
+test_that("sample weighted regression forest is identical to replicating samples", {
   # To make these forests comparable sample.fraction has to be 1 to draw the same samples
   # and min.node.size 1 for the split stopping condition to be the same.
   n <- 500


### PR DESCRIPTION
Just adding one more test: that sample weighting is identical to replicating samples.