### PR TITLE
Access single-variable responses_by_sample with (sample, 0) instead of (sample)

### DIFF
--- a/core/src/relabeling/CausalSurvivalRelabelingStrategy.cpp
+++ b/core/src/relabeling/CausalSurvivalRelabelingStrategy.cpp
@@ -47,7 +47,7 @@ bool CausalSurvivalRelabelingStrategy::relabel(
   for (size_t sample : samples) {
     double response = (data.get_causal_survival_numerator(sample) -
       data.get_causal_survival_denominator(sample) * eta) / denominator_sum;
-    responses_by_sample(sample) = response;
+    responses_by_sample(sample, 0) = response;
   }
   return false;
 }

--- a/core/src/relabeling/InstrumentalRelabelingStrategy.cpp
+++ b/core/src/relabeling/InstrumentalRelabelingStrategy.cpp
@@ -86,7 +86,7 @@ bool InstrumentalRelabelingStrategy::relabel(
     double regularized_instrument = (1 - reduced_form_weight) * instrument + reduced_form_weight * treatment;
 
     double residual = (response - average_outcome) - local_average_treatment_effect * (treatment - average_treatment);
-    responses_by_sample(sample) = (regularized_instrument - average_regularized_instrument) * residual;
+    responses_by_sample(sample, 0) = (regularized_instrument - average_regularized_instrument) * residual;
   }
   return false;
 }

--- a/core/src/relabeling/LLRegressionRelabelingStrategy.cpp
+++ b/core/src/relabeling/LLRegressionRelabelingStrategy.cpp
@@ -86,7 +86,7 @@ bool LLRegressionRelabelingStrategy::relabel(
   for (size_t sample : samples) {
       double prediction_sample = leaf_predictions(i);
       double residual = prediction_sample - data.get_outcome(sample);
-      responses_by_sample(sample) = residual;
+      responses_by_sample(sample, 0) = residual;
       i++;
     }
     return false;

--- a/core/src/relabeling/NoopRelabelingStrategy.cpp
+++ b/core/src/relabeling/NoopRelabelingStrategy.cpp
@@ -26,7 +26,7 @@
 
    for (size_t sample : samples) {
      double outcome = data.get_outcome(sample);
-     responses_by_sample(sample) = outcome;
+     responses_by_sample(sample, 0) = outcome;
    }
    return false;
  }

--- a/core/src/relabeling/QuantileRelabelingStrategy.cpp
+++ b/core/src/relabeling/QuantileRelabelingStrategy.cpp
@@ -55,7 +55,7 @@ bool QuantileRelabelingStrategy::relabel(
                                      quantile_cutoffs.end(),
                                      outcome);
     long quantile_index = quantile - quantile_cutoffs.begin();
-    responses_by_sample(sample) = (uint) quantile_index;
+    responses_by_sample(sample, 0) = (uint) quantile_index;
   }
   return false;
 }

--- a/core/src/splitting/CausalSurvivalSplittingRule.cpp
+++ b/core/src/splitting/CausalSurvivalSplittingRule.cpp
@@ -81,7 +81,7 @@ bool CausalSurvivalSplittingRule::find_best_split(const Data& data,
   for (auto& sample : samples[node]) {
     double sample_weight = data.get_weight(sample);
     weight_sum_node += sample_weight;
-    sum_node += sample_weight * responses_by_sample(sample);
+    sum_node += sample_weight * responses_by_sample(sample, 0);
 
     double z = data.get_instrument(sample);
     sum_node_z += sample_weight * z;
@@ -183,7 +183,7 @@ void CausalSurvivalSplittingRule::find_best_split_value(const Data& data,
 
     if (std::isnan(sample_value)) {
       weight_sum_missing += sample_weight;
-      sum_missing += sample_weight * responses_by_sample(sample);
+      sum_missing += sample_weight * responses_by_sample(sample, 0);
       ++n_missing;
 
       sum_z_missing += sample_weight * z;
@@ -196,7 +196,7 @@ void CausalSurvivalSplittingRule::find_best_split_value(const Data& data,
       }
     } else {
       weight_sums[split_index] += sample_weight;
-      sums[split_index] += sample_weight * responses_by_sample(sample);
+      sums[split_index] += sample_weight * responses_by_sample(sample, 0);
       ++counter[split_index];
 
       sums_z[split_index] += sample_weight * z;

--- a/core/src/splitting/InstrumentalSplittingRule.cpp
+++ b/core/src/splitting/InstrumentalSplittingRule.cpp
@@ -76,7 +76,7 @@ bool InstrumentalSplittingRule::find_best_split(const Data& data,
   for (auto& sample : samples[node]) {
     double sample_weight = data.get_weight(sample);
     weight_sum_node += sample_weight;
-    sum_node += sample_weight * responses_by_sample(sample);
+    sum_node += sample_weight * responses_by_sample(sample, 0);
 
     double z = data.get_instrument(sample);
     sum_node_z += sample_weight * z;
@@ -169,7 +169,7 @@ void InstrumentalSplittingRule::find_best_split_value(const Data& data,
 
     if (std::isnan(sample_value)) {
       weight_sum_missing += sample_weight;
-      sum_missing += sample_weight * responses_by_sample(sample);
+      sum_missing += sample_weight * responses_by_sample(sample, 0);
       ++n_missing;
 
       sum_z_missing += sample_weight * z;
@@ -179,7 +179,7 @@ void InstrumentalSplittingRule::find_best_split_value(const Data& data,
       }
     } else {
       weight_sums[split_index] += sample_weight;
-      sums[split_index] += sample_weight * responses_by_sample(sample);
+      sums[split_index] += sample_weight * responses_by_sample(sample, 0);
       ++counter[split_index];
 
       sums_z[split_index] += sample_weight * z;

--- a/core/src/splitting/ProbabilitySplittingRule.cpp
+++ b/core/src/splitting/ProbabilitySplittingRule.cpp
@@ -58,7 +58,7 @@ bool ProbabilitySplittingRule::find_best_split(const Data& data,
   double* class_counts = new double[num_classes]();
   for (size_t i = 0; i < size_node; ++i) {
     size_t sample = samples[node][i];
-    uint sample_class = (uint) std::round(responses_by_sample(sample));
+    uint sample_class = (uint) std::round(responses_by_sample(sample, 0));
     double sample_weight = data.get_weight(sample);
     class_counts[sample_class] += sample_weight;
   }
@@ -123,7 +123,7 @@ void ProbabilitySplittingRule::find_best_split_value(const Data& data,
     size_t sample = sorted_samples[i];
     size_t next_sample = sorted_samples[i + 1];
     double sample_value = data.get(sample, var);
-    uint sample_class = responses_by_sample(sample);
+    uint sample_class = responses_by_sample(sample, 0);
     double sample_weight = data.get_weight(sample);
 
     if (std::isnan(sample_value)) {

--- a/core/src/splitting/RegressionSplittingRule.cpp
+++ b/core/src/splitting/RegressionSplittingRule.cpp
@@ -61,7 +61,7 @@ bool RegressionSplittingRule::find_best_split(const Data& data,
   for (auto& sample : samples[node]) {
     double sample_weight = data.get_weight(sample);
     weight_sum_node += sample_weight;
-    sum_node += sample_weight * responses_by_sample(sample);
+    sum_node += sample_weight * responses_by_sample(sample, 0);
   }
 
   // Initialize the variables to track the best split variable.
@@ -122,7 +122,7 @@ void RegressionSplittingRule::find_best_split_value(const Data& data,
     size_t sample = sorted_samples[i];
     size_t next_sample = sorted_samples[i + 1];
     double sample_value = data.get(sample, var);
-    double response = responses_by_sample(sample);
+    double response = responses_by_sample(sample, 0);
     double sample_weight = data.get_weight(sample);
 
     if (std::isnan(sample_value)) {

--- a/core/src/splitting/SurvivalSplittingRule.cpp
+++ b/core/src/splitting/SurvivalSplittingRule.cpp
@@ -71,7 +71,7 @@ void SurvivalSplittingRule::find_best_split_internal(const Data& data,
   std::vector<double> failure_values;
   for (auto& sample : samples) {
     if (data.is_failure(sample)) {
-      failure_values.push_back(responses_by_sample(sample));
+      failure_values.push_back(responses_by_sample(sample, 0));
     }
   }
 
@@ -105,7 +105,7 @@ void SurvivalSplittingRule::find_best_split_internal(const Data& data,
 
   // Relabel the failure values to range from 0 to the number of failures in this node
   for (auto& sample : samples) {
-    double failure_value = responses_by_sample(sample);
+    double failure_value = responses_by_sample(sample, 0);
     size_t new_failure_value = std::upper_bound(failure_values.begin(), failure_values.end(),
                                                 failure_value) - failure_values.begin();
     relabeled_failures[sample] = new_failure_value;


### PR DESCRIPTION
The shortcut `operator()(Index index)` for arrays is not crystal clearly [documented](https://eigen.tuxfamily.org/dox/classEigen_1_1DenseCoeffsBase_3_01Derived_00_01ReadOnlyAccessors_01_4.html#af9fadc22d12e48c82745dad534a1671a) and appear to rely on logic that can be [deprecated](https://eigen.tuxfamily.org/dox/group__flags.html#ga4b983a15d57cd55806df618ac544d09e).

Switch to accessing `responses_by_sample` with `(sample, 0)` in all single-response forests for future proofness.