### PR TITLE
Speed up SampleWeightComputer

### DIFF
--- a/core/src/prediction/DefaultPredictionStrategy.h
+++ b/core/src/prediction/DefaultPredictionStrategy.h
@@ -18,9 +18,9 @@
 #ifndef GRF_DEFAULTPREDICTIONSTRATEGY_H
 #define GRF_DEFAULTPREDICTIONSTRATEGY_H
 
-#include <unordered_map>
 #include <vector>
 
+#include "Eigen/Sparse"
 #include "commons/globals.h"
 #include "commons/Data.h"
 #include "prediction/Prediction.h"
@@ -45,7 +45,7 @@ public:
    */
   virtual size_t prediction_length() const = 0;
 
-  /**
+  /** // TODO UPDATE WITH A DESCRIPTION of Eigen::SparseVector<double>& weights_by_sample protocol
    * Computes a prediction for a single test sample.
    *
    * sample: the ID of the test sample.
@@ -57,7 +57,7 @@ public:
    *     be the same as the training matrix.
    */
   virtual std::vector<double> predict(size_t sample,
-    const std::unordered_map<size_t, double>& weights_by_sample,
+    const Eigen::SparseVector<double>& weights_by_sample,
     const Data& train_data,
     const Data& data) const = 0;
 
@@ -79,7 +79,7 @@ public:
   virtual std::vector<double> compute_variance(
       size_t sample,
       const std::vector<std::vector<size_t>>& samples_by_tree,
-      const std::unordered_map<size_t, double>& weights_by_sampleID,
+      const Eigen::SparseVector<double>& weights_by_sampleID,
       const Data& train_data,
       const Data& data,
       size_t ci_group_size) const = 0;

--- a/core/src/prediction/LLCausalPredictionStrategy.cpp
+++ b/core/src/prediction/LLCausalPredictionStrategy.cpp
@@ -39,14 +39,14 @@ size_t LLCausalPredictionStrategy::prediction_length() const {
 
 std::vector<double> LLCausalPredictionStrategy::predict(
         size_t sampleID,
-        const std::unordered_map<size_t, double>& weights_by_sampleID,
+        const Eigen::SparseVector<double>& weights_by_sampleID,
         const Data& train_data,
         const Data& test_data) const {
 
   // Number of predictor variables to use in local linear regression step
   size_t num_variables = linear_correction_variables.size();
 
-  size_t num_nonzero_weights = weights_by_sampleID.size();
+  size_t num_nonzero_weights = weights_by_sampleID.nonZeros();
   size_t num_lambdas = lambdas.size();
 
   // Creating a vector of neighbor weights weights
@@ -60,9 +60,9 @@ std::vector<double> LLCausalPredictionStrategy::predict(
   Eigen::MatrixXd weights_vec = Eigen::VectorXd::Zero(num_nonzero_weights);
   {
     size_t i = 0;
-    for (const auto& it : weights_by_sampleID) {
-      size_t index = it.first;
-      double weight = it.second;
+    for (Eigen::SparseVector<double>::InnerIterator it(weights_by_sampleID); it; ++it) {
+      size_t index = it.index();
+      double weight = it.value();
       indices[i] = index;
       weights_vec(i) = weight;
       i++;
@@ -147,7 +147,7 @@ std::vector<double> LLCausalPredictionStrategy::predict(
 std::vector<double> LLCausalPredictionStrategy::compute_variance(
         size_t sampleID,
         const std::vector<std::vector<size_t>>& samples_by_tree,
-        const std::unordered_map<size_t, double>& weights_by_sampleID,
+        const Eigen::SparseVector<double>& weights_by_sampleID,
         const Data& train_data,
         const Data& test_data,
         size_t ci_group_size) const {
@@ -155,7 +155,7 @@ std::vector<double> LLCausalPredictionStrategy::compute_variance(
   double lambda = lambdas[0];
 
   size_t num_variables = linear_correction_variables.size();
-  size_t num_nonzero_weights = weights_by_sampleID.size();
+  size_t num_nonzero_weights = weights_by_sampleID.nonZeros();
 
   std::vector<size_t> sample_index_map(train_data.get_num_rows());
   std::vector<size_t> indices(num_nonzero_weights);
@@ -163,9 +163,9 @@ std::vector<double> LLCausalPredictionStrategy::compute_variance(
   Eigen::MatrixXd weights_vec = Eigen::VectorXd::Zero(num_nonzero_weights);
   {
     size_t i = 0;
-    for (auto& it : weights_by_sampleID) {
-      size_t index = it.first;
-      double weight = it.second;
+    for (Eigen::SparseVector<double>::InnerIterator it(weights_by_sampleID); it; ++it) {
+      size_t index = it.index();
+      double weight = it.value();
       indices[i] = index;
       sample_index_map[index] = i;
       weights_vec(i) = weight;

--- a/core/src/prediction/LLCausalPredictionStrategy.h
+++ b/core/src/prediction/LLCausalPredictionStrategy.h
@@ -36,14 +36,14 @@ public:
     size_t prediction_length() const;
 
     std::vector<double> predict(size_t sampleID,
-                                const std::unordered_map<size_t, double>& weights_by_sampleID,
+                                const Eigen::SparseVector<double>& weights_by_sampleID,
                                 const Data& original_data,
                                 const Data& test_data) const;
 
     std::vector<double> compute_variance(
             size_t sampleID,
             const std::vector<std::vector<size_t>>& samples_by_tree,
-            const std::unordered_map<size_t, double>& weights_by_sampleID,
+            const Eigen::SparseVector<double>& weights_by_sampleID,
             const Data& train_data,
             const Data& data,
             size_t ci_group_size) const;

--- a/core/src/prediction/LocalLinearPredictionStrategy.cpp
+++ b/core/src/prediction/LocalLinearPredictionStrategy.cpp
@@ -39,19 +39,19 @@ size_t LocalLinearPredictionStrategy::prediction_length() const {
 
 std::vector<double> LocalLinearPredictionStrategy::predict(
     size_t sampleID,
-    const std::unordered_map<size_t, double>& weights_by_sampleID,
+    const Eigen::SparseVector<double>& weights_by_sampleID,
     const Data& train_data,
     const Data& data) const {
   size_t num_variables = linear_correction_variables.size();
-  size_t num_nonzero_weights = weights_by_sampleID.size();
+  size_t num_nonzero_weights = weights_by_sampleID.nonZeros();
 
   std::vector<size_t> indices(num_nonzero_weights);
   Eigen::MatrixXd weights_vec = Eigen::VectorXd::Zero(num_nonzero_weights);
   {
     size_t i = 0;
-    for (auto& it : weights_by_sampleID) {
-      size_t index = it.first;
-      double weight = it.second;
+    for (Eigen::SparseVector<double>::InnerIterator it(weights_by_sampleID); it; ++it) {
+      size_t index = it.index();
+      double weight = it.value();
       indices[i] = index;
       weights_vec(i) = weight;
       i++;
@@ -105,7 +105,7 @@ std::vector<double> LocalLinearPredictionStrategy::predict(
 std::vector<double> LocalLinearPredictionStrategy::compute_variance(
     size_t sampleID,
     const std::vector<std::vector<size_t>>& samples_by_tree,
-    const std::unordered_map<size_t, double>& weights_by_sampleID,
+    const Eigen::SparseVector<double>& weights_by_sampleID,
     const Data& train_data,
     const Data& data,
     size_t ci_group_size) const {
@@ -113,7 +113,7 @@ std::vector<double> LocalLinearPredictionStrategy::compute_variance(
   double lambda = lambdas[0];
 
   size_t num_variables = linear_correction_variables.size();
-  size_t num_nonzero_weights = weights_by_sampleID.size();
+  size_t num_nonzero_weights = weights_by_sampleID.nonZeros();
 
   std::vector<size_t> sample_index_map(train_data.get_num_rows());
   std::vector<size_t> indices(num_nonzero_weights);
@@ -121,9 +121,9 @@ std::vector<double> LocalLinearPredictionStrategy::compute_variance(
   Eigen::MatrixXd weights_vec = Eigen::VectorXd::Zero(num_nonzero_weights);
     {
       size_t i = 0;
-      for (const auto& it : weights_by_sampleID) {
-        size_t index = it.first;
-        double weight = it.second;
+      for (Eigen::SparseVector<double>::InnerIterator it(weights_by_sampleID); it; ++it) {
+        size_t index = it.index();
+        double weight = it.value();
         indices[i] = index;
         sample_index_map[index] = i;
         weights_vec(i) = weight;

--- a/core/src/prediction/LocalLinearPredictionStrategy.h
+++ b/core/src/prediction/LocalLinearPredictionStrategy.h
@@ -46,14 +46,14 @@ public:
     *   output predictions along each of these parameters.
     */
     std::vector<double> predict(size_t sampleID,
-                                const std::unordered_map<size_t, double>& weights_by_sampleID,
+                                const Eigen::SparseVector<double>& weights_by_sampleID,
                                 const Data& train_data,
                                 const Data& data) const;
 
     std::vector<double> compute_variance(
         size_t sampleID,
         const std::vector<std::vector<size_t>>& samples_by_tree,
-        const std::unordered_map<size_t, double>& weights_by_sampleID,
+        const Eigen::SparseVector<double>& weights_by_sampleID,
         const Data& train_data,
         const Data& data,
         size_t ci_group_size) const;

--- a/core/src/prediction/QuantilePredictionStrategy.cpp
+++ b/core/src/prediction/QuantilePredictionStrategy.cpp
@@ -49,7 +49,6 @@ std::vector<double> QuantilePredictionStrategy::predict(
 std::vector<double> QuantilePredictionStrategy::compute_quantile_cutoffs(
     const Eigen::SparseVector<double>& weights_by_sample,
     std::vector<std::pair<size_t, double>>& samples_and_values) const {
-
   std::sort(samples_and_values.begin(),
             samples_and_values.end(),
             [](std::pair<size_t, double> first_pair, std::pair<size_t, double> second_pair) {

--- a/core/src/prediction/QuantilePredictionStrategy.h
+++ b/core/src/prediction/QuantilePredictionStrategy.h
@@ -34,20 +34,20 @@ public:
   size_t prediction_length() const;
 
   std::vector<double> predict(size_t prediction_sample,
-    const std::unordered_map<size_t, double>& weights_by_sample,
+    const Eigen::SparseVector<double>& weights_by_sample,
     const Data& train_data,
     const Data& data) const;
 
   std::vector<double> compute_variance(
       size_t sampleID,
       const std::vector<std::vector<size_t>>& samples_by_tree,
-      const std::unordered_map<size_t, double>& weights_by_sampleID,
+      const Eigen::SparseVector<double>& weights_by_sampleID,
       const Data& train_data,
       const Data& data,
       size_t ci_group_size) const;
 
 private:
-  std::vector<double> compute_quantile_cutoffs(const std::unordered_map<size_t, double>& weights_by_sample,
+  std::vector<double> compute_quantile_cutoffs(const Eigen::SparseVector<double>& weights_by_sample,
                                                std::vector<std::pair<size_t, double>>& samples_and_values) const;
 
   std::vector<double> quantiles;

--- a/core/src/prediction/QuantilePredictionStrategy.h
+++ b/core/src/prediction/QuantilePredictionStrategy.h
@@ -48,7 +48,9 @@ public:
 
 private:
   std::vector<double> compute_quantile_cutoffs(const Eigen::SparseVector<double>& weights_by_sample,
-                                               std::vector<std::pair<size_t, double>>& samples_and_values) const;
+                                               std::vector<
+                                               std::pair<size_t, std::pair<double, double>>
+                                               >& samples_and_values) const;
 
   std::vector<double> quantiles;
 };

--- a/core/src/prediction/SurvivalPredictionStrategy.cpp
+++ b/core/src/prediction/SurvivalPredictionStrategy.cpp
@@ -37,7 +37,7 @@ size_t SurvivalPredictionStrategy::prediction_length() const {
 }
 
 std::vector<double> SurvivalPredictionStrategy::predict(size_t prediction_sample,
-    const std::unordered_map<size_t, double>& weights_by_sample,
+    const Eigen::SparseVector<double>& weights_by_sample,
     const Data& train_data,
     const Data& data) const {
   // the event times will always range from 0, ..., num_failures
@@ -45,9 +45,9 @@ std::vector<double> SurvivalPredictionStrategy::predict(size_t prediction_sample
   std::vector<double> count_failure(num_failures + 1);
   std::vector<double> count_censor(num_failures + 1);
   double sum = 0;
-  for (const auto& entry : weights_by_sample) {
-    size_t sample = entry.first;
-    double forest_weight = entry.second;
+  for (Eigen::SparseVector<double>::InnerIterator it(weights_by_sample); it; ++it) {
+    size_t sample = it.index();
+    double forest_weight = it.value();
     size_t failure_time = train_data.get_outcome(sample);
     double sample_weight = train_data.get_weight(sample);
     if (train_data.is_failure(sample)) {
@@ -115,7 +115,7 @@ std::vector<double> SurvivalPredictionStrategy::predict_nelson_aalen(
 std::vector<double> SurvivalPredictionStrategy::compute_variance(
     size_t sample,
     const std::vector<std::vector<size_t>>& samples_by_tree,
-    const std::unordered_map<size_t, double>& weights_by_sampleID,
+    const Eigen::SparseVector<double>& weights_by_sampleID,
     const Data& train_data,
     const Data& data,
     size_t ci_group_size) const {

--- a/core/src/prediction/SurvivalPredictionStrategy.h
+++ b/core/src/prediction/SurvivalPredictionStrategy.h
@@ -50,14 +50,14 @@ public:
   size_t prediction_length() const;
 
   std::vector<double> predict(size_t prediction_sample,
-    const std::unordered_map<size_t, double>& weights_by_sample,
+    const Eigen::SparseVector<double>& weights_by_sample,
     const Data& train_data,
     const Data& data) const;
 
   std::vector<double> compute_variance(
     size_t sample,
     const std::vector<std::vector<size_t>>& samples_by_tree,
-    const std::unordered_map<size_t, double>& weights_by_sampleID,
+    const Eigen::SparseVector<double>& weights_by_sampleID,
     const Data& train_data,
     const Data& data,
     size_t ci_group_size) const;

--- a/core/src/prediction/collector/DefaultPredictionCollector.cpp
+++ b/core/src/prediction/collector/DefaultPredictionCollector.cpp
@@ -89,13 +89,13 @@ std::vector<Prediction> DefaultPredictionCollector::collect_predictions_batch(
   predictions.reserve(num_samples);
 
   for (size_t sample = start; sample < num_samples + start; ++sample) {
-    std::unordered_map<size_t, double> weights_by_sample = weight_computer.compute_weights(
-        sample, forest, leaf_nodes_by_tree, valid_trees_by_sample);
+    Eigen::SparseVector<double> weights_by_sample = weight_computer.compute_weights(
+        sample, forest, leaf_nodes_by_tree, valid_trees_by_sample, train_data);
     std::vector<std::vector<size_t>> samples_by_tree;
 
     // If this sample has no neighbors, then return placeholder predictions. Note
     // that this can only occur when honesty is enabled, and is expected to be rare.
-    if (weights_by_sample.empty()) {
+    if (weights_by_sample.nonZeros() == 0) {
       std::vector<double> nan(strategy->prediction_length(), NAN);
       std::vector<double> empty;
       predictions.emplace_back(nan, estimate_variance ? nan : empty, empty, empty);

--- a/core/src/prediction/collector/SampleWeightComputer.cpp
+++ b/core/src/prediction/collector/SampleWeightComputer.cpp
@@ -29,6 +29,7 @@ Eigen::SparseVector<double> SampleWeightComputer::compute_weights(size_t sample,
   Eigen::VectorXd weights_by_sample = Eigen::VectorXd::Zero(train_data.get_num_rows());
   double total_weight = 0;
 
+  // Create a list of weighted neighbors for this sample.
   for (size_t tree_index = 0; tree_index < forest.get_trees().size(); ++tree_index) {
     if (!valid_trees_by_sample[sample][tree_index]) {
       continue;

--- a/core/src/prediction/collector/SampleWeightComputer.h
+++ b/core/src/prediction/collector/SampleWeightComputer.h
@@ -18,25 +18,20 @@
 #ifndef GRF_SAMPLEWEIGHTCOMPUTER_H
 #define GRF_SAMPLEWEIGHTCOMPUTER_H
 
+#include "Eigen/Sparse"
 #include "forest/Forest.h"
 
-#include <unordered_map>
 #include <vector>
 
 namespace grf {
 
 class SampleWeightComputer {
 public:
-  std::unordered_map<size_t, double> compute_weights(size_t sample,
-                                                     const Forest& forest,
-                                                     const std::vector<std::vector<size_t>>& leaf_nodes_by_tree,
-                                                     const std::vector<std::vector<bool>>& valid_trees_by_sample) const;
-
-private:
-  void add_sample_weights(const std::vector<size_t>& samples,
-                          std::unordered_map<size_t, double>& weights_by_sample) const;
-
-  void normalize_sample_weights(std::unordered_map<size_t, double>& weights_by_sample) const;
+  Eigen::SparseVector<double> compute_weights(size_t sample,
+                                              const Forest& forest,
+                                              const std::vector<std::vector<size_t>>& leaf_nodes_by_tree,
+                                              const std::vector<std::vector<bool>>& valid_trees_by_sample,
+                                              const Data& train_data) const;
 };
 
 } // namespace grf

--- a/core/test/prediction/QuantilePredictionStrategyTest.cpp
+++ b/core/test/prediction/QuantilePredictionStrategyTest.cpp
@@ -28,9 +28,13 @@
 using namespace grf;
 
 TEST_CASE("simple quantile prediction", "[quantile, prediction]") {
-  std::unordered_map<size_t, double> weights_by_sample = {
+  std::unordered_map<size_t, double>  weights_map = {
       {0, 0.0}, {1, 0.1}, {2, 0.2}, {3, 0.1}, {4, 0.1},
       {5, 0.1}, {6, 0.2}, {7, 0.1}, {8, 0.0}, {9, 0.1}};
+  Eigen::SparseVector<double> weights_by_sample(weights_map.size());
+  for (auto it : weights_map) {
+    weights_by_sample.insert(it.first) = it.second;
+  }
 
   std::vector<double> outcomes = { -9.99984, -7.36924, 5.11211, -0.826997, 0.655345,
                                    -5.62082, -9.05911, 3.57729, 3.58593, 8.69386 };
@@ -45,9 +49,13 @@ TEST_CASE("simple quantile prediction", "[quantile, prediction]") {
 }
 
 TEST_CASE("prediction with skewed quantiles", "[quantile, prediction]") {
-  std::unordered_map<size_t, double> weights_by_sample = {
+  std::unordered_map<size_t, double>  weights_map = {
       {0, 0.0}, {1, 0.1}, {2, 0.2}, {3, 0.1}, {4, 0.1},
       {5, 0.1}, {6, 0.2}, {7, 0.1}, {8, 0.0}, {9, 0.1}};
+  Eigen::SparseVector<double> weights_by_sample(weights_map.size());
+  for (auto it : weights_map) {
+    weights_by_sample.insert(it.first) = it.second;
+  }
 
   std::vector<double> outcomes =  { -1.99984, -0.36924, 0.11211, -1.826997, 1.655345,
                                     -1.62082, -0.05911, 0.57729, 0.58593, 1.69386 };
@@ -65,9 +73,13 @@ TEST_CASE("prediction with skewed quantiles", "[quantile, prediction]") {
 }
 
 TEST_CASE("prediction with repeated quantiles", "[quantile, prediction]") {
-  std::unordered_map<size_t, double> weights_by_sample = {
+  std::unordered_map<size_t, double>  weights_map = {
       {0, 0.0}, {1, 0.1}, {2, 0.2}, {3, 0.1}, {4, 0.1},
       {5, 0.1}, {6, 0.2}, {7, 0.1}, {8, 0.0}, {9, 0.1}};
+  Eigen::SparseVector<double> weights_by_sample(weights_map.size());
+  for (auto it : weights_map) {
+    weights_by_sample.insert(it.first) = it.second;
+  }
 
   std::vector<double> outcomes  = { -9.99984, -7.36924, 5.11211, -0.826997, 0.655345,
                                     -5.62082, -9.05911, 3.57729, 3.58593, 8.69386 };

--- a/core/test/prediction/SurvivalPredictionStrategyTest.cpp
+++ b/core/test/prediction/SurvivalPredictionStrategyTest.cpp
@@ -52,9 +52,9 @@ TEST_CASE("Kaplan-Meier survival estimates are correct", "[survival], [predictio
   data.set_outcome_index(outcome_index);
   data.set_censor_index(outcome_index + 1);
 
-  std::unordered_map<size_t, double> weights_by_sample;
+  Eigen::SparseVector<double> weights_by_sample(num_rows);
   for (size_t i = 0; i < num_rows; i++) {
-    weights_by_sample[i] = 1.0;
+    weights_by_sample.insert(i) = 1.0;
   }
 
   int prediction_type = 0; // Kaplan-Meier
@@ -114,16 +114,16 @@ TEST_CASE("Kaplan-Meier estimates on duplicated data is the same as with sample 
   data_duplicated.set_outcome_index(outcome_index);
   data_duplicated.set_censor_index(outcome_index + 1);
 
-  std::unordered_map<size_t, double> weights_by_sample;
+  Eigen::SparseVector<double> weights_by_sample(num_rows + num_duplicates);
   for (size_t i = 0; i < num_rows; i++) {
-    weights_by_sample[i] = 1.0;
+    weights_by_sample.insert(i) = 1.0;
   }
 
   int prediction_type = 0;
   SurvivalPredictionStrategy prediction_strategy(num_failures, prediction_type);
   std::vector<double> predictions_weighted = prediction_strategy.predict(0, weights_by_sample, data, data);
   for (size_t i = num_rows; i < num_rows + num_duplicates; i++) {
-    weights_by_sample[i] = 1.0;
+    weights_by_sample.insert(i) = 1.0;
   }
   std::vector<double> predictions_duplicated = prediction_strategy.predict(0, weights_by_sample, data_duplicated, data_duplicated);
 
@@ -161,9 +161,9 @@ TEST_CASE("Nelson-Aalen survival estimates are correct", "[survival], [predictio
   data.set_outcome_index(outcome_index);
   data.set_censor_index(outcome_index + 1);
 
-  std::unordered_map<size_t, double> weights_by_sample;
+  Eigen::SparseVector<double> weights_by_sample(num_rows);
   for (size_t i = 0; i < num_rows; i++) {
-    weights_by_sample[i] = 1.0;
+    weights_by_sample.insert(i) = 1.0;
   }
 
   int prediction_type = 1; // Nelson-Aalen
@@ -223,16 +223,16 @@ TEST_CASE("Nelson-Aalen estimates on duplicated data is the same as with sample 
   data_duplicated.set_outcome_index(outcome_index);
   data_duplicated.set_censor_index(outcome_index + 1);
 
-  std::unordered_map<size_t, double> weights_by_sample;
+  Eigen::SparseVector<double> weights_by_sample(num_rows + num_duplicates);
   for (size_t i = 0; i < num_rows; i++) {
-    weights_by_sample[i] = 1.0;
+    weights_by_sample.insert(i) = 1.0;
   }
 
   int prediction_type = 1;
   SurvivalPredictionStrategy prediction_strategy(num_failures, prediction_type);
   std::vector<double> predictions_weighted = prediction_strategy.predict(0, weights_by_sample, data, data);
   for (size_t i = num_rows; i < num_rows + num_duplicates; i++) {
-    weights_by_sample[i] = 1.0;
+    weights_by_sample.insert(i) = 1.0;
   }
   std::vector<double> predictions_duplicated = prediction_strategy.predict(0, weights_by_sample, data_duplicated, data_duplicated);
 

--- a/r-package/grf/bindings/AnalysisToolsBindings.cpp
+++ b/r-package/grf/bindings/AnalysisToolsBindings.cpp
@@ -77,11 +77,11 @@ Eigen::SparseMatrix<double> compute_sample_weights(Rcpp::List forest_object,
   Eigen::SparseMatrix<double> result(num_samples, num_neighbors);
 
   for (size_t sample = 0; sample < num_samples; sample++) {
-    std::unordered_map<size_t, double> weights = weight_computer.compute_weights(
-        sample, forest, leaf_nodes_by_tree, trees_by_sample);
-    for (auto it = weights.begin(); it != weights.end(); it++) {
-      size_t neighbor = it->first;
-      double weight = it->second;
+    Eigen::SparseVector<double> weights = weight_computer.compute_weights(
+        sample, forest, leaf_nodes_by_tree, trees_by_sample, *train_data);
+    for (Eigen::SparseVector<double>::InnerIterator it(weights); it; ++it) {
+      size_t neighbor = it.index();
+      double weight = it.value();
       triplet_list.emplace_back(sample, neighbor, weight);
     }
   }


### PR DESCRIPTION
wip (#359 revived): replace hash table with vector and iterate over non-zero entries to get weights.

speed bench for the 4 prediction strategies that relies on the DefaultCollector (survival benefits the most, why: because surival forests sometimes tend to have very large leaves = much more dense neighborhood = many more hash table polls):

survival speed difference
```
set.seed(1234)
n <- 30000
p <- 5
X <- matrix(runif(n * p), n, p)
W <- rbinom(n, 1, 0.5)
Y.max <- 1
failure.time <- pmin(rexp(n) * X[, 1] + W, Y.max)
censor.time <- 2 * runif(n)
Y <- pmin(failure.time, censor.time)
Y=round(Y,1)
D <- as.integer(failure.time <= censor.time)
Y.grid <- sort(unique(Y))
print(length(Y.grid))
# [1] 11

sf.survival<-survival_forest(cbind(X,W), Y, D, num.trees = 500, compute.oob.predictions = FALSE)

# Point predictions
system.time(S1<- predict(sf.survival, failure.times = Y.grid))

# master
# user  system elapsed 
# 545.602  15.628  84.926 

# this
# user  system elapsed
# 80.823   0.523  12.272
```

causal survival forest:
```
system.time(cs.forest <- causal_survival_forest(X, Y, W, D))
# master
# user   system  elapsed
# 2231.792   63.507  308.017

# this
# user  system elapsed 
# 642.242   8.247  94.731 
```

local linear + the rest is not as drastic since its own prediction logic is the major speed impediment
```
set.seed(123)
n <- 20000
p <- 10
X <- matrix(rnorm(n * p), n, p)
Y <- X[, 1] * rnorm(n)
rf = regression_forest(X, Y, compute.oob.predictions = FALSE)

system.time(pp <- predict(rf, linear.correction.variables = 1:p))
# master
# user  system elapsed
# 97.176   4.345  20.989

# this
# user  system elapsed
# 67.802   2.108  15.156
```

local linear causal:
```
n <- 5000
p <- 10
X <- matrix(rnorm(n * p), n, p)
W <- rbinom(n, 1, 0.5)
Y <- pmax(X[, 1], 0) * W + X[, 2] + pmin(X[, 3], 0) + rnorm(n)
cf <- causal_forest(X, Y, W, compute.oob.predictions = FALSE)

X.test <- matrix(rnorm(30000 * p), 30000, p)
system.time(pp <- predict(cf, X.test, linear.correction.variables = 1:p))

# master 
# user  system elapsed 
# 142.339   3.981  20.287 

# this
# user  system elapsed 
# 86.732   2.291  12.879 
```

quantile forest:
```
n <- 5000
p <- 10
X <- matrix(rnorm(n * p), n, p)
Y <- X[, 1] * rnorm(n)
q.forest <- quantile_forest(X, Y, quantiles = c(0.1, 0.5, 0.9), compute.oob.predictions = FALSE)

X.test <- matrix(rnorm(1e5 * p), 1e5, p)
system.time(q.hat <- predict(q.forest, X.test))

# master
# user  system elapsed 
# 157.440   2.471  23.106 

# this
# user  system elapsed 
# 99.107   1.535  14.738 
```

[large n gist](https://gist.github.com/erikcs/f9aad462d718d6a71f50b29ff090f31b)