### PR TITLE
Remove some variable definitions in causal_survival_forest

### DIFF
--- a/r-package/grf/R/causal_survival_forest.R
+++ b/r-package/grf/R/causal_survival_forest.R
@@ -277,7 +277,7 @@ causal_survival_forest <- function(X, Y, W, D,
   # The survival function conditioning on being treated S(t, x, 1) estimated with an "S-learner".
   if (is.null(E1.hat)) {
     sf.survival <- do.call(survival_forest, c(list(X = cbind(X, W), Y = Y, D = D), args.nuisance))
-    S1.failure.times <- S0.failure.times <- S.failure.times <- sf.survival$failure.times
+    S1.failure.times <- S0.failure.times <- sf.survival$failure.times
     # Computing OOB estimates for modified training samples is not a workflow we have implemented,
     # so we do it with a manual workaround here. Note that compute.oob.predictions has to be FALSE.
     X.orig <- sf.survival[["X.orig"]]
@@ -293,7 +293,7 @@ causal_survival_forest <- function(X, Y, W, D,
   if (is.null(E0.hat)) {
     if (!exists("sf.survival", inherits = FALSE)) {
       sf.survival <- do.call(survival_forest, c(list(X = cbind(X, W), Y = Y, D = D), args.nuisance))
-      S0.failure.times <- S.failure.times <- sf.survival$failure.times
+      S0.failure.times <- sf.survival$failure.times
     }
     X.orig <- sf.survival[["X.orig"]]
     sf.survival[["X.orig"]] <- cbind(X, rep(0, nrow(X)))
@@ -310,7 +310,6 @@ causal_survival_forest <- function(X, Y, W, D,
   if (is.null(S.hat)) {
     if (!exists("sf.survival", inherits = FALSE)) {
       sf.survival <- do.call(survival_forest, c(list(X = cbind(X, W), Y = Y, D = D), args.nuisance))
-      S.failure.times <- sf.survival$failure.times
     }
     # We want the predicted survival curves S.hat and C.hat on the common grid Y.grid:
     S.hat <- predict(sf.survival, failure.times = Y.grid)$predictions

--- a/r-package/grf/R/causal_survival_forest.R
+++ b/r-package/grf/R/causal_survival_forest.R
@@ -219,12 +219,11 @@ causal_survival_forest <- function(X, Y, W, D,
     Y.grid <- failure.times
   }
   Y.relabeled <- findInterval(Y, Y.grid)
-  num.events <- length(Y.grid)
   num.samples <- nrow(X)
-  if (num.events <= 2) {
+  if (length(Y.grid) <= 2) {
     stop("The number of distinct event times should be more than 2.")
   }
-  if (num.samples > 5000 && num.events / num.samples > 0.1) {
+  if (num.samples > 5000 && length(Y.grid) / num.samples > 0.1) {
     warning(paste0("The number of events are more than 10% of the sample size. ",
                    "To reduce the computational burden of fitting survival and ",
                    "censoring curves, consider rounding the event values `Y` or ",
@@ -318,7 +317,7 @@ causal_survival_forest <- function(X, Y, W, D,
     S.hat <- predict(sf.survival, failure.times = Y.grid)$predictions
   } else if (NROW(S.hat) != num.samples) {
     stop("S.hat has incorrect length.")
-  } else if (NCOL(S.hat) != num.events) {
+  } else if (NCOL(S.hat) != length(Y.grid)) {
     stop("S.hat has incorrect number of columns (should be equal to the number of events).")
   }
 
@@ -328,7 +327,7 @@ causal_survival_forest <- function(X, Y, W, D,
     C.hat <- predict(sf.censor, failure.times = Y.grid)$predictions
   } else if (NROW(C.hat) != num.samples) {
     stop("C.hat has incorrect length.")
-  } else if (NCOL(C.hat) != num.events) {
+  } else if (NCOL(C.hat) != length(Y.grid)) {
     stop("C.hat has incorrect number of columns (should be equal to the number of events).")
   }
 

--- a/r-package/grf/R/causal_survival_forest.R
+++ b/r-package/grf/R/causal_survival_forest.R
@@ -219,11 +219,10 @@ causal_survival_forest <- function(X, Y, W, D,
     Y.grid <- failure.times
   }
   Y.relabeled <- findInterval(Y, Y.grid)
-  num.samples <- nrow(X)
   if (length(Y.grid) <= 2) {
     stop("The number of distinct event times should be more than 2.")
   }
-  if (num.samples > 5000 && length(Y.grid) / num.samples > 0.1) {
+  if (nrow(X) > 5000 && length(Y.grid) / nrow(X) > 0.1) {
     warning(paste0("The number of events are more than 10% of the sample size. ",
                    "To reduce the computational burden of fitting survival and ",
                    "censoring curves, consider rounding the event values `Y` or ",
@@ -254,8 +253,8 @@ causal_survival_forest <- function(X, Y, W, D,
     forest.W <- do.call(regression_forest, args.orthog)
     W.hat <- predict(forest.W)$predictions
   } else if (length(W.hat) == 1) {
-    W.hat <- rep(W.hat, num.samples)
-  } else if (length(W.hat) != num.samples) {
+    W.hat <- rep(W.hat, nrow(X))
+  } else if (length(W.hat) != nrow(X)) {
     stop("W.hat has incorrect length.")
   }
   W.centered <- W - W.hat
@@ -282,11 +281,11 @@ causal_survival_forest <- function(X, Y, W, D,
     # Computing OOB estimates for modified training samples is not a workflow we have implemented,
     # so we do it with a manual workaround here. Note that compute.oob.predictions has to be FALSE.
     X.orig <- sf.survival[["X.orig"]]
-    sf.survival[["X.orig"]] <- cbind(X, rep(1, num.samples))
+    sf.survival[["X.orig"]] <- cbind(X, rep(1, nrow(X)))
     S1.hat <- predict(sf.survival)$predictions
     sf.survival[["X.orig"]] <- X.orig
     E1.hat <- expected_survival(S1.hat, S1.failure.times)
-  } else if (length(E1.hat) != num.samples) {
+  } else if (length(E1.hat) != nrow(X)) {
     stop("E1.hat has incorrect length.")
   }
 
@@ -297,11 +296,11 @@ causal_survival_forest <- function(X, Y, W, D,
       S0.failure.times <- S.failure.times <- sf.survival$failure.times
     }
     X.orig <- sf.survival[["X.orig"]]
-    sf.survival[["X.orig"]] <- cbind(X, rep(0, num.samples))
+    sf.survival[["X.orig"]] <- cbind(X, rep(0, nrow(X)))
     S0.hat <- predict(sf.survival)$predictions
     sf.survival[["X.orig"]] <- X.orig
     E0.hat <- expected_survival(S0.hat, S0.failure.times)
-  } else if (length(E0.hat) != num.samples) {
+  } else if (length(E0.hat) != nrow(X)) {
     stop("E0.hat has incorrect length.")
   }
   # Compute m(x) = e(X) E[T | X, W = 1] + (1 - e(X)) E[T | X, W = 0]
@@ -315,7 +314,7 @@ causal_survival_forest <- function(X, Y, W, D,
     }
     # We want the predicted survival curves S.hat and C.hat on the common grid Y.grid:
     S.hat <- predict(sf.survival, failure.times = Y.grid)$predictions
-  } else if (NROW(S.hat) != num.samples) {
+  } else if (NROW(S.hat) != nrow(X)) {
     stop("S.hat has incorrect length.")
   } else if (NCOL(S.hat) != length(Y.grid)) {
     stop("S.hat has incorrect number of columns (should be equal to the number of events).")
@@ -325,7 +324,7 @@ causal_survival_forest <- function(X, Y, W, D,
   if (is.null(C.hat)) {
     sf.censor <- do.call(survival_forest, c(list(X = cbind(X, W), Y = Y, D = 1 - D), args.nuisance))
     C.hat <- predict(sf.censor, failure.times = Y.grid)$predictions
-  } else if (NROW(C.hat) != num.samples) {
+  } else if (NROW(C.hat) != nrow(X)) {
     stop("C.hat has incorrect length.")
   } else if (NCOL(C.hat) != length(Y.grid)) {
     stop("C.hat has incorrect number of columns (should be equal to the number of events).")


### PR DESCRIPTION
Makes this already involved code easier to read by reducing the number of objects you need to keep track of.