### PR TITLE
Remove defunct PredictionValues.clear()

### DIFF
--- a/core/src/prediction/PredictionValues.cpp
+++ b/core/src/prediction/PredictionValues.cpp
@@ -55,10 +55,4 @@ const size_t PredictionValues::get_num_types() const {
   return num_types;
 }
 
-void PredictionValues::clear() {
-  num_nodes = 0;
-  num_types = 0;
-  values.clear();
-}
-
 } // namespace grf

--- a/core/src/prediction/PredictionValues.h
+++ b/core/src/prediction/PredictionValues.h
@@ -45,11 +45,6 @@ public:
   const size_t get_num_nodes() const;
   const size_t get_num_types() const;
 
-  /**
-   * Empties out all data in this object. Used to reduce memory
-   * usage when destructively iterating through a {@link Forest} object.
-   */
-  void clear();
 private:
   std::vector<std::vector<double>> values;
   size_t num_nodes;

--- a/r-package/grf/bindings/RcppUtilities.cpp
+++ b/r-package/grf/bindings/RcppUtilities.cpp
@@ -72,6 +72,7 @@ Rcpp::List RcppUtilities::serialize_forest(Forest& forest) {
   size_t num_types = 0;
 
   for (size_t t = 0; t < num_trees; t++) {
+    // Destructively iterate over the forest by moving the unique_ptr to each tree.
     std::unique_ptr<Tree> tree = std::move(forest.get_trees_().at(t));
     root_nodes[t] = tree->get_root_node();
     child_nodes[t] = tree->get_child_nodes();

--- a/r-package/grf/bindings/RcppUtilities.h
+++ b/r-package/grf/bindings/RcppUtilities.h
@@ -14,6 +14,10 @@ public:
    * Converts the provided {@link Forest} object and OOB predictions to an R list
    * to be returned through the Rcpp bindings. The provided predictions vector can
    * be present if OOB predictions were not requested as part of training.
+   *
+   * NOTE: To conserve memory, this method destructively modifies the forest
+   * object by clearing out individual {@link Tree} objects. The forest cannot
+   * be used once it has been passed to the method.
    */
   static Rcpp::List create_forest_object(Forest& forest,
                                          const std::vector<Prediction>& predictions);

--- a/r-package/grf/bindings/RcppUtilities.h
+++ b/r-package/grf/bindings/RcppUtilities.h
@@ -14,10 +14,6 @@ public:
    * Converts the provided {@link Forest} object and OOB predictions to an R list
    * to be returned through the Rcpp bindings. The provided predictions vector can
    * be present if OOB predictions were not requested as part of training.
-   *
-   * NOTE: To conserve memory, this method destructively modifies the forest
-   * object by clearing out individual {@link Tree} objects. The forest cannot
-   * be used once it has been passed to the method.
    */
   static Rcpp::List create_forest_object(Forest& forest,
                                          const std::vector<Prediction>& predictions);


### PR DESCRIPTION
Minor aesthetic: After #519 this method is not used anymore as there are no destructive iterations over forest objects.