### PR TITLE
Return zero in case variance is zero

### DIFF
--- a/core/src/prediction/ObjectiveBayesDebiaser.cpp
+++ b/core/src/prediction/ObjectiveBayesDebiaser.cpp
@@ -39,6 +39,9 @@ double ObjectiveBayesDebiaser::debias(double var_between,
 
   double initial_estimate = var_between - group_noise;
   double initial_se = std::max(var_between, group_noise) * std::sqrt(2.0 / num_good_groups);
+  if (equal_doubles(initial_se, 0.0, 1.0e-10)) {
+    return 0.0;
+  }
 
   double ratio = initial_estimate / initial_se;
 

--- a/core/src/prediction/ObjectiveBayesDebiaser.cpp
+++ b/core/src/prediction/ObjectiveBayesDebiaser.cpp
@@ -24,7 +24,7 @@ namespace grf {
 double ObjectiveBayesDebiaser::debias(double var_between,
                                       double group_noise,
                                       double num_good_groups) const {
-  
+
   // Let S denote the true between-groups variance, and assume that
   // group_noise is measured exactly; our method-of-moments estimate is
   // then \hat{S} = var_between - group_noise. Now, if we take
@@ -36,12 +36,12 @@ double ObjectiveBayesDebiaser::debias(double var_between,
   // relies on this fact, and puts a uniform prior on S for the interval [0, infty).
   // This debiasing does nothing when \hat{S} >> var_between * sqrt(2 / num_good_groups),
   // but keeps \hat{S} from going negative.
-  
+
   double initial_estimate = var_between - group_noise;
   double initial_se = std::max(var_between, group_noise) * std::sqrt(2.0 / num_good_groups);
-  
+
   double ratio = initial_estimate / initial_se;
-  
+
   // corresponds to \int_(-r)^infty x * phi(x) dx, for the standard Gaussian density phi(x)
   double numerator = std::exp(- ratio * ratio / 2) * ONE_over_SQRT_TWO_PI;
 


### PR DESCRIPTION
In the very unlikely event the pointwise variance is zero `ObjectiveBayesDebiaser::debias` will return NaN instead of zero because of a division by 0.

```
> set.seed(4)
> n = 100; p = 5
> X = matrix(rnorm(n*p), n, p)
> Y = rep(10, n)
> Y[1:2] = 20
> rf = regression_forest(X, Y)
> predict(rf, estimate.variance = TRUE)$variance.estimates
  [1]          NaN          NaN 1.084467e-03 6.803920e-04 1.847954e-03 4.816733e-03 8.203224e-01 4.293588e-04
  [9] 1.829098e-04 1.900269e-05 5.725878e-04 5.007151e-04 4.442478e-04 2.015354e+00 9.222246e-04 6.571535e-03
 [17] 4.125939e-05 1.849286e-01 6.999847e-04 4.101375e-03 8.153235e-04 6.298040e-02 2.201760e-04 2.345587e-04
 [25] 5.584594e-04 7.875910e-01 3.903191e-04 2.584297e-02 1.033622e-03          NaN 6.820829e-02 7.781560e-04
 [33] 6.627194e-02 8.416648e-03 7.708847e-03 1.274524e-02 1.032078e-03 4.218256e-04 4.648232e-02 5.286281e-03
 [41] 2.513496e-03 6.221305e-04 7.911286e-01          NaN 1.504383e-03 4.277373e-03 2.169149e-04 6.074676e-03
 [49] 4.358099e-02 6.032285e-05 9.496147e-02 4.849994e-03 5.686745e-03 1.781502e+00 7.227831e-04 2.043368e-02
 [57] 1.092717e-01 5.004730e-04 2.641433e-03 2.109869e-04 1.851874e-01 6.543436e-04 2.123106e-03 1.949772e-05
 [65] 2.143668e-01          NaN 1.389167e+00 4.543741e-04 1.474735e-03 1.689061e-02 4.124312e-02 1.023715e-02
 [73] 1.868594e-04 1.037281e-03 2.020268e+00 3.173060e-03 5.103605e-04 3.988280e-01 9.698419e-04 3.593078e-01
 [81] 1.144471e-02 6.796741e-04 5.030712e-01 5.810431e-01 3.333577e-04 1.291237e-01 6.487563e-01 6.073819e-02
 [89] 1.543236e-01 8.928875e-04 6.950175e-05 3.936929e-03 6.665407e-03 2.611613e-01 3.551226e-04 1.956802e-01
 [97] 1.187531e-04 1.600311e-02 2.019206e-05 3.908156e-03
```

Suggested change: return zero in this case. Let me know if you agree @swager and @jtibshirani.



