### PR TITLE
Add sample.weights/clusters to CSF nuisance args

### DIFF
--- a/r-package/grf/R/causal_survival_forest.R
+++ b/r-package/grf/R/causal_survival_forest.R
@@ -266,6 +266,8 @@ causal_survival_forest <- function(X, Y, W, D,
 
   args.nuisance <- list(failure.times = failure.times,
                         num.trees = max(50, num.trees / 4),
+                        sample.weights = sample.weights,
+                        clusters = clusters,
                         equalize.cluster.weights = equalize.cluster.weights,
                         sample.fraction = sample.fraction,
                         mtry = mtry,


### PR DESCRIPTION
These two entries were missing from the survival nuisance arguments, a re-run of mse from #884:

```
summary(replicate(100, {
  n <- 2000
  p <- 5
  X <- matrix(runif(n * p), n, p)
  W <- rbinom(n, 1, 0.5)
  Y.max <- 1
  failure.time <- pmin(rexp(n) * X[, 1] + W, Y.max)
  censor.time <- 4 * runif(n)
  Y <- pmin(failure.time, censor.time)
  D <- as.integer(failure.time <= censor.time)
  Y <- round(Y, 2)
  
  e <- 1 / (1 + exp(-4 * X[, 1]))
  w <- runif(n) <= e
  sample.weights <- 1 / e[w]
  
  r.monte.carlo <- rexp(5000)
  tau <- rep(NA, n)
  for (i in 1:n) {
    tau[i] <- mean(pmin(r.monte.carlo * X[i, 1] + 1, Y.max) -
                     pmin(r.monte.carlo * X[i, 1], Y.max))
  }
  
  cs.forest <- causal_survival_forest(X[w, ], Y[w], W[w], D[w], num.trees = 500)
  cs.forest.weighted <- causal_survival_forest(X[w, ], Y[w], W[w], D[w], sample.weights = sample.weights, num.trees = 500)
  
  mse <- mean((predict(cs.forest, X)$predictions - tau)^2)
  mse.weighted <- mean((predict(cs.forest.weighted, X)$predictions - tau)^2)
  
  mse.weighted / mse
}))
   Min. 1st Qu.  Median    Mean 3rd Qu.    Max. 
 0.6574  0.8184  0.8836  0.8938  0.9576  1.1432 
```
