### PR TITLE
Remove `orthog.boosting` argument

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -222,7 +222,7 @@ The accuracy of a forest can be sensitive to several training parameters:
 - the parameters that control honesty behavior `honesty.fraction` and `honesty.prune.leaves`
 - the split balance parameters `alpha` and `imbalance.penalty`
 
-GRF provides a cross-validation procedure to select values of these parameters to use in training. To enable this tuning during training, the option `tune.parameters = "all"` can be passed to main forest method.
+GRF provides a cross-validation procedure to select values of these parameters to use in training. To enable this tuning during training, the option `tune.parameters = "all"` can be passed to main forest method. The cross-validation methods can also be called directly through `tune_regression_forest` and `tune_causal_forest`. Parameter tuning is currently disabled by default.
 
 The cross-validation procedure works as follows:
 - Draw a number of random points in the space of possible parameter values. By default, 100 distinct sets of parameter values are chosen (`tune.num.reps`).

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -255,8 +255,6 @@ The `boosted_regression_forest` method also contains parameters to control the s
 
 Alternatively, you can to skip the cross-validation procedure and specify the number of steps directly through the parameter `boost.steps`.
 
-By default, `causal_forest` uses `regression_forest` to perform orthogonalization (that is, estimating `e(x) = E[W|X=x]` and `m(x) = E[Y|X=x]`). If the `orthog.boosting` flag is enabled, then `boosted_regression_forest` will be used instead.
-
 Some additional notes about the behavior of boosted regression forests:
 - For computational reasons, if `tune.parameters` is enabled, then parameters are chosen by the `regression_forest` procedure once in the first boosting step. The selected parameters are then applied to train the forests in any further steps.
 - The `estimate.variance` parameter is not available for boosted forests.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -222,7 +222,7 @@ The accuracy of a forest can be sensitive to several training parameters:
 - the parameters that control honesty behavior `honesty.fraction` and `honesty.prune.leaves`
 - the split balance parameters `alpha` and `imbalance.penalty`
 
-GRF provides a cross-validation procedure to select values of these parameters to use in training. To enable this tuning during training, the option `tune.parameters = "all"` can be passed to main forest method. The cross-validation methods can also be called directly through `tune_regression_forest` and `tune_causal_forest`. Parameter tuning is currently disabled by default.
+GRF provides a cross-validation procedure to select values of these parameters to use in training. To enable this tuning during training, the option `tune.parameters = "all"` can be passed to main forest method.
 
 The cross-validation procedure works as follows:
 - Draw a number of random points in the space of possible parameter values. By default, 100 distinct sets of parameter values are chosen (`tune.num.reps`).

--- a/r-package/grf/man/causal_forest.Rd
+++ b/r-package/grf/man/causal_forest.Rd
@@ -29,7 +29,6 @@ causal_forest(
   tune.num.reps = 50,
   tune.num.draws = 1000,
   compute.oob.predictions = TRUE,
-  orthog.boosting = FALSE,
   num.threads = NULL,
   seed = runif(1, 0, .Machine$integer.max)
 )
@@ -122,10 +121,6 @@ Default is "none" (no parameters are tuned).}
 to select the optimal parameters. Default is 1000.}
 
 \item{compute.oob.predictions}{Whether OOB predictions on training set should be precomputed. Default is TRUE.}
-
-\item{orthog.boosting}{(experimental) If TRUE, then when Y.hat = NULL or W.hat is NULL,
-the missing quantities are estimated using boosted regression forests.
-The number of boosting steps is selected automatically. Default is FALSE.}
 
 \item{num.threads}{Number of threads used in training. By default, the number of threads is set
 to the maximum hardware concurrency.}

--- a/r-package/grf/tests/testthat/test_causal_forest.R
+++ b/r-package/grf/tests/testthat/test_causal_forest.R
@@ -179,14 +179,6 @@ test_that("IPCC weighting in the training of a causal forest with missing data i
   forest <- causal_forest(X[cc, ], Y[cc], W[cc], num.trees = num.trees)
   weighted.forest <- causal_forest(X[cc, ], Y[cc], W[cc], sample.weights = sample.weights[cc], num.trees = num.trees)
   expect_lt(mse(weighted.forest) / mse(forest), .9)
-
-  boosted.forest <- causal_forest(X[cc, ], Y[cc], W[cc], orthog.boosting = TRUE, num.trees = num.trees)
-  boosted.weighted.forest <- causal_forest(
-      X[cc, ], Y[cc], W[cc],
-      sample.weights = sample.weights[cc],
-      orthog.boosting = TRUE, num.trees = num.trees
-  )
-  expect_lt(mse(boosted.weighted.forest) / mse(boosted.forest), .9)
 })
 
 test_that("Weighting is roughly equivalent to replication of samples", {


### PR DESCRIPTION
Upcoming 2.0 release allows for making some breaking changes trimming unnecessary features: remove the `orthog.boosting` (#388) argument from `causal_forest`. No other forest has this argument, and a user can already pass custom `Y.hat` and `W.hat`.

