### PR TITLE
Use `expect_equal` in `test_average_effect.R`

### DIFF
--- a/r-package/grf/tests/testthat/test_average_effect.R
+++ b/r-package/grf/tests/testthat/test_average_effect.R
@@ -40,7 +40,7 @@ test_that("average effects are translation invariant", {
 
   wate <- average_treatment_effect(forest.causal, target.sample = "overlap")
   wate.plus.1 <- average_treatment_effect(forest.causal.plus.1, target.sample = "overlap")
-  expect_true(abs(wate[1] - wate.plus.1[1]) <= 0.006)
+  expect_equal(wate[1], wate.plus.1[1], tolerance = 0.006)
 
   # Now test this in "average partial effect" mode. Add some fuzz to the treatments
   # so the "continuous treatment" code path is triggered. However, first cache
@@ -69,43 +69,43 @@ test_that("average treatment effect estimates are reasonable", {
   forest.causal <- causal_forest(X, Y, W, num.trees = 500, ci.group.size = 1)
 
   cate.aipw <- average_treatment_effect(forest.causal, target.sample = "all", method = "AIPW")
-  expect_true(abs(cate.aipw[1] - mean(TAU)) <= 0.2)
-  expect_true(abs(cate.aipw[1] - mean(TAU)) <= 3 * cate.aipw[2])
+  expect_equal(cate.aipw[[1]], mean(TAU), tolerance = 0.2)
+  expect_equal(cate.aipw[[1]], mean(TAU), tolerance = 3 * cate.aipw[2])
 
   cate.tmle <- average_treatment_effect(forest.causal, target.sample = "all", method = "TMLE")
-  expect_true(abs(cate.tmle[1] - mean(TAU)) <= 0.2)
-  expect_true(abs(cate.tmle[1] - mean(TAU)) <= 3 * cate.tmle[2])
+  expect_equal(cate.tmle[[1]], mean(TAU), tolerance = 0.2)
+  expect_equal(cate.tmle[[1]], mean(TAU), tolerance = 3 * cate.tmle[2])
 
-  expect_true(abs(cate.aipw[1] - cate.tmle[1]) <= 0.01)
-  expect_true(abs(cate.aipw[2] - cate.tmle[2]) <= 0.01)
+  expect_equal(cate.aipw[1], cate.tmle[1], tolerance = 0.01)
+  expect_equal(cate.aipw[2], cate.tmle[2], tolerance = 0.01)
 
   catt.aipw <- average_treatment_effect(forest.causal, target.sample = "treated", method = "AIPW")
-  expect_true(abs(catt.aipw[1] - mean(TAU[W == 1])) <= 0.2)
-  expect_true(abs(catt.aipw[1] - mean(TAU[W == 1])) <= 3 * catt.aipw[2])
+  expect_equal(catt.aipw[[1]], mean(TAU[W == 1]), tolerance = 0.2)
+  expect_equal(catt.aipw[[1]], mean(TAU[W == 1]), tolerance = 3 * catt.aipw[2])
 
   catt.tmle <- average_treatment_effect(forest.causal, target.sample = "treated", method = "TMLE")
-  expect_true(abs(catt.tmle[1] - mean(TAU[W == 1])) <= 0.2)
-  expect_true(abs(catt.tmle[1] - mean(TAU[W == 1])) <= 3 * catt.tmle[2])
+  expect_equal(catt.tmle[[1]], mean(TAU[W == 1]), tolerance = 0.2)
+  expect_equal(catt.tmle[[1]], mean(TAU[W == 1]), tolerance = 3 * catt.tmle[2])
 
-  expect_true(abs(catt.aipw[1] - catt.tmle[1]) <= 0.05)
-  expect_true(abs(catt.aipw[2] - catt.tmle[2]) <= 0.05)
+  expect_equal(catt.aipw[1], catt.tmle[1], tolerance = 0.05)
+  expect_equal(catt.aipw[2], catt.tmle[2], tolerance = 0.05)
 
   catc.aipw <- average_treatment_effect(forest.causal, target.sample = "control", method = "AIPW")
-  expect_true(abs(catc.aipw[1] - mean(TAU[W == 0])) <= 0.25)
-  expect_true(abs(catc.aipw[1] - mean(TAU[W == 0])) <= 3 * catc.aipw[2])
+  expect_equal(catc.aipw[[1]], mean(TAU[W == 0]), tolerance = 0.25)
+  expect_equal(catc.aipw[[1]], mean(TAU[W == 0]), tolerance = 3 * catc.aipw[2])
 
   catc.tmle <- average_treatment_effect(forest.causal, target.sample = "control", method = "TMLE")
-  expect_true(abs(catc.tmle[1] - mean(TAU[W == 0])) <= 0.25)
-  expect_true(abs(catc.tmle[1] - mean(TAU[W == 0])) <= 3 * catc.tmle[2])
+  expect_equal(catc.tmle[[1]], mean(TAU[W == 0]), tolerance = 0.25)
+  expect_equal(catc.tmle[[1]], mean(TAU[W == 0]), tolerance = 3 * catc.tmle[2])
 
-  expect_true(abs(catc.aipw[1] - catc.tmle[1]) <= 0.05)
-  expect_true(abs(catc.aipw[2] - catc.tmle[2]) <= 0.05)
+  expect_equal(catc.aipw[1], catc.tmle[1], tolerance = 0.05)
+  expect_equal(catc.aipw[2], catc.tmle[2], tolerance = 0.05)
 
   cape.nocal <- average_treatment_effect(forest.causal)
-  expect_true(abs(cape.nocal[1] - mean(TAU)) <= 0.2)
-  expect_true(abs(cape.nocal[1] - mean(TAU)) <= 3 * cape.nocal[2])
-  expect_true(abs(cate.aipw[1] - cape.nocal[1]) <= 0.05)
-  expect_true(abs(cate.aipw[2] - cape.nocal[2]) <= 0.05)
+  expect_equal(cape.nocal[[1]], mean(TAU), tolerance = 0.2)
+  expect_equal(cape.nocal[[1]], mean(TAU), tolerance = 3 * cape.nocal[2])
+  expect_equal(cate.aipw[1], cape.nocal[1], tolerance = 0.05)
+  expect_equal(cate.aipw[2], cape.nocal[2], tolerance = 0.05)
 
   # The calibration option was eliminated after version 1.2.0.
   # cape.cal <- average_treatment_effect(forest.causal, calibrate.weights = TRUE)
@@ -116,8 +116,8 @@ test_that("average treatment effect estimates are reasonable", {
 
   wate <- average_treatment_effect(forest.causal, target.sample = "overlap")
   tau.overlap <- sum(eX * (1 - eX) * TAU) / sum(eX * (1 - eX))
-  expect_true(abs(wate[1] - tau.overlap) <= 0.2)
-  expect_true(abs(wate[1] - tau.overlap) <= 3 * wate[2])
+  expect_equal(wate[[1]], tau.overlap, tolerance = 0.2)
+  expect_equal(wate[[1]], tau.overlap, tolerance = 3 * wate[2])
 
   cate.aipw.pos <- average_treatment_effect(forest.causal,
     target.sample = "all",

--- a/r-package/grf/tests/testthat/test_average_effect.R
+++ b/r-package/grf/tests/testthat/test_average_effect.R
@@ -137,11 +137,11 @@ test_that("average treatment effect estimates are reasonable", {
   )
   wate.pos <- average_treatment_effect(forest.causal, target.sample = "overlap", subset = X[, 1] > 0)
 
-  expect_true(abs(cate.aipw.pos[1] - 4) < 0.2)
-  expect_true(abs(cate.tmle.pos[1] - 4) < 0.2)
-  expect_true(abs(cate.aipw.pos.treat[1] - 4) < 0.2)
-  expect_true(abs(cate.tmle.pos.control[1] - 4) < 0.3)
-  expect_true(abs(wate.pos[1] - 4) < 0.2)
+  expect_equal(cate.aipw.pos[[1]], 4, tolerance = 0.2)
+  expect_equal(cate.tmle.pos[[1]], 4, tolerance = 0.2)
+  expect_equal(cate.aipw.pos.treat[[1]], 4, tolerance = 0.2)
+  expect_equal(cate.tmle.pos.control[[1]], 4, tolerance = 0.3)
+  expect_equal(wate.pos[[1]], 4, tolerance = 0.2)
 })
 
 test_that("average partial effect estimates are reasonable", {
@@ -157,7 +157,7 @@ test_that("average partial effect estimates are reasonable", {
     ci.group.size = 1, clusters = rep(1:(n / 2), 2)
   )
   cape.pos <- average_treatment_effect(forest.causal, subset = X[, 1] > 0)
-  expect_true(abs(cape.pos["estimate"] - 4) < 0.1)
+  expect_equal(cape.pos[["estimate"]], 4, tolerance = 0.1)
 })
 
 test_that("average treatment effects larger example works", {
@@ -174,22 +174,22 @@ test_that("average treatment effects larger example works", {
   forest.causal <- causal_forest(X, Y, W, num.trees = 1000, ci.group.size = 1)
 
   cate.aipw <- average_treatment_effect(forest.causal, target.sample = "all", method = "AIPW")
-  expect_true(abs(cate.aipw[1] - mean(TAU)) <= 3 * cate.aipw[2])
+  expect_equal(cate.aipw[[1]], mean(TAU), tolerance = 3 * cate.aipw[2])
 
   cate.tmle <- average_treatment_effect(forest.causal, target.sample = "all", method = "TMLE")
-  expect_true(abs(cate.tmle[1] - mean(TAU)) <= 3 * cate.tmle[2])
+  expect_equal(cate.tmle[[1]], mean(TAU), tolerance = 3 * cate.tmle[2])
 
   catt.aipw <- average_treatment_effect(forest.causal, target.sample = "treated", method = "AIPW")
-  expect_true(abs(catt.aipw[1] - mean(TAU[W == 1])) <= 3 * catt.aipw[2])
+  expect_equal(catt.aipw[[1]], mean(TAU[W == 1]), tolerance = 3 * catt.aipw[2])
 
   catt.tmle <- average_treatment_effect(forest.causal, target.sample = "treated", method = "TMLE")
-  expect_true(abs(catt.tmle[1] - mean(TAU[W == 1])) <= 3 * catt.tmle[2])
+  expect_equal(catt.tmle[[1]], mean(TAU[W == 1]), tolerance = 3 * catt.tmle[2])
 
   catc.aipw <- average_treatment_effect(forest.causal, target.sample = "control", method = "AIPW")
-  expect_true(abs(catc.aipw[1] - mean(TAU[W == 0])) <= 3 * catc.aipw[2])
+  expect_equal(catc.aipw[[1]], mean(TAU[W == 0]), tolerance = 3 * catc.aipw[2])
 
   catc.tmle <- average_treatment_effect(forest.causal, target.sample = "control", method = "TMLE")
-  expect_true(abs(catc.tmle[1] - mean(TAU[W == 0])) <= 3 * catc.tmle[2])
+  expect_equal(catc.tmle[[1]], mean(TAU[W == 0]), tolerance = 3 * catc.tmle[2])
 })
 
 test_that("average partial effects larger example works", {
@@ -206,8 +206,8 @@ test_that("average partial effects larger example works", {
   forest.causal <- causal_forest(X, Y, W, num.trees = 1000, ci.group.size = 1)
 
   cape <- average_treatment_effect(forest.causal)
-  expect_true(abs(cape[1] - mean(TAU)) <= 0.2)
-  expect_true(abs(cape[1] - mean(TAU)) <= 3 * cape[2])
+  expect_equal(cape[[1]],  mean(TAU), tolerance = 0.2)
+  expect_equal(cape[[1]], mean(TAU), tolerance = 3 * cape[2])
 })
 
 test_that("average treatment effect with overlap: larger example works", {
@@ -225,8 +225,8 @@ test_that("average treatment effect with overlap: larger example works", {
 
   wate <- average_treatment_effect(forest.causal, target.sample = "overlap")
   tau.overlap <- sum(eX * (1 - eX) * TAU) / sum(eX * (1 - eX))
-  expect_true(abs(wate[1] - tau.overlap) <= 0.2)
-  expect_true(abs(wate[1] - tau.overlap) <= 3 * wate[2])
+  expect_equal(wate[[1]], tau.overlap, tolerance = 0.2)
+  expect_equal(wate[[1]], tau.overlap, tolerance = 3 * wate[2])
 })
 
 test_that("cluster robust average effects are consistent", {
@@ -250,28 +250,28 @@ test_that("cluster robust average effects are consistent", {
 
   cate.aipw <- average_treatment_effect(forest.causal, target.sample = "all", method = "AIPW")
   cate.clust.aipw <- average_treatment_effect(forest.causal.clust, target.sample = "all", method = "AIPW")
-  expect_true(abs(cate.aipw[1] - cate.clust.aipw[1]) <= 0.05)
-  expect_true(abs(cate.aipw[2] - cate.clust.aipw[2]) <= 0.008)
+  expect_equal(cate.aipw[1], cate.clust.aipw[1], tolerance = 0.05)
+  expect_equal(cate.aipw[2], cate.clust.aipw[2], tolerance = 0.008)
 
   catt.aipw <- average_treatment_effect(forest.causal, target.sample = "treated", method = "AIPW")
   catt.clust.aipw <- average_treatment_effect(forest.causal.clust, target.sample = "treated", method = "AIPW")
-  expect_true(abs(catt.aipw[1] - catt.clust.aipw[1]) <= 0.05)
-  expect_true(abs(catt.aipw[2] - catt.clust.aipw[2]) <= 0.008)
+  expect_equal(catt.aipw[1], catt.clust.aipw[1], tolerance = 0.05)
+  expect_equal(catt.aipw[2], catt.clust.aipw[2], tolerance = 0.008)
 
   catc.aipw <- average_treatment_effect(forest.causal, target.sample = "control", method = "AIPW")
   catc.clust.aipw <- average_treatment_effect(forest.causal.clust, target.sample = "control", method = "AIPW")
-  expect_true(abs(catc.aipw[1] - catc.clust.aipw[1]) <= 0.05)
-  expect_true(abs(catc.aipw[2] - catc.clust.aipw[2]) <= 0.008)
+  expect_equal(catc.aipw[1], catc.clust.aipw[1], tolerance = 0.05)
+  expect_equal(catc.aipw[2], catc.clust.aipw[2], tolerance = 0.008)
 
   cape <- average_treatment_effect(forest.causal, num.trees.for.weights = 200)
   cape.clust <- average_treatment_effect(forest.causal.clust, num.trees.for.weights = 200)
-  expect_true(abs(cape[1] - cape.clust[1]) <= 0.05)
-  expect_true(abs(cape[2] - cape.clust[2]) <= 0.005)
+  expect_equal(cape[1], cape.clust[1], tolerance = 0.05)
+  expect_equal(cape[2], cape.clust[2], tolerance = 0.005)
 
   wate <- average_treatment_effect(forest.causal, target.sample = "overlap")
   wate.clust <- average_treatment_effect(forest.causal.clust, target.sample = "overlap")
-  expect_true(abs(wate[1] - wate.clust[1]) <= 0.05)
-  expect_true(abs(wate[2] - wate.clust[2]) <= 0.005)
+  expect_equal(wate[1], wate.clust[1], tolerance = 0.05)
+  expect_equal(wate[2], wate.clust[2], tolerance = 0.005)
 })
 
 test_that("cluster robust average effects do weighting correctly", {

--- a/r-package/grf/tests/testthat/test_probability_forest.R
+++ b/r-package/grf/tests/testthat/test_probability_forest.R
@@ -75,13 +75,13 @@ test_that("sample weighted probability forest is invariant to scaling", {
   p1 <- predict(pf)
   p2 <- predict(pf2)
 
-  expect_true(all(p1$predictions - p2$predictions == 0))
+  expect_equal(p1$predictions, p2$predictions)
 
   # Variance estimates are invariant to sample weight scaling
   v1 <- predict(pf, estimate.variance = TRUE)
   v2 <- predict(pf2, estimate.variance = TRUE)
 
-  expect_true(all(v1$variance.estimates - v2$variance.estimates == 0))
+  expect_equal(v1$variance.estimates, v2$variance.estimates)
 })
 
 test_that("sample weighted probability forest improves complete-data MSE", {

--- a/r-package/grf/tests/testthat/test_regression_forest.R
+++ b/r-package/grf/tests/testthat/test_regression_forest.R
@@ -231,9 +231,7 @@ test_that("sample weighting is identical to replicating samples", {
                                           honesty = FALSE,
                                           ci.group.size = 1,
                                           seed = 123)
-  diff.abs <- abs(predict(rf.weighted, XX)$predictions - predict(rf.duplicated.data, XX)$predictions)
-
-  expect_equal(all(diff.abs == 0), TRUE)
+  expect_equal(predict(rf.weighted, XX)$predictions, predict(rf.duplicated.data, XX)$predictions)
 })
 
 test_that("a non-pruned honest regression forest has lower MSE than a pruned honest regression forests
@@ -250,7 +248,7 @@ test_that("a non-pruned honest regression forest has lower MSE than a pruned hon
   mse.notpruned <- mean((predict(f2)$predictions - Y)^2)
 
   # Upper bound of 65 % is based on 10 000 repetitions of the above DGP
-  expect_true(mse.notpruned < 0.65 * mse.pruned)
+  expect_lt(mse.notpruned / mse.pruned, 0.65)
 })
 
 test_that("regression_forest works as expected with missing values", {


### PR DESCRIPTION
Some minor housekeeping towards #722.

Some tests swap out `[` with `[[` because `expect_equal` expects the names of the objects compared to be the same.

(+two minor expect_equal polishes in other test cases, more can be done in separate PRs)