### PR TITLE
Remove redundant argument in multi_causal_trainer

### DIFF
--- a/core/src/forest/ForestTrainers.cpp
+++ b/core/src/forest/ForestTrainers.cpp
@@ -53,9 +53,8 @@ ForestTrainer instrumental_trainer(double reduced_form_weight,
 }
 
 ForestTrainer multi_causal_trainer(size_t num_treatments,
-                                   size_t num_outcomes,
-                                   size_t response_length) {
-
+                                   size_t num_outcomes) {
+  size_t response_length = num_treatments * num_outcomes;
   std::unique_ptr<RelabelingStrategy> relabeling_strategy(new MultiCausalRelabelingStrategy(response_length));
   std::unique_ptr<SplittingRuleFactory> splitting_rule_factory =
    std::unique_ptr<SplittingRuleFactory>(new MultiRegressionSplittingRuleFactory(response_length));

--- a/core/src/forest/ForestTrainers.h
+++ b/core/src/forest/ForestTrainers.h
@@ -26,8 +26,7 @@ ForestTrainer instrumental_trainer(double reduced_form_weight,
                                    bool stabilize_splits);
 
 ForestTrainer multi_causal_trainer(size_t num_treatments,
-                                   size_t num_outcomes,
-                                   size_t response_length);
+                                   size_t num_outcomes);
 
 ForestTrainer quantile_trainer(const std::vector<double>& quantiles);
 

--- a/core/test/forest/ForestCharacterizationTest.cpp
+++ b/core/test/forest/ForestCharacterizationTest.cpp
@@ -292,7 +292,7 @@ TEST_CASE("multi causal forest predictions with sample weights have not changed"
   data->set_weight_index(8);
 
   size_t num_treatments = 2;
-  ForestTrainer trainer = multi_causal_trainer(num_treatments, 1, num_treatments);
+  ForestTrainer trainer = multi_causal_trainer(num_treatments, 1);
   ForestOptions options = ForestTestUtilities::default_options();
 
   Forest forest = trainer.train(*data, options);

--- a/r-package/grf/bindings/MultiCausalForestBindings.cpp
+++ b/r-package/grf/bindings/MultiCausalForestBindings.cpp
@@ -33,7 +33,7 @@ Rcpp::List multi_causal_train(Rcpp::NumericMatrix train_matrix,
                               unsigned int seed) {
   size_t num_treatments = treatment_index.size();
   size_t num_outcomes = outcome_index.size();
-  ForestTrainer trainer = multi_causal_trainer(num_treatments, num_outcomes, num_treatments * num_outcomes);
+  ForestTrainer trainer = multi_causal_trainer(num_treatments, num_outcomes);
 
   std::unique_ptr<Data> data = RcppUtilities::convert_data(train_matrix, sparse_train_matrix);
   data->set_outcome_index(outcome_index);


### PR DESCRIPTION
Heeding @jtibshirani's suggestion in #848 and omitting this redundant argument which was intended for future experimentation flexibility.