### PR TITLE
Return `unname(tau.hat)` in `average_treatment_effect` 

### DIFF
--- a/r-package/grf/R/average_treatment_effect.R
+++ b/r-package/grf/R/average_treatment_effect.R
@@ -438,5 +438,5 @@ average_treatment_effect <- function(forest,
 
   tau.avg <- tau.avg.raw + dr.correction
   tau.se <- sqrt(tau.avg.var + sigma2.hat)
-  return(c(estimate = tau.avg, std.err = tau.se))
+  return(c(estimate = unname(tau.avg), std.err = tau.se))
 }


### PR DESCRIPTION
With option `TMLE` the returned vector name is `estimate.1` instead of `estimate`. `unname` the object for consistency before returning. Minor CC @swager

```R
> p <- 6
> n <- 2000
> X <- matrix(2 * runif(n * p) - 1, n, p)
> eX <- 0.25 + 0.5 * (X[, 1] > 0)
> W <- rbinom(n, 1, eX)
> TAU <- 4 * (X[, 1] > 0)
> Y <- TAU * (W - 0.5) + rnorm(n)
> forest.causal <- causal_forest(X, Y, W, num.trees = 500)

> average_treatment_effect(forest.causal, target.sample = "all", method = "AIPW")
  estimate    std.err 
2.11521382 0.07102092 

> average_treatment_effect(forest.causal, target.sample = "all", method = "TMLE")
estimate.1    std.err 
2.11394668 0.06854403 
```