### PR TITLE
Store outcomes/treatments in separate data matrix

### DIFF
--- a/core/src/commons/Data.cpp
+++ b/core/src/commons/Data.cpp
@@ -142,23 +142,33 @@ bool Data::load_from_other_file(std::ifstream& input_file,
 }
 
 void Data::set_outcome_index(size_t index) {
-  this->outcome_index = std::vector<size_t>({index});
-  disallowed_split_variables.insert(index);
+  set_outcome_index(std::vector<size_t>({index}));
 }
 
 void Data::set_outcome_index(const std::vector<size_t>& index) {
   this->outcome_index = index;
   disallowed_split_variables.insert(index.begin(), index.end());
+  this->outcomes = Eigen::MatrixXd(get_num_rows(), index.size());
+  for (size_t i = 0; i < get_num_rows(); i++) {
+    for (size_t j = 0; j < index.size(); j++) {
+      this->outcomes(i, j) = get(i, index[j]);
+    }
+  }
 }
 
 void Data::set_treatment_index(size_t index) {
-  this->treatment_index = std::vector<size_t>({index});
-  disallowed_split_variables.insert(index);
+  set_treatment_index(std::vector<size_t>({index}));
 }
 
 void Data::set_treatment_index(const std::vector<size_t>& index) {
   this->treatment_index = index;
   disallowed_split_variables.insert(index.begin(), index.end());
+  this->treatments = Eigen::MatrixXd(get_num_rows(), index.size());
+  for (size_t i = 0; i < get_num_rows(); i++) {
+    for (size_t j = 0; j < index.size(); j++) {
+      this->treatments(i, j) = get(i, index[j]);
+    }
+  }
 }
 
 void Data::set_instrument_index(size_t index) {
@@ -247,24 +257,16 @@ double Data::get_outcome(size_t row) const {
   return get(row, outcome_index.value()[0]);
 }
 
-Eigen::VectorXd Data::get_outcomes(size_t row) const {
-  Eigen::VectorXd out(outcome_index.value().size());
-  for (size_t i = 0; i < outcome_index.value().size(); i++) {
-    out(i) = get(row, outcome_index.value()[i]);
-  }
-  return out;
+Eigen::MatrixXd::ConstRowXpr Data::get_outcomes(size_t row) const {
+  return outcomes.row(row);
 }
 
 double Data::get_treatment(size_t row) const {
   return get(row, treatment_index.value()[0]);
 }
 
-Eigen::VectorXd Data::get_treatments(size_t row) const {
-  Eigen::VectorXd out(treatment_index.value().size());
-  for (size_t i = 0; i < treatment_index.value().size(); i++) {
-    out(i) = get(row, treatment_index.value()[i]);
-  }
-  return out;
+Eigen::MatrixXd::ConstRowXpr Data::get_treatments(size_t row) const {
+  return treatments.row(row);
 }
 
 double Data::get_instrument(size_t row) const {

--- a/core/src/commons/Data.h
+++ b/core/src/commons/Data.h
@@ -48,10 +48,22 @@ public:
 
   void set_outcome_index(size_t index);
 
+  /**
+   * Sets index for multiple responses.
+   * For performance reasons the data is copied into a separate Eigen matrix.
+   * This means the public method `set` will not work as expected if used
+   * to change elements in the response data.
+   */
   void set_outcome_index(const std::vector<size_t>& index);
 
   void set_treatment_index(size_t index);
 
+  /**
+   * Sets index for multiple treatments.
+   * For performance reasons the data is copied into a separate Eigen matrix.
+   * This means the public method `set` will not work as expected if used
+   * to change elements in the treatments data.
+   */
   void set_treatment_index(const std::vector<size_t>& index);
 
   void set_instrument_index(size_t index);
@@ -89,11 +101,11 @@ public:
 
   double get_outcome(size_t row) const;
 
-  Eigen::VectorXd get_outcomes(size_t row) const;
+  Eigen::MatrixXd::ConstRowXpr get_outcomes(size_t row) const;
 
   double get_treatment(size_t row) const;
 
-  Eigen::VectorXd get_treatments(size_t row) const;
+  Eigen::MatrixXd::ConstRowXpr get_treatments(size_t row) const;
 
   double get_instrument(size_t row) const;
 
@@ -119,6 +131,8 @@ protected:
   nonstd::optional<size_t> causal_survival_numerator_index;
   nonstd::optional<size_t> causal_survival_denominator_index;
   nonstd::optional<size_t> censor_index;
+  Eigen::MatrixXd outcomes;
+  Eigen::MatrixXd treatments;
 
 private:
   DISALLOW_COPY_AND_ASSIGN(Data);


### PR DESCRIPTION
A simple way (at the cost of slight redundancy) of addressing 2. in #747. 

Will make a speed difference for multivariate stabilized splits where there are many calls to `get_treatments`.