### PR TITLE
Update sample weights for causal survival forest

### DIFF
--- a/core/src/prediction/CausalSurvivalPredictionStrategy.cpp
+++ b/core/src/prediction/CausalSurvivalPredictionStrategy.cpp
@@ -141,8 +141,8 @@ PredictionValues CausalSurvivalPredictionStrategy::precompute_prediction_values(
       continue;
     }
 
-    value[NUMERATOR] = numerator_sum / sum_weight;
-    value[DENOMINATOR] = denominator_sum / sum_weight;
+    value[NUMERATOR] = numerator_sum / leaf_size;
+    value[DENOMINATOR] = denominator_sum / leaf_size;
   }
 
   return PredictionValues(values, NUM_TYPES);

--- a/core/src/prediction/CausalSurvivalPredictionStrategy.cpp
+++ b/core/src/prediction/CausalSurvivalPredictionStrategy.cpp
@@ -132,15 +132,6 @@ PredictionValues CausalSurvivalPredictionStrategy::precompute_prediction_values(
       continue;
     }
 
-    // if the denominator sum is zero, treat the leaf as empty
-    // this can only occur when there are zero failures in the leaf,
-    // which can happen with RegressionSplitting (does not take censoring
-    // status into account when splitting), or with CausalSurvivalSplitting
-    // but honesty on.
-    if (equal_doubles(denominator_sum, 0.0, 1.0e-10)) {
-      continue;
-    }
-
     value[NUMERATOR] = numerator_sum / leaf_size;
     value[DENOMINATOR] = denominator_sum / leaf_size;
   }

--- a/core/src/relabeling/CausalSurvivalRelabelingStrategy.cpp
+++ b/core/src/relabeling/CausalSurvivalRelabelingStrategy.cpp
@@ -28,13 +28,16 @@ bool CausalSurvivalRelabelingStrategy::relabel(
   // Prepare the relevant averages.
   double numerator_sum = 0;
   double denominator_sum = 0;
+  double sum_weight = 0.0;
 
   for (size_t sample : samples) {
-    numerator_sum += data.get_causal_survival_numerator(sample);
-    denominator_sum += data.get_causal_survival_denominator(sample);
+    double sample_weight = data.get_weight(sample);
+    numerator_sum += sample_weight * data.get_causal_survival_numerator(sample);
+    denominator_sum += sample_weight * data.get_causal_survival_denominator(sample);
+    sum_weight += sample_weight;
   }
 
-  if (equal_doubles(denominator_sum, 0.0, 1.0e-10)) {
+  if (equal_doubles(denominator_sum, 0.0, 1.0e-10) || std::abs(sum_weight) <= 1e-16) {
     return true;
   }
 

--- a/r-package/grf/tests/testthat/test_causal_survival_forest.R
+++ b/r-package/grf/tests/testthat/test_causal_survival_forest.R
@@ -50,23 +50,29 @@ test_that("causal survival forest variance estimates are decent", {
   true.effect <- data$cate
   cs.forest <- causal_survival_forest(data$X, data$Y, data$W, data$D, num.trees = 500)
   cs.pred <- predict(cs.forest, estimate.variance = TRUE)
-
   ub.oob <- cs.pred$predictions + 2 * sqrt(cs.pred$variance.estimates)
   lb.oob <- cs.pred$predictions - 2 * sqrt(cs.pred$variance.estimates)
   cate.coverage.oob <- mean(lb.oob < true.effect & true.effect < ub.oob)
+  expect_true(cate.coverage.oob >= 0.65)
 
   X.test <- matrix(0.5, 10, p)
   X.test[, 1] <- seq(0, 1, length.out = 10)
-  true.effect.test <- rep(NA, 10)
   true.effect.test <- generate_survival_data(10, p, Y.max = 1, X = X.test, n.mc = 5000, dgp = "simple1")$cate
   cs.pred.test <- predict(cs.forest, X.test, estimate.variance = TRUE)
 
   ub.test <- cs.pred.test$predictions + 2 * sqrt(cs.pred.test$variance.estimates)
   lb.test <- cs.pred.test$predictions - 2 * sqrt(cs.pred.test$variance.estimates)
   cate.coverage.test <- mean(lb.test < true.effect.test & true.effect.test < ub.test)
-
-  expect_true(cate.coverage.oob >= 0.65)
   expect_true(cate.coverage.test >= 0.65)
+
+  # Duplicate some samples
+  sample.weights <- sample(c(1, 2), n, TRUE)
+  cs.forest.weighted <- causal_survival_forest(data$X, data$Y, data$W, data$D, num.trees = 500, sample.weights = sample.weights)
+  cs.pred.weighted <- predict(cs.forest.weighted, estimate.variance = TRUE)
+  ub.oob.weighted <- cs.pred.weighted$predictions + 2 * sqrt(cs.pred.weighted$variance.estimates)
+  lb.oob.weighted <- cs.pred.weighted$predictions - 2 * sqrt(cs.pred.weighted$variance.estimates)
+  cate.coverage.oob.weighted <- mean(lb.oob.weighted < true.effect & true.effect < ub.oob.weighted)
+  expect_true(cate.coverage.oob.weighted >= 0.65)
 })
 
 test_that("sample weighted causal survival forest is invariant to scaling", {


### PR DESCRIPTION
Updates sample weighted estimation for `causal_survival_forest` in accordance with #796: sample weights enter the estimating equation as sample_weight * forest_weight. (Also adds sample weighted relabeling).


1. #### MSE check: sample weighting with IPCW improves complete-data MSE
```R
summary(replicate(100, {
  n <- 2000
  p <- 5
  X <- matrix(runif(n * p), n, p)
  W <- rbinom(n, 1, 0.5)
  Y.max <- 1
  failure.time <- pmin(rexp(n) * X[, 1] + W, Y.max)
  censor.time <- 4 * runif(n)
  Y <- pmin(failure.time, censor.time)
  D <- as.integer(failure.time <= censor.time)
  Y <- round(Y, 2)

  e <- 1 / (1 + exp(-4 * X[, 1]))
  w <- runif(n) <= e
  sample.weights <- 1 / e[w]

  r.monte.carlo <- rexp(5000)
  tau <- rep(NA, n)
  for (i in 1:n) {
    tau[i] <- mean(pmin(r.monte.carlo * X[i, 1] + 1, Y.max) -
                     pmin(r.monte.carlo * X[i, 1], Y.max))
  }

  cs.forest <- causal_survival_forest(X[w, ], Y[w], W[w], D[w], num.trees = 500)
  cs.forest.weighted <- causal_survival_forest(X[w, ], Y[w], W[w], D[w], sample.weights = sample.weights, num.trees = 500)

  mse <- mean((predict(cs.forest, X)$predictions - tau)^2)
  mse.weighted <- mean((predict(cs.forest.weighted, X)$predictions - tau)^2)

  mse.weighted / mse
}))
# Min. 1st Qu.  Median    Mean 3rd Qu.    Max.
# 0.6104  0.8003  0.8887  0.8913  0.9656  1.2659
```
(max > 1.0 is just rare behavior)

2. #### Coverage check: sample weighting with IPCW maintains reasonable complete-data coverage
```R
summary(replicate(100, {
  n <- 2000
  p <- 5
  X <- matrix(runif(n * p), n, p)
  W <- rbinom(n, 1, 0.5)
  Y.max <- 1
  failure.time <- pmin(rexp(n) * X[, 1] + W, Y.max)
  censor.time <- 4 * runif(n)
  Y <- pmin(failure.time, censor.time)
  D <- as.integer(failure.time <= censor.time)
  Y <- round(Y, 2)
  
  e <- 1 / (1 + exp(-4 * X[, 1]))
  w <- runif(n) <= e
  sample.weights <- 1 / e[w]
  
  r.monte.carlo <- rexp(5000)
  tau <- rep(NA, n)
  for (i in 1:n) {
    tau[i] <- mean(pmin(r.monte.carlo * X[i, 1] + 1, Y.max) -
                     pmin(r.monte.carlo * X[i, 1], Y.max))
  }
  
  cs.forest.weighted <- causal_survival_forest(X[w, ], Y[w], W[w], D[w], sample.weights = sample.weights, num.trees = 500)
  pp <- predict(cs.forest.weighted, X, estimate.variance = TRUE)
  ub <- pp$predictions + 1.96 * sqrt(pp$variance.estimates)  
  lb <- pp$predictions - 1.96 * sqrt(pp$variance.estimates)  
  mean(lb < tau & tau < ub)
}))
# Min. 1st Qu.  Median    Mean 3rd Qu.    Max. 
# 0.7515  0.8669  0.9065  0.8992  0.9315  0.9865 

# Same simulation on complete data:
# Min. 1st Qu.  Median    Mean 3rd Qu.    Max. 
# 0.6965  0.8718  0.9107  0.8965  0.9333  0.9840 

```
