### PR TITLE
Replace any(is.na(x)) with anyNA(x)

### DIFF
--- a/r-package/grf/R/input_utilities.R
+++ b/r-package/grf/R/input_utilities.R
@@ -21,7 +21,7 @@ validate_X <- function(X, allow.na = FALSE) {
     ))
   }
 
-  has.missing.values <- any(is.na(X))
+  has.missing.values <- anyNA(X)
 
   if (!allow.na && has.missing.values) {
     stop("The feature matrix X contains at least one NA.")
@@ -52,7 +52,7 @@ validate_observations <- function(V, X, allow.matrix = FALSE) {
     ))
   }
 
-  if (any(is.na(V))) {
+  if (anyNA(V)) {
     stop("The vector of observations (W, Y, Z or D) contains at least one NA.")
   }
 

--- a/r-package/grf/R/multi_arm_causal_forest.R
+++ b/r-package/grf/R/multi_arm_causal_forest.R
@@ -194,7 +194,7 @@ multi_arm_causal_forest <- function(X, Y, W,
   if (length(W) != nrow(X)) {
     stop("length of observation (W, Y, Z or D) does not equal nrow(X).")
   }
-  if (any(is.na(W))) {
+  if (anyNA(W)) {
     stop("The vector of observations (W, Y, Z or D) contains at least one NA.")
   }
   if (!is.factor(W)) {

--- a/r-package/grf/R/probability_forest.R
+++ b/r-package/grf/R/probability_forest.R
@@ -104,7 +104,7 @@ probability_forest <- function(X, Y,
   if (length(Y) != nrow(X)) {
     stop("length of observations Y does not equal nrow(X).")
   }
-  if (any(is.na(Y))) {
+  if (anyNA(Y)) {
     stop("The vector of observations contains at least one NA.")
   }
   if (!is.factor(Y)) {

--- a/r-package/grf/R/tune_forest.R
+++ b/r-package/grf/R/tune_forest.R
@@ -47,7 +47,7 @@ tune_forest <- function(data,
     mean(error, na.rm = TRUE)
   })
 
-  if (any(is.na(small.forest.errors))) {
+  if (anyNA(small.forest.errors)) {
     warning(paste0(
       "Could not tune forest because some small forest error estimates were NA.\n",
       "Consider increasing tuning argument tune.num.trees."))


### PR DESCRIPTION
Since [R 3.1](https://cran.r-project.org/doc/manuals/r-release/NEWS.3.html) there is a fast vectorized alternative to `any(is.na(x))`: `anyNA(x)` (https://stat.ethz.ch/R-manual/R-patched/library/base/html/NA.html). Make use of this the few places an NA check is needed.

