### PR TITLE
Use tolerance instead of tol alias

### DIFF
--- a/r-package/grf/tests/testthat/test_average_effect.R
+++ b/r-package/grf/tests/testthat/test_average_effect.R
@@ -298,7 +298,7 @@ test_that("cluster robust average effects do weighting correctly", {
   # `coeftest`, whereas `average_treatment_effect` uses a direct calculation.
   cate.aipw.blp <- best_linear_projection(forest.causal, A = NULL)
   expect_equal(as.numeric(cate.aipw[1]), cate.aipw.blp[1,1])
-  expect_equal(as.numeric(cate.aipw[2]), cate.aipw.blp[1,2], tol = 0.0001)
+  expect_equal(as.numeric(cate.aipw[2]), cate.aipw.blp[1,2], tolerance = 0.0001)
 
   catt.aipw <- average_treatment_effect(forest.causal, target.sample = "treated", method = "AIPW")
   expect_lte(abs(catt.aipw[1] - t0) / (3 * catt.aipw[2]), 1)
@@ -327,8 +327,8 @@ test_that("cluster robust average effects do weighting correctly", {
                                              num.trees = 400)
   compliance.score <- rep(1, n)
   aclate <- average_treatment_effect(forest.instrumental, compliance.score=compliance.score)
-  expect_equal(cate.aipw["estimate"], aclate["estimate"], tol = 0.03)
-  expect_equal(cate.aipw["std.err"], aclate["std.err"], tol = 0.002)
+  expect_equal(cate.aipw["estimate"], aclate["estimate"], tolerance = 0.03)
+  expect_equal(cate.aipw["std.err"], aclate["std.err"], tolerance = 0.002)
 })
 
 test_that("cluster robust average effects do weighting correctly with IPCC weights", {
@@ -380,10 +380,10 @@ test_that("cluster robust average effects do weighting correctly with IPCC weigh
   # `coeftest`, whereas `average_treatment_effect` uses a direct calculation.
   cate.aipw.blp <- best_linear_projection(forest.weighted, A = NULL)
   expect_equal(as.numeric(cate.aipw[1]), cate.aipw.blp[1,1])
-  expect_equal(as.numeric(cate.aipw[2]), cate.aipw.blp[1,2], tol = 0.01)
+  expect_equal(as.numeric(cate.aipw[2]), cate.aipw.blp[1,2], tolerance = 0.01)
   biased.cate.aipw.blp <- best_linear_projection(forest.unweighted, A = NULL)
   expect_equal(as.numeric(biased.cate.aipw[1]), biased.cate.aipw.blp[1,1])
-  expect_equal(as.numeric(biased.cate.aipw[2]), biased.cate.aipw.blp[1,2], tol = 0.01)
+  expect_equal(as.numeric(biased.cate.aipw[2]), biased.cate.aipw.blp[1,2], tolerance = 0.01)
 
   catt.aipw <- average_treatment_effect(forest.weighted, target.sample = "treated", method = "AIPW")
   biased.catt.aipw <- average_treatment_effect(forest.unweighted, target.sample = "treated", method = "AIPW")
@@ -446,9 +446,9 @@ test_that("average conditional local average treatment effect estimation is reas
   tau.x1p <- average_treatment_effect(forest.iv, compliance.score=compliance.score,
                           subset = X[,1] > 0)
 
-  expect_equal(as.numeric(tau.hat["estimate"]), mean(tau), tol = 0.2)
+  expect_equal(as.numeric(tau.hat["estimate"]), mean(tau), tolerance = 0.2)
   expect_lt(abs(tau.hat["estimate"] - mean(tau)) / tau.hat["std.err"], 3)
 
-  expect_equal(as.numeric(tau.x1p["estimate"]), mean(tau[X[,1] > 0]), tol = 0.3)
+  expect_equal(as.numeric(tau.x1p["estimate"]), mean(tau[X[,1] > 0]), tolerance = 0.3)
   expect_lt(abs(tau.x1p["estimate"] - mean(tau[X[,1] > 0])) / tau.x1p["std.err"], 3)
 })

--- a/r-package/grf/tests/testthat/test_causal_forest.R
+++ b/r-package/grf/tests/testthat/test_causal_forest.R
@@ -311,13 +311,13 @@ test_that("causal_forest works as expected with missing values", {
   diff.mse <- mean((predict(rf.mia, X.mia)$pred - Y)^2) - mean((predict(rf, X)$pred - Y)^2)
   diff.mse.test <- mean((predict(rf.mia, X.mia.test)$pred - Y)^2) - mean((predict(rf, X.test)$pred - Y)^2)
 
-  expect_equal(mse.oob.diff, 0, tol = 0.005)
-  expect_equal(mse.diff, 0, tol = 0.005)
-  expect_equal(mse.test.diff, 0, tol = 0.005)
+  expect_equal(mse.oob.diff, 0, tolerance = 0.005)
+  expect_equal(mse.diff, 0, tolerance = 0.005)
+  expect_equal(mse.test.diff, 0, tolerance = 0.005)
 
-  expect_equal(diff.mse.oob, 0, tol = 0.05)
-  expect_equal(diff.mse, 0, tol = 0.05)
-  expect_equal(diff.mse.test, 0, tol = 0.05)
+  expect_equal(diff.mse.oob, 0, tolerance = 0.05)
+  expect_equal(diff.mse, 0, tolerance = 0.05)
+  expect_equal(diff.mse.test, 0, tolerance = 0.05)
 
   # All NaNs
   X[, ] <- NaN
@@ -331,7 +331,7 @@ test_that("causal_forest works as expected with missing values", {
   rf.mia <- causal_forest(X.mia, Y, W, 0, 0, seed = 123)
   rf <- causal_forest(X, Y, W, 0, 0, seed = 123)
   mse.oob.diff.allnan <- mean((predict(rf.mia)$pred - predict(rf)$pred)^2)
-  expect_equal(mse.oob.diff.allnan, 0, tol = 0.0001)
+  expect_equal(mse.oob.diff.allnan, 0, tolerance = 0.0001)
 })
 
 test_that("a causal forest workflow with missing values works as expected", {

--- a/r-package/grf/tests/testthat/test_causal_survival_forest.R
+++ b/r-package/grf/tests/testthat/test_causal_survival_forest.R
@@ -170,8 +170,8 @@ test_that("causal survival forest works as expected with missing values", {
   mse.oob.diff <- mean((predict(csf)$predictions - predict(csf.mia)$predictions)^2)
   mse.diff <- mean((predict(csf, data$X)$predictions - predict(csf.mia, X.mia)$predictions)^2)
 
-  expect_equal(mse.oob.diff, 0, tol = 0.001)
-  expect_equal(mse.diff, 0, tol = 0.001)
+  expect_equal(mse.oob.diff, 0, tolerance = 0.001)
+  expect_equal(mse.diff, 0, tolerance = 0.001)
 })
 
 # This characterization test locks in behavior for the default causal survival forest.
@@ -231,10 +231,10 @@ test_that("causal survival forest summary functions works as expected", {
   ate.subset <- average_treatment_effect(cs.forest, subset = X[, 1] > 0.5)
 
   expect_equal(blp[1], ate[["estimate"]])
-  expect_equal(blp[2], ate[["std.err"]], tol = 1e-4)
-  expect_equal(ate[["estimate"]], mean(tau), tol = 3 * ate[["std.err"]])
+  expect_equal(blp[2], ate[["std.err"]], tolerance = 1e-4)
+  expect_equal(ate[["estimate"]], mean(tau), tolerance = 3 * ate[["std.err"]])
 
   expect_equal(blp.subset[1], ate.subset[["estimate"]])
-  expect_equal(blp.subset[2], ate.subset[["std.err"]], tol = 1e-4)
-  expect_equal(ate.subset[["estimate"]], mean(tau[X[, 1] > 0.5]), tol = 3 * ate.subset[["std.err"]])
+  expect_equal(blp.subset[2], ate.subset[["std.err"]], tolerance = 1e-4)
+  expect_equal(ate.subset[["estimate"]], mean(tau[X[, 1] > 0.5]), tolerance = 3 * ate.subset[["std.err"]])
 })

--- a/r-package/grf/tests/testthat/test_forest_summaries.R
+++ b/r-package/grf/tests/testthat/test_forest_summaries.R
@@ -160,14 +160,14 @@ test_that("best linear projection is reasonable", {
   beta1.true <- 0.25 # cov(pmax(Z, 0), Z)/2
 
   blp.all <- best_linear_projection(forest, X[,1:2])
-  expect_equal(blp.all[1,1], beta0.true, tol = 0.1)
-  expect_equal(blp.all[2,1], beta1.true, tol = 0.1)
-  expect_equal(blp.all[3,1], 0, tol = 0.1)
+  expect_equal(blp.all[1,1], beta0.true, tolerance = 0.1)
+  expect_equal(blp.all[2,1], beta1.true, tolerance = 0.1)
+  expect_equal(blp.all[3,1], 0, tolerance = 0.1)
 
   blp.subset <- best_linear_projection(forest, X[,1:2], subset = (S == 1))
-  expect_equal(blp.subset[1,1], beta0.true * 2, tol = 0.2)
-  expect_equal(blp.subset[2,1], beta1.true * 2, tol = 0.2)
-  expect_equal(blp.subset[3,1], 0, tol = 0.2)
+  expect_equal(blp.subset[1,1], beta0.true * 2, tolerance = 0.2)
+  expect_equal(blp.subset[2,1], beta1.true * 2, tolerance = 0.2)
+  expect_equal(blp.subset[3,1], 0, tolerance = 0.2)
 
   std.errs <- c((blp.all[1,1] - beta0.true) / blp.all[1,2],
                (blp.all[2,1] - beta1.true) / blp.all[2,2],
@@ -180,11 +180,11 @@ test_that("best linear projection is reasonable", {
   expect_gt(mean(abs(std.errs)), 0.25)
 
   blp.shifted <- best_linear_projection(forest.shifted.W, X[,1:2])
-  expect_equal(blp.all[, "Estimate"], blp.shifted[, "Estimate"], tol = 0.05)
-  expect_equal(blp.all[, "Std. Error"], blp.shifted[, "Std. Error"], tol = 0.05)
+  expect_equal(blp.all[, "Estimate"], blp.shifted[, "Estimate"], tolerance = 0.05)
+  expect_equal(blp.all[, "Std. Error"], blp.shifted[, "Std. Error"], tolerance = 0.05)
 
   blp.2W <- best_linear_projection(forest.2W, X[,1:2])
-  expect_equal(blp.all[, "Estimate"]/2, blp.2W[, "Estimate"], tol = 0.05)
+  expect_equal(blp.all[, "Estimate"]/2, blp.2W[, "Estimate"], tolerance = 0.05)
 })
 
 test_that("best linear projection works with edge case input types", {
@@ -212,12 +212,12 @@ test_that("best linear projection works as expected with causal survival forest"
 
   ate.true <- mean(data.test$cate)
   blp.ate <- best_linear_projection(cs.forest)
-  expect_equal(ate.true, blp.ate[1, "Estimate"], tol = 2.1 * sqrt(blp.ate[1, "Std. Error"]))
+  expect_equal(ate.true, blp.ate[1, "Estimate"], tolerance = 2.1 * sqrt(blp.ate[1, "Std. Error"]))
 
   A1 <- data.test$X[, 1]
   blp.X1.true <- lm(data.test$cate ~ A1)$coefficients
   blp.X1 <- best_linear_projection(cs.forest, data$X[, 1])
-  expect_equal(blp.X1.true, blp.X1[, "Estimate"], tol = 2.1 * sqrt(blp.X1[, "Std. Error"]))
+  expect_equal(blp.X1.true, blp.X1[, "Estimate"], tolerance = 2.1 * sqrt(blp.X1[, "Std. Error"]))
 
   weights <- rep(1, n)
   dup <- sample(1:n, 50)
@@ -230,5 +230,5 @@ test_that("best linear projection works as expected with causal survival forest"
 
   blp.weight <- best_linear_projection(cs.forest.weight)
   blp.dup <- best_linear_projection(cs.forest.dup)
-  expect_equal(blp.weight[1, "Estimate"], blp.dup[1, "Estimate"], tol = 0.01)
+  expect_equal(blp.weight[1, "Estimate"], blp.dup[1, "Estimate"], tolerance = 0.01)
 })

--- a/r-package/grf/tests/testthat/test_multi_arm_causal_forest.R
+++ b/r-package/grf/tests/testthat/test_multi_arm_causal_forest.R
@@ -22,15 +22,15 @@ test_that("single treatment multi_arm_causal_forest is similar to causal_forest"
   pp.mcf <- predict(mcf, estimate.variance = TRUE)
   z.cf <- abs(pp.cf$predictions - tau) / sqrt(pp.cf$variance.estimates)
   z.mcf <- abs(pp.mcf$predictions[,,] - tau) / sqrt(pp.mcf$variance.estimates)
-  expect_equal(mean(z.cf <= 1.96), mean(z.mcf <= 1.96), tol = 0.05)
+  expect_equal(mean(z.cf <= 1.96), mean(z.mcf <= 1.96), tolerance = 0.05)
 
-  expect_equal(mean((pp.cf$predictions - pp.mcf$predictions)^2), 0, tol = 0.05)
-  expect_equal(mean(pp.cf$predictions), mean(pp.mcf$predictions), tol = 0.05)
+  expect_equal(mean((pp.cf$predictions - pp.mcf$predictions)^2), 0, tolerance = 0.05)
+  expect_equal(mean(pp.cf$predictions), mean(pp.mcf$predictions), tolerance = 0.05)
 
-  expect_equal(mean((predict(cf, X)$predictions - predict(mcf, X)$predictions)^2), 0, tol = 0.05)
-  expect_equal(mean(predict(cf, X)$predictions), mean(predict(mcf, X)$predictions), tol = 0.05)
+  expect_equal(mean((predict(cf, X)$predictions - predict(mcf, X)$predictions)^2), 0, tolerance = 0.05)
+  expect_equal(mean(predict(cf, X)$predictions), mean(predict(mcf, X)$predictions), tolerance = 0.05)
 
-  expect_equal(average_treatment_effect(cf), average_treatment_effect(mcf)[,], tol = 0.001)
+  expect_equal(average_treatment_effect(cf), average_treatment_effect(mcf)[,], tolerance = 0.001)
 })
 
 test_that("multi_arm_causal_forest contrasts works as expected", {
@@ -49,18 +49,18 @@ test_that("multi_arm_causal_forest contrasts works as expected", {
   tau.hat.C <- predict(mcf.C, X)$predictions[,,]
 
   # 1. With easy constant treatment effects we estimate the correct contrasts
-  expect_equal(colMeans(tau.hat.oob.A), c("B - A" = 2.8 - 1.5, "C - A" = -4 - 1.5), tol = 0.04)
-  expect_equal(colMeans(tau.hat.A), c("B - A" = 2.8 - 1.5, "C - A" = -4 - 1.5), tol = 0.04)
-  expect_equal(colMeans(tau.hat.oob.C), c("A - C" = 1.5 - (-4), "B - C" = 2.8 - (-4)), tol = 0.04)
-  expect_equal(colMeans(tau.hat.C), c("A - C" = 1.5 - (-4), "B - C" = 2.8 - (-4)), tol = 0.04)
+  expect_equal(colMeans(tau.hat.oob.A), c("B - A" = 2.8 - 1.5, "C - A" = -4 - 1.5), tolerance = 0.04)
+  expect_equal(colMeans(tau.hat.A), c("B - A" = 2.8 - 1.5, "C - A" = -4 - 1.5), tolerance = 0.04)
+  expect_equal(colMeans(tau.hat.oob.C), c("A - C" = 1.5 - (-4), "B - C" = 2.8 - (-4)), tolerance = 0.04)
+  expect_equal(colMeans(tau.hat.C), c("A - C" = 1.5 - (-4), "B - C" = 2.8 - (-4)), tolerance = 0.04)
 
   # 2. The estimated contrast respects the symmetry properties we expect. It is not possible to check
   # this invariant exactly since differences in relabeling may lead to different trees
-  expect_equal(tau.hat.oob.A[, "C - A"], -1 * tau.hat.oob.C[, "A - C"], tol = 0.01)
-  expect_equal(tau.hat.A[, "C - A"], -1 * tau.hat.C[, "A - C"], tol = 0.01)
+  expect_equal(tau.hat.oob.A[, "C - A"], -1 * tau.hat.oob.C[, "A - C"], tolerance = 0.01)
+  expect_equal(tau.hat.A[, "C - A"], -1 * tau.hat.C[, "A - C"], tolerance = 0.01)
 
-  expect_equal(tau.hat.oob.A[, "B - A"] - tau.hat.oob.A[, "C - A"], tau.hat.oob.C[, "B - C"], tol = 0.01)
-  expect_equal(tau.hat.A[, "B - A"] - tau.hat.A[, "C - A"], tau.hat.C[, "B - C"], tol = 0.01)
+  expect_equal(tau.hat.oob.A[, "B - A"] - tau.hat.oob.A[, "C - A"], tau.hat.oob.C[, "B - C"], tolerance = 0.01)
+  expect_equal(tau.hat.A[, "B - A"] - tau.hat.A[, "C - A"], tau.hat.C[, "B - C"], tolerance = 0.01)
 
   # The above invariance holds exactly if we ignore splitting and just predict
   mcf.A.ns <- multi_arm_causal_forest(X, Y, W, num.trees = 250, seed = 42, min.node.size = n)
@@ -71,11 +71,11 @@ test_that("multi_arm_causal_forest contrasts works as expected", {
   tau.hat.oob.C.ns <- predict(mcf.C.ns)$predictions[,,]
   tau.hat.C.ns <- predict(mcf.C.ns, X)$predictions[,,]
 
-  expect_equal(tau.hat.oob.A.ns[, "C - A"], -1 * tau.hat.oob.C.ns[, "A - C"], tol = 1e-10)
-  expect_equal(tau.hat.A.ns[, "C - A"], -1 * tau.hat.C.ns[, "A - C"], tol = 1e-10)
+  expect_equal(tau.hat.oob.A.ns[, "C - A"], -1 * tau.hat.oob.C.ns[, "A - C"], tolerance = 1e-10)
+  expect_equal(tau.hat.A.ns[, "C - A"], -1 * tau.hat.C.ns[, "A - C"], tolerance = 1e-10)
 
-  expect_equal(tau.hat.oob.A.ns[, "B - A"] - tau.hat.oob.A.ns[, "C - A"], tau.hat.oob.C.ns[, "B - C"], tol = 1e-10)
-  expect_equal(tau.hat.A.ns[, "B - A"] - tau.hat.A.ns[, "C - A"], tau.hat.C.ns[, "B - C"], tol = 1e-10)
+  expect_equal(tau.hat.oob.A.ns[, "B - A"] - tau.hat.oob.A.ns[, "C - A"], tau.hat.oob.C.ns[, "B - C"], tolerance = 1e-10)
+  expect_equal(tau.hat.A.ns[, "B - A"] - tau.hat.A.ns[, "C - A"], tau.hat.C.ns[, "B - C"], tolerance = 1e-10)
 })
 
 test_that("multi_arm_causal_forest with binary treatment respects contrast invariance", {
@@ -98,9 +98,9 @@ test_that("multi_arm_causal_forest with binary treatment respects contrast invar
   pp.flipped <- predict(cf.flipped)$predictions[,,]
   pp.relevel <- predict(cf.relevel)$predictions[,,]
 
-  expect_equal(pp, -1 * pp.flipped, tol = 0)
-  expect_equal(pp, -1 * pp.relevel, tol = 0)
-  expect_equal(pp.flipped, pp.relevel, tol = 0)
+  expect_equal(pp, -1 * pp.flipped, tolerance = 0)
+  expect_equal(pp, -1 * pp.relevel, tolerance = 0)
+  expect_equal(pp.flipped, pp.relevel, tolerance = 0)
 })
 
 test_that("multi_arm_causal_forest ATE works as expected", {
@@ -114,17 +114,17 @@ test_that("multi_arm_causal_forest ATE works as expected", {
   mcf <- multi_arm_causal_forest(X, Y, W, num.trees = 500)
 
   ate <- average_treatment_effect(mcf)
-  expect_equal(ate["B - A", "estimate"], mean(tauB), tol = 3 * ate["B - A", "std.err"])
-  expect_equal(ate["C - A", "estimate"], mean(tauC), tol = 3 * ate["C - A", "std.err"])
+  expect_equal(ate["B - A", "estimate"], mean(tauB), tolerance = 3 * ate["B - A", "std.err"])
+  expect_equal(ate["C - A", "estimate"], mean(tauC), tolerance = 3 * ate["C - A", "std.err"])
 
   ate.subset <- average_treatment_effect(mcf, subset = X[, 2] < 0)
-  expect_equal(ate.subset["B - A", "estimate"], 0, tol = 3 * ate.subset["B - A", "std.err"])
+  expect_equal(ate.subset["B - A", "estimate"], 0, tolerance = 3 * ate.subset["B - A", "std.err"])
 
   mcf.B <- multi_arm_causal_forest(X, Y, relevel(W, ref = "B"), num.trees = 500)
   ate.B <- average_treatment_effect(mcf.B)
 
-  expect_equal(ate.B["A - B", "estimate"], -1 * ate["B - A", "estimate"], tol = 0.05)
-  expect_equal(ate.B["C - B", "estimate"], ate["C - A", "estimate"] - ate["B - A", "estimate"], tol = 0.05)
+  expect_equal(ate.B["A - B", "estimate"], -1 * ate["B - A", "estimate"], tolerance = 0.05)
+  expect_equal(ate.B["C - B", "estimate"], ate["C - A", "estimate"] - ate["B - A", "estimate"], tolerance = 0.05)
 })
 
 test_that("multi_arm_causal_forest ATE standard errors are consistent with rest of GRF", {
@@ -146,8 +146,8 @@ test_that("multi_arm_causal_forest ATE standard errors are consistent with rest 
                               cluster = clusters <- if (length(mcf$clusters) > 0)
                                 mcf$clusters else 1:length(mcf$Y.orig)
                               )
-  expect_equal(ate[1, 2], lm.test[1, 2], tol = 1e-10)
-  expect_equal(ate[2, 2], lm.test[2, 2], tol = 1e-10)
+  expect_equal(ate[1, 2], lm.test[1, 2], tolerance = 1e-10)
+  expect_equal(ate[2, 2], lm.test[2, 2], tolerance = 1e-10)
 })
 
 test_that("multi_arm_causal_forest predictions are kernel weighted correctly", {
@@ -172,8 +172,8 @@ test_that("multi_arm_causal_forest predictions are kernel weighted correctly", {
   alpha1.weighted <- get_forest_weights(mcf.weighted, x1)[1, ]
   theta1.lm.weighted <- lm(Y ~ W.matrix[, -1], weights = alpha1.weighted * sample.weights)
 
-  expect_equal(as.numeric(theta1), as.numeric(theta1.lm$coefficients[-1]), tol = 1e-6)
-  expect_equal(as.numeric(theta1.weighted), as.numeric(theta1.lm.weighted$coefficients[-1]), tol = 1e-6)
+  expect_equal(as.numeric(theta1), as.numeric(theta1.lm$coefficients[-1]), tolerance = 1e-6)
+  expect_equal(as.numeric(theta1.weighted), as.numeric(theta1.lm.weighted$coefficients[-1]), tolerance = 1e-6)
 })
 
 test_that("multi_arm_causal_forest predictions and variance estimates are invariant to scaling of the sample weights.", {
@@ -193,9 +193,9 @@ test_that("multi_arm_causal_forest predictions and variance estimates are invari
   pred.1 <- predict(forest.1, estimate.variance = TRUE)
   pred.2 <- predict(forest.2, estimate.variance = TRUE)
 
-  expect_equal(pred.1$predictions, pred.2$predictions, tol = 1e-10)
-  # expect_equal(pred.1$variance.estimates, pred.2$variance.estimates, tol = 1e-10)
-  # expect_equal(pred.1$debiased.error, pred.2$debiased.error, tol = 1e-10)
+  expect_equal(pred.1$predictions, pred.2$predictions, tolerance = 1e-10)
+  # expect_equal(pred.1$variance.estimates, pred.2$variance.estimates, tolerance = 1e-10)
+  # expect_equal(pred.1$debiased.error, pred.2$debiased.error, tolerance = 1e-10)
 })
 
 test_that("multi_arm_causal_forest confidence intervals are reasonable", {

--- a/r-package/grf/tests/testthat/test_quantile_forest.R
+++ b/r-package/grf/tests/testthat/test_quantile_forest.R
@@ -84,6 +84,6 @@ test_that("quantile_forest works as expected with missing values", {
   mean.diff.oob <- colMeans((predict(rf)$predictions - predict(rf.mia)$predictions))
   mean.diff <- colMeans((predict(rf, X)$predictions - predict(rf.mia, X.mia)$predictions))
 
-  expect_equal(mean.diff.oob, c(0, 0, 0), tol = 0.5)
-  expect_equal(mean.diff, c(0, 0, 0), tol = 0.5)
+  expect_equal(mean.diff.oob, c(0, 0, 0), tolerance = 0.5)
+  expect_equal(mean.diff, c(0, 0, 0), tolerance = 0.5)
 })

--- a/r-package/grf/tests/testthat/test_regression_forest.R
+++ b/r-package/grf/tests/testthat/test_regression_forest.R
@@ -286,13 +286,13 @@ test_that("regression_forest works as expected with missing values", {
   diff.mse <- mean((predict(rf.mia, X.mia)$pred - Y)^2) - mean((predict(rf, X)$pred - Y)^2)
   diff.mse.test <- mean((predict(rf.mia, X.mia.test)$pred - Y)^2) - mean((predict(rf, X.test)$pred - Y)^2)
 
-  expect_equal(mse.oob.diff, 0, tol = 0.001)
-  expect_equal(mse.diff, 0, tol = 0.001)
-  expect_equal(mse.test.diff, 0, tol = 0.001)
+  expect_equal(mse.oob.diff, 0, tolerance = 0.001)
+  expect_equal(mse.diff, 0, tolerance = 0.001)
+  expect_equal(mse.test.diff, 0, tolerance = 0.001)
 
-  expect_equal(diff.mse.oob, 0, tol = 0.01)
-  expect_equal(diff.mse, 0, tol = 0.01)
-  expect_equal(diff.mse.test, 0, tol = 0.01)
+  expect_equal(diff.mse.oob, 0, tolerance = 0.01)
+  expect_equal(diff.mse, 0, tolerance = 0.01)
+  expect_equal(diff.mse.test, 0, tolerance = 0.01)
 
   # All NaNs
   X[, ] <- NaN
@@ -306,5 +306,5 @@ test_that("regression_forest works as expected with missing values", {
   rf.mia <- regression_forest(X.mia, Y, seed = 123)
   rf <- regression_forest(X, Y, seed = 123)
   mse.oob.diff.allnan <- mean((predict(rf.mia)$pred - predict(rf)$pred)^2)
-  expect_equal(mse.oob.diff.allnan, 0, tol = 0.0001)
+  expect_equal(mse.oob.diff.allnan, 0, tolerance = 0.0001)
 })

--- a/r-package/grf/tests/testthat/test_survival_forest.R
+++ b/r-package/grf/tests/testthat/test_survival_forest.R
@@ -109,6 +109,6 @@ test_that("survival_forest works as expected with missing values", {
   mse.oob.diff <- mean(rowMeans((predict(sf)$predictions - predict(sf.mia)$predictions)^2))
   mse.diff <- mean(rowMeans((predict(sf, X)$predictions - predict(sf.mia, X.mia)$predictions)^2))
 
-  expect_equal(mse.oob.diff, 0, tol = 0.001)
-  expect_equal(mse.diff, 0, tol = 0.001)
+  expect_equal(mse.oob.diff, 0, tolerance = 0.001)
+  expect_equal(mse.diff, 0, tolerance = 0.001)
 })


### PR DESCRIPTION
Explicitly pass argument `tolerance`, as `tol` is an undocumented alias in expect_equal.