### PR TITLE
Consistent docstring for ll.lambda 

### DIFF
--- a/r-package/grf/R/local_linear_forest.R
+++ b/r-package/grf/R/local_linear_forest.R
@@ -213,7 +213,7 @@ ll_regression_forest <- function(X, Y,
 #'                   We run a locally weighted linear regression on the included variables.
 #'                   Please note that this is a beta feature still in development, and may slow down
 #'                   prediction considerably. Defaults to NULL.
-#' @param ll.lambda Ridge penalty for local linear predictions
+#' @param ll.lambda Ridge penalty for local linear predictions. Defaults to NULL and will be cross-validated.
 #' @param ll.weight.penalty Option to standardize ridge penalty by covariance (TRUE),
 #'                            or penalize all covariates equally (FALSE). Defaults to FALSE.
 #' @param num.threads Number of threads used in training. If set to NULL, the software

--- a/r-package/grf/R/regression_forest.R
+++ b/r-package/grf/R/regression_forest.R
@@ -197,7 +197,7 @@ regression_forest <- function(X, Y,
 #'                   we run a locally weighted linear regression on the included variables.
 #'                   Please note that this is a beta feature still in development, and may slow down
 #'                   prediction considerably. Defaults to NULL.
-#' @param ll.lambda Ridge penalty for local linear predictions
+#' @param ll.lambda Ridge penalty for local linear predictions. Defaults to NULL and will be cross-validated.
 #' @param ll.weight.penalty Option to standardize ridge penalty by covariance (TRUE),
 #'                            or penalize all covariates equally (FALSE). Defaults to FALSE.
 #' @param num.threads Number of threads used in training. If set to NULL, the software

--- a/r-package/grf/man/predict.ll_regression_forest.Rd
+++ b/r-package/grf/man/predict.ll_regression_forest.Rd
@@ -30,7 +30,7 @@ We run a locally weighted linear regression on the included variables.
 Please note that this is a beta feature still in development, and may slow down
 prediction considerably. Defaults to NULL.}
 
-\item{ll.lambda}{Ridge penalty for local linear predictions}
+\item{ll.lambda}{Ridge penalty for local linear predictions. Defaults to NULL and will be cross-validated.}
 
 \item{ll.weight.penalty}{Option to standardize ridge penalty by covariance (TRUE),
 or penalize all covariates equally (FALSE). Defaults to FALSE.}

--- a/r-package/grf/man/predict.regression_forest.Rd
+++ b/r-package/grf/man/predict.regression_forest.Rd
@@ -30,7 +30,7 @@ we run a locally weighted linear regression on the included variables.
 Please note that this is a beta feature still in development, and may slow down
 prediction considerably. Defaults to NULL.}
 
-\item{ll.lambda}{Ridge penalty for local linear predictions}
+\item{ll.lambda}{Ridge penalty for local linear predictions. Defaults to NULL and will be cross-validated.}
 
 \item{ll.weight.penalty}{Option to standardize ridge penalty by covariance (TRUE),
 or penalize all covariates equally (FALSE). Defaults to FALSE.}


### PR DESCRIPTION
Update @rinafriedberg's local linear forest to have the same argument description for `ll.lambda` across all forests (i.e. that it is tuned by default - copied from causal forests' local linear predict description).