### PR TITLE
Consistent sample.weight docstring in probability_forest

### DIFF
--- a/r-package/grf/R/probability_forest.R
+++ b/r-package/grf/R/probability_forest.R
@@ -8,7 +8,7 @@
 #' @param num.trees Number of trees grown in the forest. Note: Getting accurate
 #'                  confidence intervals generally requires more trees than
 #'                  getting accurate predictions. Default is 2000.
-#' @param sample.weights Weights given to an observation in prediction.
+#' @param sample.weights Weights given to an observation in estimation.
 #'                       If NULL, each observation is given the same weight. Default is NULL.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
 #'  Default is NULL (ignored).

--- a/r-package/grf/man/probability_forest.Rd
+++ b/r-package/grf/man/probability_forest.Rd
@@ -34,7 +34,7 @@ probability_forest(
 confidence intervals generally requires more trees than
 getting accurate predictions. Default is 2000.}
 
-\item{sample.weights}{Weights given to an observation in prediction.
+\item{sample.weights}{Weights given to an observation in estimation.
 If NULL, each observation is given the same weight. Default is NULL.}
 
 \item{clusters}{Vector of integers or factors specifying which cluster each observation corresponds to.


### PR DESCRIPTION
Use same description as all forests doing sample weights in splitting+prediction.