### PR TITLE
Use same consistent argument names in tune_forest

### DIFF
--- a/r-package/grf/R/causal_forest.R
+++ b/r-package/grf/R/causal_forest.R
@@ -262,7 +262,7 @@ causal_forest <- function(X, Y, W,
                                  tune.parameters = tune.parameters,
                                  tune.parameters.defaults = tune.parameters.defaults,
                                  tune.num.trees = tune.num.trees,
-                                 num.fit.reps = tune.num.reps,
+                                 tune.num.reps = tune.num.reps,
                                  num.optimize.reps = tune.num.draws,
                                  train = causal_train)
 

--- a/r-package/grf/R/causal_forest.R
+++ b/r-package/grf/R/causal_forest.R
@@ -261,7 +261,7 @@ causal_forest <- function(X, Y, W,
                                  args = args,
                                  tune.parameters = tune.parameters,
                                  tune.parameters.defaults = tune.parameters.defaults,
-                                 num.fit.trees = tune.num.trees,
+                                 tune.num.trees = tune.num.trees,
                                  num.fit.reps = tune.num.reps,
                                  num.optimize.reps = tune.num.draws,
                                  train = causal_train)

--- a/r-package/grf/R/causal_forest.R
+++ b/r-package/grf/R/causal_forest.R
@@ -263,7 +263,7 @@ causal_forest <- function(X, Y, W,
                                  tune.parameters.defaults = tune.parameters.defaults,
                                  tune.num.trees = tune.num.trees,
                                  tune.num.reps = tune.num.reps,
-                                 num.optimize.reps = tune.num.draws,
+                                 tune.num.draws = tune.num.draws,
                                  train = causal_train)
 
     args <- modifyList(args, as.list(tuning.output[["params"]]))

--- a/r-package/grf/R/instrumental_forest.R
+++ b/r-package/grf/R/instrumental_forest.R
@@ -230,7 +230,7 @@ instrumental_forest <- function(X, Y, W, Z,
                                  tune.parameters = tune.parameters,
                                  tune.parameters.defaults = tune.parameters.defaults,
                                  tune.num.trees = tune.num.trees,
-                                 num.fit.reps = tune.num.reps,
+                                 tune.num.reps = tune.num.reps,
                                  num.optimize.reps = tune.num.draws,
                                  train = instrumental_train)
 

--- a/r-package/grf/R/instrumental_forest.R
+++ b/r-package/grf/R/instrumental_forest.R
@@ -229,7 +229,7 @@ instrumental_forest <- function(X, Y, W, Z,
                                  args = args,
                                  tune.parameters = tune.parameters,
                                  tune.parameters.defaults = tune.parameters.defaults,
-                                 num.fit.trees = tune.num.trees,
+                                 tune.num.trees = tune.num.trees,
                                  num.fit.reps = tune.num.reps,
                                  num.optimize.reps = tune.num.draws,
                                  train = instrumental_train)

--- a/r-package/grf/R/instrumental_forest.R
+++ b/r-package/grf/R/instrumental_forest.R
@@ -231,7 +231,7 @@ instrumental_forest <- function(X, Y, W, Z,
                                  tune.parameters.defaults = tune.parameters.defaults,
                                  tune.num.trees = tune.num.trees,
                                  tune.num.reps = tune.num.reps,
-                                 num.optimize.reps = tune.num.draws,
+                                 tune.num.draws = tune.num.draws,
                                  train = instrumental_train)
 
     args <- modifyList(args, as.list(tuning.output[["params"]]))

--- a/r-package/grf/R/regression_forest.R
+++ b/r-package/grf/R/regression_forest.R
@@ -160,7 +160,7 @@ regression_forest <- function(X, Y,
                                  tune.parameters = tune.parameters,
                                  tune.parameters.defaults = tune.parameters.defaults,
                                  tune.num.trees = tune.num.trees,
-                                 num.fit.reps = tune.num.reps,
+                                 tune.num.reps = tune.num.reps,
                                  num.optimize.reps = tune.num.draws,
                                  train = regression_train)
 

--- a/r-package/grf/R/regression_forest.R
+++ b/r-package/grf/R/regression_forest.R
@@ -159,7 +159,7 @@ regression_forest <- function(X, Y,
                                  args = args,
                                  tune.parameters = tune.parameters,
                                  tune.parameters.defaults = tune.parameters.defaults,
-                                 num.fit.trees = tune.num.trees,
+                                 tune.num.trees = tune.num.trees,
                                  num.fit.reps = tune.num.reps,
                                  num.optimize.reps = tune.num.draws,
                                  train = regression_train)

--- a/r-package/grf/R/regression_forest.R
+++ b/r-package/grf/R/regression_forest.R
@@ -161,7 +161,7 @@ regression_forest <- function(X, Y,
                                  tune.parameters.defaults = tune.parameters.defaults,
                                  tune.num.trees = tune.num.trees,
                                  tune.num.reps = tune.num.reps,
-                                 num.optimize.reps = tune.num.draws,
+                                 tune.num.draws = tune.num.draws,
                                  train = regression_train)
 
     args <- modifyList(args, as.list(tuning.output[["params"]]))

--- a/r-package/grf/R/tune_forest.R
+++ b/r-package/grf/R/tune_forest.R
@@ -9,7 +9,7 @@
 #' @param tune.parameters The vector of parameter names to tune.
 #' @param tune.parameters.defaults The grf default values for the vector of parameter names to tune.
 #' @param tune.num.trees The number of trees in each 'mini forest' used to fit the tuning model.
-#' @param num.fit.reps The number of forests used to fit the tuning model.
+#' @param tune.num.reps The number of forests used to fit the tuning model.
 #' @param num.optimize.reps The number of random parameter values considered when using the model
 #'  to select the optimal parameters.
 #' @param train The grf forest training function.
@@ -26,7 +26,7 @@ tune_forest <- function(data,
                         tune.parameters,
                         tune.parameters.defaults,
                         tune.num.trees,
-                        num.fit.reps,
+                        tune.num.reps,
                         num.optimize.reps,
                         train) {
   fit.parameters <- args[!names(args) %in% tune.parameters]
@@ -36,8 +36,8 @@ tune_forest <- function(data,
 
   # 1. Train several mini-forests, and gather their debiased OOB error estimates.
   num.params <- length(tune.parameters)
-  unif <- with_seed(runif(num.fit.reps * num.params), seed = args$seed)
-  fit.draws <- matrix(unif, num.fit.reps, num.params,
+  unif <- with_seed(runif(tune.num.reps * num.params), seed = args$seed)
+  fit.draws <- matrix(unif, tune.num.reps, num.params,
                       dimnames = list(NULL, tune.parameters))
 
   small.forest.errors <- apply(fit.draws, 1, function(draw) {

--- a/r-package/grf/R/tune_forest.R
+++ b/r-package/grf/R/tune_forest.R
@@ -10,7 +10,7 @@
 #' @param tune.parameters.defaults The grf default values for the vector of parameter names to tune.
 #' @param tune.num.trees The number of trees in each 'mini forest' used to fit the tuning model.
 #' @param tune.num.reps The number of forests used to fit the tuning model.
-#' @param num.optimize.reps The number of random parameter values considered when using the model
+#' @param tune.num.draws The number of random parameter values considered when using the model
 #'  to select the optimal parameters.
 #' @param train The grf forest training function.
 #'
@@ -27,7 +27,7 @@ tune_forest <- function(data,
                         tune.parameters.defaults,
                         tune.num.trees,
                         tune.num.reps,
-                        num.optimize.reps,
+                        tune.num.draws,
                         train) {
   fit.parameters <- args[!names(args) %in% tune.parameters]
   fit.parameters[["num.trees"]] <- tune.num.trees
@@ -90,8 +90,8 @@ tune_forest <- function(data,
 
   # 3. To determine the optimal parameter values, predict using the kriging model at a large
   # number of random values, then select those that produced the lowest error.
-  unif <- with_seed(runif(num.optimize.reps * num.params), seed = args$seed)
-  optimize.draws <- matrix(unif, num.optimize.reps, num.params,
+  unif <- with_seed(runif(tune.num.draws * num.params), seed = args$seed)
+  optimize.draws <- matrix(unif, tune.num.draws, num.params,
                            dimnames = list(NULL, tune.parameters))
   model.surface <- predict(kriging.model, newdata = data.frame(optimize.draws), type = "SK")$mean
   tuned.params <- get_params_from_draw(nrow.X, ncol.X, optimize.draws)

--- a/r-package/grf/R/tune_forest.R
+++ b/r-package/grf/R/tune_forest.R
@@ -8,7 +8,7 @@
 #' @param args The remaining call arguments for the forest.
 #' @param tune.parameters The vector of parameter names to tune.
 #' @param tune.parameters.defaults The grf default values for the vector of parameter names to tune.
-#' @param num.fit.trees The number of trees in each 'mini forest' used to fit the tuning model.
+#' @param tune.num.trees The number of trees in each 'mini forest' used to fit the tuning model.
 #' @param num.fit.reps The number of forests used to fit the tuning model.
 #' @param num.optimize.reps The number of random parameter values considered when using the model
 #'  to select the optimal parameters.
@@ -25,12 +25,12 @@ tune_forest <- function(data,
                         args,
                         tune.parameters,
                         tune.parameters.defaults,
-                        num.fit.trees,
+                        tune.num.trees,
                         num.fit.reps,
                         num.optimize.reps,
                         train) {
   fit.parameters <- args[!names(args) %in% tune.parameters]
-  fit.parameters[["num.trees"]] <- num.fit.trees
+  fit.parameters[["num.trees"]] <- tune.num.trees
   fit.parameters[["ci.group.size"]] <- 1
   fit.parameters[["compute.oob.predictions"]] <- TRUE
 
@@ -50,7 +50,7 @@ tune_forest <- function(data,
   if (any(is.na(small.forest.errors))) {
     warning(paste0(
       "Could not tune forest because some small forest error estimates were NA.\n",
-      "Consider increasing tuning argument num.fit.trees."))
+      "Consider increasing tuning argument tune.num.trees."))
     out <- get_tuning_output(params = c(tune.parameters.defaults), status = "failure")
     return(out)
   }
@@ -58,7 +58,7 @@ tune_forest <- function(data,
   if (sd(small.forest.errors) == 0 || sd(small.forest.errors) / mean(small.forest.errors) < 1e-10) {
     warning(paste0(
       "Could not tune forest because small forest errors were nearly constant.\n",
-      "Consider increasing argument num.fit.trees."))
+      "Consider increasing argument tune.num.trees."))
     out <- get_tuning_output(params = c(tune.parameters.defaults), status = "failure")
     return(out)
   }
@@ -100,7 +100,7 @@ tune_forest <- function(data,
 
   # To avoid the possibility of selection bias, re-train a moderately-sized forest
   # at the value chosen by the method above
-  fit.parameters[["num.trees"]] <- num.fit.trees * 4
+  fit.parameters[["num.trees"]] <- tune.num.trees * 4
   retrained.forest.params <- grid[small.forest.optimal.draw, -1]
   retrained.forest <- do.call.rcpp(train, c(data, fit.parameters, retrained.forest.params))
   retrained.forest.error <- mean(retrained.forest$debiased.error, na.rm = TRUE)

--- a/r-package/grf/man/tune_forest.Rd
+++ b/r-package/grf/man/tune_forest.Rd
@@ -11,7 +11,7 @@ tune_forest(
   args,
   tune.parameters,
   tune.parameters.defaults,
-  num.fit.trees,
+  tune.num.trees,
   num.fit.reps,
   num.optimize.reps,
   train
@@ -30,7 +30,7 @@ tune_forest(
 
 \item{tune.parameters.defaults}{The grf default values for the vector of parameter names to tune.}
 
-\item{num.fit.trees}{The number of trees in each 'mini forest' used to fit the tuning model.}
+\item{tune.num.trees}{The number of trees in each 'mini forest' used to fit the tuning model.}
 
 \item{num.fit.reps}{The number of forests used to fit the tuning model.}
 

--- a/r-package/grf/man/tune_forest.Rd
+++ b/r-package/grf/man/tune_forest.Rd
@@ -13,7 +13,7 @@ tune_forest(
   tune.parameters.defaults,
   tune.num.trees,
   tune.num.reps,
-  num.optimize.reps,
+  tune.num.draws,
   train
 )
 }
@@ -34,7 +34,7 @@ tune_forest(
 
 \item{tune.num.reps}{The number of forests used to fit the tuning model.}
 
-\item{num.optimize.reps}{The number of random parameter values considered when using the model
+\item{tune.num.draws}{The number of random parameter values considered when using the model
 to select the optimal parameters.}
 
 \item{train}{The grf forest training function.}

--- a/r-package/grf/man/tune_forest.Rd
+++ b/r-package/grf/man/tune_forest.Rd
@@ -12,7 +12,7 @@ tune_forest(
   tune.parameters,
   tune.parameters.defaults,
   tune.num.trees,
-  num.fit.reps,
+  tune.num.reps,
   num.optimize.reps,
   train
 )
@@ -32,7 +32,7 @@ tune_forest(
 
 \item{tune.num.trees}{The number of trees in each 'mini forest' used to fit the tuning model.}
 
-\item{num.fit.reps}{The number of forests used to fit the tuning model.}
+\item{tune.num.reps}{The number of forests used to fit the tuning model.}
 
 \item{num.optimize.reps}{The number of random parameter values considered when using the model
 to select the optimal parameters.}


### PR DESCRIPTION
Just a minor aesthetic polish: use the same argument names in the internal tuning function `tune_forest` as the external arguments the callee uses. Less names to keep track of = less room for bugs.