### PR TITLE
Pass all Rcpp training/test data as const reference

### DIFF
--- a/r-package/grf/bindings/AnalysisToolsBindings.cpp
+++ b/r-package/grf/bindings/AnalysisToolsBindings.cpp
@@ -50,8 +50,8 @@ Rcpp::NumericMatrix compute_split_frequencies(Rcpp::List forest_object,
 }
 
 Eigen::SparseMatrix<double> compute_sample_weights(Rcpp::List forest_object,
-                                                   Rcpp::NumericMatrix train_matrix,
-                                                   Rcpp::NumericMatrix test_matrix,
+                                                   const Rcpp::NumericMatrix& train_matrix,
+                                                   const Rcpp::NumericMatrix& test_matrix,
                                                    unsigned int num_threads,
                                                    bool oob_prediction) {
   Data train_data = RcppUtilities::convert_data(train_matrix);
@@ -90,8 +90,8 @@ Eigen::SparseMatrix<double> compute_sample_weights(Rcpp::List forest_object,
 
 // [[Rcpp::export]]
 Eigen::SparseMatrix<double> compute_weights(Rcpp::List forest_object,
-                                            Rcpp::NumericMatrix train_matrix,
-                                            Rcpp::NumericMatrix test_matrix,
+                                            const Rcpp::NumericMatrix& train_matrix,
+                                            const Rcpp::NumericMatrix& test_matrix,
                                             unsigned int num_threads) {
   return compute_sample_weights(forest_object, train_matrix,
                                 test_matrix, num_threads, false);
@@ -99,7 +99,7 @@ Eigen::SparseMatrix<double> compute_weights(Rcpp::List forest_object,
 
 // [[Rcpp::export]]
 Eigen::SparseMatrix<double> compute_weights_oob(Rcpp::List forest_object,
-                                                Rcpp::NumericMatrix train_matrix,
+                                                const Rcpp::NumericMatrix& train_matrix,
                                                 unsigned int num_threads) {
   return compute_sample_weights(forest_object, train_matrix,
                                 train_matrix, num_threads, true);

--- a/r-package/grf/bindings/CausalForestBindings.cpp
+++ b/r-package/grf/bindings/CausalForestBindings.cpp
@@ -26,7 +26,7 @@
 using namespace grf;
 
 // [[Rcpp::export]]
-Rcpp::List causal_train(Rcpp::NumericMatrix train_matrix,
+Rcpp::List causal_train(const Rcpp::NumericMatrix& train_matrix,
                         size_t outcome_index,
                         size_t treatment_index,
                         size_t sample_weight_index,
@@ -74,10 +74,10 @@ Rcpp::List causal_train(Rcpp::NumericMatrix train_matrix,
 
 // [[Rcpp::export]]
 Rcpp::List causal_predict(Rcpp::List forest_object,
-                          Rcpp::NumericMatrix train_matrix,
+                          const Rcpp::NumericMatrix& train_matrix,
                           size_t outcome_index,
                           size_t treatment_index,
-                          Rcpp::NumericMatrix test_matrix,
+                          const Rcpp::NumericMatrix& test_matrix,
                           unsigned int num_threads,
                           bool estimate_variance) {
   Data train_data = RcppUtilities::convert_data(train_matrix);
@@ -97,7 +97,7 @@ Rcpp::List causal_predict(Rcpp::List forest_object,
 
 // [[Rcpp::export]]
 Rcpp::List causal_predict_oob(Rcpp::List forest_object,
-                              Rcpp::NumericMatrix train_matrix,
+                              const Rcpp::NumericMatrix& train_matrix,
                               size_t outcome_index,
                               size_t treatment_index,
                               unsigned int num_threads,
@@ -118,10 +118,10 @@ Rcpp::List causal_predict_oob(Rcpp::List forest_object,
 
 // [[Rcpp::export]]
 Rcpp::List ll_causal_predict(Rcpp::List forest_object,
-                             Rcpp::NumericMatrix train_matrix,
+                             const Rcpp::NumericMatrix& train_matrix,
                              size_t outcome_index,
                              size_t treatment_index,
-                             Rcpp::NumericMatrix test_matrix,
+                             const Rcpp::NumericMatrix& test_matrix,
                              std::vector<double> ll_lambda,
                              bool ll_weight_penalty,
                              std::vector<size_t> linear_correction_variables,
@@ -145,7 +145,7 @@ Rcpp::List ll_causal_predict(Rcpp::List forest_object,
 
 // [[Rcpp::export]]
 Rcpp::List ll_causal_predict_oob(Rcpp::List forest_object,
-                                 Rcpp::NumericMatrix train_matrix,
+                                 const Rcpp::NumericMatrix& train_matrix,
                                  size_t outcome_index,
                                  size_t treatment_index,
                                  std::vector<double> ll_lambda,

--- a/r-package/grf/bindings/CausalSurvivalForestBindings.cpp
+++ b/r-package/grf/bindings/CausalSurvivalForestBindings.cpp
@@ -14,7 +14,7 @@
   You should have received a copy of the GNU General Public License
   along with grf. If not, see <http://www.gnu.org/licenses/>.
  #-------------------------------------------------------------------------------*/
- 
+
 #include <Rcpp.h>
 #include <vector>
 
@@ -26,7 +26,7 @@
 using namespace grf;
 
 // [[Rcpp::export]]
-Rcpp::List causal_survival_train(Rcpp::NumericMatrix& train_matrix,
+Rcpp::List causal_survival_train(const Rcpp::NumericMatrix& train_matrix,
                                  size_t causal_survival_numerator_index,
                                  size_t causal_survival_denominator_index,
                                  size_t treatment_index,
@@ -76,8 +76,8 @@ Rcpp::List causal_survival_train(Rcpp::NumericMatrix& train_matrix,
 
 // [[Rcpp::export]]
 Rcpp::List causal_survival_predict(Rcpp::List& forest_object,
-                                   Rcpp::NumericMatrix& train_matrix,
-                                   Rcpp::NumericMatrix& test_matrix,
+                                   const Rcpp::NumericMatrix& train_matrix,
+                                   const Rcpp::NumericMatrix& test_matrix,
                                    unsigned int num_threads,
                                    bool estimate_variance) {
   Data train_data = RcppUtilities::convert_data(train_matrix);
@@ -94,7 +94,7 @@ Rcpp::List causal_survival_predict(Rcpp::List& forest_object,
 
 // [[Rcpp::export]]
 Rcpp::List causal_survival_predict_oob(Rcpp::List& forest_object,
-                                       Rcpp::NumericMatrix& train_matrix,
+                                       const Rcpp::NumericMatrix& train_matrix,
                                        unsigned int num_threads,
                                        bool estimate_variance) {
   Data data = RcppUtilities::convert_data(train_matrix);

--- a/r-package/grf/bindings/InstrumentalForestBindings.cpp
+++ b/r-package/grf/bindings/InstrumentalForestBindings.cpp
@@ -26,7 +26,7 @@
 using namespace grf;
 
 // [[Rcpp::export]]
-Rcpp::List instrumental_train(Rcpp::NumericMatrix train_matrix,
+Rcpp::List instrumental_train(const Rcpp::NumericMatrix& train_matrix,
                               size_t outcome_index,
                               size_t treatment_index,
                               size_t instrument_index,
@@ -74,11 +74,11 @@ Rcpp::List instrumental_train(Rcpp::NumericMatrix train_matrix,
 
 // [[Rcpp::export]]
 Rcpp::List instrumental_predict(Rcpp::List forest_object,
-                                Rcpp::NumericMatrix train_matrix,
+                                const Rcpp::NumericMatrix& train_matrix,
                                 size_t outcome_index,
                                 size_t treatment_index,
                                 size_t instrument_index,
-                                Rcpp::NumericMatrix test_matrix,
+                                const Rcpp::NumericMatrix& test_matrix,
                                 unsigned int num_threads,
                                 bool estimate_variance) {
   Data train_data = RcppUtilities::convert_data(train_matrix);
@@ -98,7 +98,7 @@ Rcpp::List instrumental_predict(Rcpp::List forest_object,
 
 // [[Rcpp::export]]
 Rcpp::List instrumental_predict_oob(Rcpp::List forest_object,
-                                    Rcpp::NumericMatrix train_matrix,
+                                    const Rcpp::NumericMatrix& train_matrix,
                                     size_t outcome_index,
                                     size_t treatment_index,
                                     size_t instrument_index,

--- a/r-package/grf/bindings/MultiCausalForestBindings.cpp
+++ b/r-package/grf/bindings/MultiCausalForestBindings.cpp
@@ -26,7 +26,7 @@
 using namespace grf;
 
 // [[Rcpp::export]]
-Rcpp::List multi_causal_train(Rcpp::NumericMatrix train_matrix,
+Rcpp::List multi_causal_train(const Rcpp::NumericMatrix& train_matrix,
                               const std::vector<size_t>& outcome_index,
                               const std::vector<size_t>& treatment_index,
                               size_t sample_weight_index,
@@ -73,8 +73,8 @@ Rcpp::List multi_causal_train(Rcpp::NumericMatrix train_matrix,
 
 // [[Rcpp::export]]
 Rcpp::List multi_causal_predict(Rcpp::List forest_object,
-                                Rcpp::NumericMatrix train_matrix,
-                                Rcpp::NumericMatrix test_matrix,
+                                const Rcpp::NumericMatrix& train_matrix,
+                                const Rcpp::NumericMatrix& test_matrix,
                                 size_t num_outcomes,
                                 size_t num_treatments,
                                 unsigned int num_threads,
@@ -93,7 +93,7 @@ Rcpp::List multi_causal_predict(Rcpp::List forest_object,
 
 // [[Rcpp::export]]
 Rcpp::List multi_causal_predict_oob(Rcpp::List forest_object,
-                                    Rcpp::NumericMatrix train_matrix,
+                                    const Rcpp::NumericMatrix& train_matrix,
                                     size_t num_outcomes,
                                     size_t num_treatments,
                                     unsigned int num_threads,

--- a/r-package/grf/bindings/MultiRegressionForestBindings.cpp
+++ b/r-package/grf/bindings/MultiRegressionForestBindings.cpp
@@ -26,7 +26,7 @@
 using namespace grf;
 
 // [[Rcpp::export]]
-Rcpp::List multi_regression_train(Rcpp::NumericMatrix& train_matrix,
+Rcpp::List multi_regression_train(const Rcpp::NumericMatrix& train_matrix,
                                   const std::vector<size_t>& outcome_index,
                                   size_t sample_weight_index,
                                   bool use_sample_weights,
@@ -67,8 +67,8 @@ Rcpp::List multi_regression_train(Rcpp::NumericMatrix& train_matrix,
 
 // [[Rcpp::export]]
 Rcpp::List multi_regression_predict(Rcpp::List& forest_object,
-                                    Rcpp::NumericMatrix& train_matrix,
-                                    Rcpp::NumericMatrix& test_matrix,
+                                    const Rcpp::NumericMatrix& train_matrix,
+                                    const Rcpp::NumericMatrix& test_matrix,
                                     size_t num_outcomes,
                                     unsigned int num_threads) {
   Data train_data = RcppUtilities::convert_data(train_matrix);
@@ -84,7 +84,7 @@ Rcpp::List multi_regression_predict(Rcpp::List& forest_object,
 
 // [[Rcpp::export]]
 Rcpp::List multi_regression_predict_oob(Rcpp::List& forest_object,
-                                        Rcpp::NumericMatrix& train_matrix,
+                                        const Rcpp::NumericMatrix& train_matrix,
                                         size_t num_outcomes,
                                         unsigned int num_threads) {
   Data data = RcppUtilities::convert_data(train_matrix);

--- a/r-package/grf/bindings/ProbabilityForestBindings.cpp
+++ b/r-package/grf/bindings/ProbabilityForestBindings.cpp
@@ -14,7 +14,7 @@
   You should have received a copy of the GNU General Public License
   along with grf. If not, see <http://www.gnu.org/licenses/>.
  #-------------------------------------------------------------------------------*/
- 
+
 #include <Rcpp.h>
 #include <vector>
 
@@ -26,7 +26,7 @@
 using namespace grf;
 
 // [[Rcpp::export]]
-Rcpp::List probability_train(Rcpp::NumericMatrix& train_matrix,
+Rcpp::List probability_train(const Rcpp::NumericMatrix& train_matrix,
                              size_t outcome_index,
                              size_t sample_weight_index,
                              bool use_sample_weights,
@@ -69,10 +69,10 @@ Rcpp::List probability_train(Rcpp::NumericMatrix& train_matrix,
 
 // [[Rcpp::export]]
 Rcpp::List probability_predict(Rcpp::List& forest_object,
-                               Rcpp::NumericMatrix& train_matrix,
+                               const Rcpp::NumericMatrix& train_matrix,
                                size_t outcome_index,
                                size_t num_classes,
-                               Rcpp::NumericMatrix& test_matrix,
+                               const Rcpp::NumericMatrix& test_matrix,
                                unsigned int num_threads,
                                bool estimate_variance) {
   Data train_data = RcppUtilities::convert_data(train_matrix);
@@ -89,7 +89,7 @@ Rcpp::List probability_predict(Rcpp::List& forest_object,
 
 // [[Rcpp::export]]
 Rcpp::List probability_predict_oob(Rcpp::List& forest_object,
-                                   Rcpp::NumericMatrix& train_matrix,
+                                   const Rcpp::NumericMatrix& train_matrix,
                                    size_t outcome_index,
                                    size_t num_classes,
                                    unsigned int num_threads,

--- a/r-package/grf/bindings/QuantileForestBindings.cpp
+++ b/r-package/grf/bindings/QuantileForestBindings.cpp
@@ -28,7 +28,7 @@ using namespace grf;
 // [[Rcpp::export]]
 Rcpp::List quantile_train(std::vector<double> quantiles,
                           bool regression_splitting,
-                          Rcpp::NumericMatrix train_matrix,
+                          const Rcpp::NumericMatrix& train_matrix,
                           size_t outcome_index,
                           unsigned int mtry,
                           unsigned int num_trees,
@@ -68,9 +68,9 @@ Rcpp::List quantile_train(std::vector<double> quantiles,
 // [[Rcpp::export]]
 Rcpp::NumericMatrix quantile_predict(Rcpp::List forest_object,
                                      std::vector<double> quantiles,
-                                     Rcpp::NumericMatrix train_matrix,
+                                     const Rcpp::NumericMatrix& train_matrix,
                                      size_t outcome_index,
-                                     Rcpp::NumericMatrix test_matrix,
+                                     const Rcpp::NumericMatrix& test_matrix,
                                      unsigned int num_threads) {
   Data train_data = RcppUtilities::convert_data(train_matrix);
   Data data = RcppUtilities::convert_data(test_matrix);
@@ -88,7 +88,7 @@ Rcpp::NumericMatrix quantile_predict(Rcpp::List forest_object,
 // [[Rcpp::export]]
 Rcpp::NumericMatrix quantile_predict_oob(Rcpp::List forest_object,
                                          std::vector<double> quantiles,
-                                         Rcpp::NumericMatrix train_matrix,
+                                         const Rcpp::NumericMatrix& train_matrix,
                                          size_t outcome_index,
                                          unsigned int num_threads) {
   Data data = RcppUtilities::convert_data(train_matrix);

--- a/r-package/grf/bindings/RcppUtilities.cpp
+++ b/r-package/grf/bindings/RcppUtilities.cpp
@@ -112,7 +112,7 @@ Rcpp::List RcppUtilities::serialize_forest(Forest& forest) {
   return result;
 };
 
-Data RcppUtilities::convert_data(Rcpp::NumericMatrix& input_data) {
+Data RcppUtilities::convert_data(const Rcpp::NumericMatrix& input_data) {
   return Data(input_data.begin(), input_data.nrow(), input_data.ncol());
 }
 

--- a/r-package/grf/bindings/RcppUtilities.h
+++ b/r-package/grf/bindings/RcppUtilities.h
@@ -41,7 +41,7 @@ public:
   static Rcpp::List serialize_forest(Forest& forest);
   static Forest deserialize_forest(const Rcpp::List& forest_object);
 
-  static Data convert_data(Rcpp::NumericMatrix& input_data);
+  static Data convert_data(const Rcpp::NumericMatrix& input_data);
 
   static Rcpp::List create_prediction_object(const std::vector<Prediction>& predictions);
   static void add_predictions(Rcpp::List& output,

--- a/r-package/grf/bindings/RegressionForestBindings.cpp
+++ b/r-package/grf/bindings/RegressionForestBindings.cpp
@@ -26,7 +26,7 @@
 using namespace grf;
 
 // [[Rcpp::export]]
-Rcpp::List regression_train(Rcpp::NumericMatrix train_matrix,
+Rcpp::List regression_train(const Rcpp::NumericMatrix& train_matrix,
                             size_t outcome_index,
                             size_t sample_weight_index,
                             bool use_sample_weights,
@@ -68,9 +68,9 @@ Rcpp::List regression_train(Rcpp::NumericMatrix train_matrix,
 
 // [[Rcpp::export]]
 Rcpp::List regression_predict(Rcpp::List forest_object,
-                              Rcpp::NumericMatrix train_matrix,
+                              const Rcpp::NumericMatrix& train_matrix,
                               size_t outcome_index,
-                              Rcpp::NumericMatrix test_matrix,
+                              const Rcpp::NumericMatrix& test_matrix,
                               unsigned int num_threads,
                               unsigned int estimate_variance) {
   Data train_data = RcppUtilities::convert_data(train_matrix);
@@ -87,7 +87,7 @@ Rcpp::List regression_predict(Rcpp::List forest_object,
 
 // [[Rcpp::export]]
 Rcpp::List regression_predict_oob(Rcpp::List forest_object,
-                                  Rcpp::NumericMatrix train_matrix,
+                                  const Rcpp::NumericMatrix& train_matrix,
                                   size_t outcome_index,
                                   unsigned int num_threads,
                                   bool estimate_variance) {
@@ -104,7 +104,7 @@ Rcpp::List regression_predict_oob(Rcpp::List forest_object,
 }
 
 // [[Rcpp::export]]
-Rcpp::List ll_regression_train(Rcpp::NumericMatrix train_matrix,
+Rcpp::List ll_regression_train(const Rcpp::NumericMatrix& train_matrix,
                             size_t outcome_index,
                             double ll_split_lambda,
                             bool ll_split_weight_penalty,
@@ -141,9 +141,9 @@ Rcpp::List ll_regression_train(Rcpp::NumericMatrix train_matrix,
 
 // [[Rcpp::export]]
 Rcpp::List ll_regression_predict(Rcpp::List forest_object,
-                                Rcpp::NumericMatrix train_matrix,
+                                const Rcpp::NumericMatrix& train_matrix,
                                 size_t outcome_index,
-                                Rcpp::NumericMatrix test_matrix,
+                                const Rcpp::NumericMatrix& test_matrix,
                                 std::vector<double> ll_lambda,
                                 bool ll_weight_penalty,
                                 std::vector<size_t> linear_correction_variables,
@@ -165,7 +165,7 @@ Rcpp::List ll_regression_predict(Rcpp::List forest_object,
 
 // [[Rcpp::export]]
 Rcpp::List ll_regression_predict_oob(Rcpp::List forest_object,
-                                    Rcpp::NumericMatrix train_matrix,
+                                    const Rcpp::NumericMatrix& train_matrix,
                                     size_t outcome_index,
                                     std::vector<double> ll_lambda,
                                     bool ll_weight_penalty,

--- a/r-package/grf/bindings/SurvivalForestBindings.cpp
+++ b/r-package/grf/bindings/SurvivalForestBindings.cpp
@@ -26,7 +26,7 @@
 using namespace grf;
 
 // [[Rcpp::export]]
-Rcpp::List survival_train(Rcpp::NumericMatrix train_matrix,
+Rcpp::List survival_train(const Rcpp::NumericMatrix& train_matrix,
                           size_t outcome_index,
                           size_t censor_index,
                           size_t sample_weight_index,
@@ -72,11 +72,11 @@ Rcpp::List survival_train(Rcpp::NumericMatrix train_matrix,
 
 // [[Rcpp::export]]
 Rcpp::List survival_predict(Rcpp::List forest_object,
-                            Rcpp::NumericMatrix train_matrix,
+                            const Rcpp::NumericMatrix& train_matrix,
                             size_t outcome_index,
                             size_t censor_index,
                             int prediction_type,
-                            Rcpp::NumericMatrix test_matrix,
+                            const Rcpp::NumericMatrix& test_matrix,
                             unsigned int num_threads,
                             size_t num_failures) {
   Data train_data = RcppUtilities::convert_data(train_matrix);
@@ -95,7 +95,7 @@ Rcpp::List survival_predict(Rcpp::List forest_object,
 
 // [[Rcpp::export]]
 Rcpp::List survival_predict_oob(Rcpp::List forest_object,
-                                Rcpp::NumericMatrix train_matrix,
+                                const Rcpp::NumericMatrix& train_matrix,
                                 size_t outcome_index,
                                 size_t censor_index,
                                 int prediction_type,

--- a/r-package/grf/src/RcppExports.cpp
+++ b/r-package/grf/src/RcppExports.cpp
@@ -161,12 +161,12 @@ BEGIN_RCPP
 END_RCPP
 }
 // causal_survival_train
-Rcpp::List causal_survival_train(Rcpp::NumericMatrix& train_matrix, size_t causal_survival_numerator_index, size_t causal_survival_denominator_index, size_t treatment_index, size_t censor_index, size_t sample_weight_index, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double alpha, double imbalance_penalty, bool stabilize_splits, const std::vector<size_t>& clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, unsigned int num_threads, unsigned int seed);
+Rcpp::List causal_survival_train(const Rcpp::NumericMatrix& train_matrix, size_t causal_survival_numerator_index, size_t causal_survival_denominator_index, size_t treatment_index, size_t censor_index, size_t sample_weight_index, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double alpha, double imbalance_penalty, bool stabilize_splits, const std::vector<size_t>& clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, unsigned int num_threads, unsigned int seed);
 RcppExport SEXP _grf_causal_survival_train(SEXP train_matrixSEXP, SEXP causal_survival_numerator_indexSEXP, SEXP causal_survival_denominator_indexSEXP, SEXP treatment_indexSEXP, SEXP censor_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP ci_group_sizeSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP stabilize_splitsSEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP compute_oob_predictionsSEXP, SEXP num_threadsSEXP, SEXP seedSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type causal_survival_numerator_index(causal_survival_numerator_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type causal_survival_denominator_index(causal_survival_denominator_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type treatment_index(treatment_indexSEXP);
@@ -194,14 +194,14 @@ BEGIN_RCPP
 END_RCPP
 }
 // causal_survival_predict
-Rcpp::List causal_survival_predict(Rcpp::List& forest_object, Rcpp::NumericMatrix& train_matrix, Rcpp::NumericMatrix& test_matrix, unsigned int num_threads, bool estimate_variance);
+Rcpp::List causal_survival_predict(Rcpp::List& forest_object, const Rcpp::NumericMatrix& train_matrix, const Rcpp::NumericMatrix& test_matrix, unsigned int num_threads, bool estimate_variance);
 RcppExport SEXP _grf_causal_survival_predict(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP test_matrixSEXP, SEXP num_threadsSEXP, SEXP estimate_varianceSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::List& >::type forest_object(forest_objectSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix& >::type test_matrix(test_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type test_matrix(test_matrixSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     Rcpp::traits::input_parameter< bool >::type estimate_variance(estimate_varianceSEXP);
     rcpp_result_gen = Rcpp::wrap(causal_survival_predict(forest_object, train_matrix, test_matrix, num_threads, estimate_variance));
@@ -209,13 +209,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // causal_survival_predict_oob
-Rcpp::List causal_survival_predict_oob(Rcpp::List& forest_object, Rcpp::NumericMatrix& train_matrix, unsigned int num_threads, bool estimate_variance);
+Rcpp::List causal_survival_predict_oob(Rcpp::List& forest_object, const Rcpp::NumericMatrix& train_matrix, unsigned int num_threads, bool estimate_variance);
 RcppExport SEXP _grf_causal_survival_predict_oob(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP num_threadsSEXP, SEXP estimate_varianceSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::List& >::type forest_object(forest_objectSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     Rcpp::traits::input_parameter< bool >::type estimate_variance(estimate_varianceSEXP);
     rcpp_result_gen = Rcpp::wrap(causal_survival_predict_oob(forest_object, train_matrix, num_threads, estimate_variance));
@@ -355,12 +355,12 @@ BEGIN_RCPP
 END_RCPP
 }
 // multi_regression_train
-Rcpp::List multi_regression_train(Rcpp::NumericMatrix& train_matrix, const std::vector<size_t>& outcome_index, size_t sample_weight_index, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, double alpha, double imbalance_penalty, std::vector<size_t>& clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, unsigned int num_threads, unsigned int seed);
+Rcpp::List multi_regression_train(const Rcpp::NumericMatrix& train_matrix, const std::vector<size_t>& outcome_index, size_t sample_weight_index, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, double alpha, double imbalance_penalty, std::vector<size_t>& clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, unsigned int num_threads, unsigned int seed);
 RcppExport SEXP _grf_multi_regression_train(SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP compute_oob_predictionsSEXP, SEXP num_threadsSEXP, SEXP seedSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< const std::vector<size_t>& >::type outcome_index(outcome_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type sample_weight_index(sample_weight_indexSEXP);
     Rcpp::traits::input_parameter< bool >::type use_sample_weights(use_sample_weightsSEXP);
@@ -383,14 +383,14 @@ BEGIN_RCPP
 END_RCPP
 }
 // multi_regression_predict
-Rcpp::List multi_regression_predict(Rcpp::List& forest_object, Rcpp::NumericMatrix& train_matrix, Rcpp::NumericMatrix& test_matrix, size_t num_outcomes, unsigned int num_threads);
+Rcpp::List multi_regression_predict(Rcpp::List& forest_object, const Rcpp::NumericMatrix& train_matrix, const Rcpp::NumericMatrix& test_matrix, size_t num_outcomes, unsigned int num_threads);
 RcppExport SEXP _grf_multi_regression_predict(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP test_matrixSEXP, SEXP num_outcomesSEXP, SEXP num_threadsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::List& >::type forest_object(forest_objectSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix& >::type test_matrix(test_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type test_matrix(test_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type num_outcomes(num_outcomesSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     rcpp_result_gen = Rcpp::wrap(multi_regression_predict(forest_object, train_matrix, test_matrix, num_outcomes, num_threads));
@@ -398,13 +398,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // multi_regression_predict_oob
-Rcpp::List multi_regression_predict_oob(Rcpp::List& forest_object, Rcpp::NumericMatrix& train_matrix, size_t num_outcomes, unsigned int num_threads);
+Rcpp::List multi_regression_predict_oob(Rcpp::List& forest_object, const Rcpp::NumericMatrix& train_matrix, size_t num_outcomes, unsigned int num_threads);
 RcppExport SEXP _grf_multi_regression_predict_oob(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP num_outcomesSEXP, SEXP num_threadsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::List& >::type forest_object(forest_objectSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type num_outcomes(num_outcomesSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     rcpp_result_gen = Rcpp::wrap(multi_regression_predict_oob(forest_object, train_matrix, num_outcomes, num_threads));
@@ -412,12 +412,12 @@ BEGIN_RCPP
 END_RCPP
 }
 // probability_train
-Rcpp::List probability_train(Rcpp::NumericMatrix& train_matrix, size_t outcome_index, size_t sample_weight_index, bool use_sample_weights, size_t num_classes, unsigned int mtry, unsigned int num_trees, int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double alpha, double imbalance_penalty, const std::vector<size_t>& clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, int num_threads, unsigned int seed);
+Rcpp::List probability_train(const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, size_t sample_weight_index, bool use_sample_weights, size_t num_classes, unsigned int mtry, unsigned int num_trees, int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double alpha, double imbalance_penalty, const std::vector<size_t>& clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, int num_threads, unsigned int seed);
 RcppExport SEXP _grf_probability_train(SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP num_classesSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP ci_group_sizeSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP compute_oob_predictionsSEXP, SEXP num_threadsSEXP, SEXP seedSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type outcome_index(outcome_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type sample_weight_index(sample_weight_indexSEXP);
     Rcpp::traits::input_parameter< bool >::type use_sample_weights(use_sample_weightsSEXP);
@@ -442,16 +442,16 @@ BEGIN_RCPP
 END_RCPP
 }
 // probability_predict
-Rcpp::List probability_predict(Rcpp::List& forest_object, Rcpp::NumericMatrix& train_matrix, size_t outcome_index, size_t num_classes, Rcpp::NumericMatrix& test_matrix, unsigned int num_threads, bool estimate_variance);
+Rcpp::List probability_predict(Rcpp::List& forest_object, const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, size_t num_classes, const Rcpp::NumericMatrix& test_matrix, unsigned int num_threads, bool estimate_variance);
 RcppExport SEXP _grf_probability_predict(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP num_classesSEXP, SEXP test_matrixSEXP, SEXP num_threadsSEXP, SEXP estimate_varianceSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::List& >::type forest_object(forest_objectSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type outcome_index(outcome_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type num_classes(num_classesSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix& >::type test_matrix(test_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type test_matrix(test_matrixSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     Rcpp::traits::input_parameter< bool >::type estimate_variance(estimate_varianceSEXP);
     rcpp_result_gen = Rcpp::wrap(probability_predict(forest_object, train_matrix, outcome_index, num_classes, test_matrix, num_threads, estimate_variance));
@@ -459,13 +459,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // probability_predict_oob
-Rcpp::List probability_predict_oob(Rcpp::List& forest_object, Rcpp::NumericMatrix& train_matrix, size_t outcome_index, size_t num_classes, unsigned int num_threads, bool estimate_variance);
+Rcpp::List probability_predict_oob(Rcpp::List& forest_object, const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, size_t num_classes, unsigned int num_threads, bool estimate_variance);
 RcppExport SEXP _grf_probability_predict_oob(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP num_classesSEXP, SEXP num_threadsSEXP, SEXP estimate_varianceSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::List& >::type forest_object(forest_objectSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type outcome_index(outcome_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type num_classes(num_classesSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);

--- a/r-package/grf/src/RcppExports.cpp
+++ b/r-package/grf/src/RcppExports.cpp
@@ -19,27 +19,27 @@ BEGIN_RCPP
 END_RCPP
 }
 // compute_weights
-Eigen::SparseMatrix<double> compute_weights(Rcpp::List forest_object, Rcpp::NumericMatrix train_matrix, Rcpp::NumericMatrix test_matrix, unsigned int num_threads);
+Eigen::SparseMatrix<double> compute_weights(Rcpp::List forest_object, const Rcpp::NumericMatrix& train_matrix, const Rcpp::NumericMatrix& test_matrix, unsigned int num_threads);
 RcppExport SEXP _grf_compute_weights(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP test_matrixSEXP, SEXP num_threadsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::List >::type forest_object(forest_objectSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type train_matrix(train_matrixSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type test_matrix(test_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type test_matrix(test_matrixSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     rcpp_result_gen = Rcpp::wrap(compute_weights(forest_object, train_matrix, test_matrix, num_threads));
     return rcpp_result_gen;
 END_RCPP
 }
 // compute_weights_oob
-Eigen::SparseMatrix<double> compute_weights_oob(Rcpp::List forest_object, Rcpp::NumericMatrix train_matrix, unsigned int num_threads);
+Eigen::SparseMatrix<double> compute_weights_oob(Rcpp::List forest_object, const Rcpp::NumericMatrix& train_matrix, unsigned int num_threads);
 RcppExport SEXP _grf_compute_weights_oob(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP num_threadsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::List >::type forest_object(forest_objectSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     rcpp_result_gen = Rcpp::wrap(compute_weights_oob(forest_object, train_matrix, num_threads));
     return rcpp_result_gen;
@@ -57,12 +57,12 @@ BEGIN_RCPP
 END_RCPP
 }
 // causal_train
-Rcpp::List causal_train(Rcpp::NumericMatrix train_matrix, size_t outcome_index, size_t treatment_index, size_t sample_weight_index, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double reduced_form_weight, double alpha, double imbalance_penalty, bool stabilize_splits, std::vector<size_t> clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, unsigned int num_threads, unsigned int seed);
+Rcpp::List causal_train(const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, size_t treatment_index, size_t sample_weight_index, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double reduced_form_weight, double alpha, double imbalance_penalty, bool stabilize_splits, std::vector<size_t> clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, unsigned int num_threads, unsigned int seed);
 RcppExport SEXP _grf_causal_train(SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP treatment_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP ci_group_sizeSEXP, SEXP reduced_form_weightSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP stabilize_splitsSEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP compute_oob_predictionsSEXP, SEXP num_threadsSEXP, SEXP seedSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type outcome_index(outcome_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type treatment_index(treatment_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type sample_weight_index(sample_weight_indexSEXP);
@@ -89,16 +89,16 @@ BEGIN_RCPP
 END_RCPP
 }
 // causal_predict
-Rcpp::List causal_predict(Rcpp::List forest_object, Rcpp::NumericMatrix train_matrix, size_t outcome_index, size_t treatment_index, Rcpp::NumericMatrix test_matrix, unsigned int num_threads, bool estimate_variance);
+Rcpp::List causal_predict(Rcpp::List forest_object, const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, size_t treatment_index, const Rcpp::NumericMatrix& test_matrix, unsigned int num_threads, bool estimate_variance);
 RcppExport SEXP _grf_causal_predict(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP treatment_indexSEXP, SEXP test_matrixSEXP, SEXP num_threadsSEXP, SEXP estimate_varianceSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::List >::type forest_object(forest_objectSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type outcome_index(outcome_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type treatment_index(treatment_indexSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type test_matrix(test_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type test_matrix(test_matrixSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     Rcpp::traits::input_parameter< bool >::type estimate_variance(estimate_varianceSEXP);
     rcpp_result_gen = Rcpp::wrap(causal_predict(forest_object, train_matrix, outcome_index, treatment_index, test_matrix, num_threads, estimate_variance));
@@ -106,13 +106,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // causal_predict_oob
-Rcpp::List causal_predict_oob(Rcpp::List forest_object, Rcpp::NumericMatrix train_matrix, size_t outcome_index, size_t treatment_index, unsigned int num_threads, bool estimate_variance);
+Rcpp::List causal_predict_oob(Rcpp::List forest_object, const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, size_t treatment_index, unsigned int num_threads, bool estimate_variance);
 RcppExport SEXP _grf_causal_predict_oob(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP treatment_indexSEXP, SEXP num_threadsSEXP, SEXP estimate_varianceSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::List >::type forest_object(forest_objectSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type outcome_index(outcome_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type treatment_index(treatment_indexSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
@@ -122,16 +122,16 @@ BEGIN_RCPP
 END_RCPP
 }
 // ll_causal_predict
-Rcpp::List ll_causal_predict(Rcpp::List forest_object, Rcpp::NumericMatrix train_matrix, size_t outcome_index, size_t treatment_index, Rcpp::NumericMatrix test_matrix, std::vector<double> ll_lambda, bool ll_weight_penalty, std::vector<size_t> linear_correction_variables, unsigned int num_threads, bool estimate_variance);
+Rcpp::List ll_causal_predict(Rcpp::List forest_object, const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, size_t treatment_index, const Rcpp::NumericMatrix& test_matrix, std::vector<double> ll_lambda, bool ll_weight_penalty, std::vector<size_t> linear_correction_variables, unsigned int num_threads, bool estimate_variance);
 RcppExport SEXP _grf_ll_causal_predict(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP treatment_indexSEXP, SEXP test_matrixSEXP, SEXP ll_lambdaSEXP, SEXP ll_weight_penaltySEXP, SEXP linear_correction_variablesSEXP, SEXP num_threadsSEXP, SEXP estimate_varianceSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::List >::type forest_object(forest_objectSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type outcome_index(outcome_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type treatment_index(treatment_indexSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type test_matrix(test_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type test_matrix(test_matrixSEXP);
     Rcpp::traits::input_parameter< std::vector<double> >::type ll_lambda(ll_lambdaSEXP);
     Rcpp::traits::input_parameter< bool >::type ll_weight_penalty(ll_weight_penaltySEXP);
     Rcpp::traits::input_parameter< std::vector<size_t> >::type linear_correction_variables(linear_correction_variablesSEXP);
@@ -142,13 +142,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // ll_causal_predict_oob
-Rcpp::List ll_causal_predict_oob(Rcpp::List forest_object, Rcpp::NumericMatrix train_matrix, size_t outcome_index, size_t treatment_index, std::vector<double> ll_lambda, bool ll_weight_penalty, std::vector<size_t> linear_correction_variables, unsigned int num_threads, bool estimate_variance);
+Rcpp::List ll_causal_predict_oob(Rcpp::List forest_object, const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, size_t treatment_index, std::vector<double> ll_lambda, bool ll_weight_penalty, std::vector<size_t> linear_correction_variables, unsigned int num_threads, bool estimate_variance);
 RcppExport SEXP _grf_ll_causal_predict_oob(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP treatment_indexSEXP, SEXP ll_lambdaSEXP, SEXP ll_weight_penaltySEXP, SEXP linear_correction_variablesSEXP, SEXP num_threadsSEXP, SEXP estimate_varianceSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::List >::type forest_object(forest_objectSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type outcome_index(outcome_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type treatment_index(treatment_indexSEXP);
     Rcpp::traits::input_parameter< std::vector<double> >::type ll_lambda(ll_lambdaSEXP);
@@ -223,12 +223,12 @@ BEGIN_RCPP
 END_RCPP
 }
 // instrumental_train
-Rcpp::List instrumental_train(Rcpp::NumericMatrix train_matrix, size_t outcome_index, size_t treatment_index, size_t instrument_index, size_t sample_weight_index, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double reduced_form_weight, double alpha, double imbalance_penalty, bool stabilize_splits, std::vector<size_t> clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, unsigned int num_threads, unsigned int seed);
+Rcpp::List instrumental_train(const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, size_t treatment_index, size_t instrument_index, size_t sample_weight_index, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double reduced_form_weight, double alpha, double imbalance_penalty, bool stabilize_splits, std::vector<size_t> clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, unsigned int num_threads, unsigned int seed);
 RcppExport SEXP _grf_instrumental_train(SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP treatment_indexSEXP, SEXP instrument_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP ci_group_sizeSEXP, SEXP reduced_form_weightSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP stabilize_splitsSEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP compute_oob_predictionsSEXP, SEXP num_threadsSEXP, SEXP seedSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type outcome_index(outcome_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type treatment_index(treatment_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type instrument_index(instrument_indexSEXP);
@@ -256,17 +256,17 @@ BEGIN_RCPP
 END_RCPP
 }
 // instrumental_predict
-Rcpp::List instrumental_predict(Rcpp::List forest_object, Rcpp::NumericMatrix train_matrix, size_t outcome_index, size_t treatment_index, size_t instrument_index, Rcpp::NumericMatrix test_matrix, unsigned int num_threads, bool estimate_variance);
+Rcpp::List instrumental_predict(Rcpp::List forest_object, const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, size_t treatment_index, size_t instrument_index, const Rcpp::NumericMatrix& test_matrix, unsigned int num_threads, bool estimate_variance);
 RcppExport SEXP _grf_instrumental_predict(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP treatment_indexSEXP, SEXP instrument_indexSEXP, SEXP test_matrixSEXP, SEXP num_threadsSEXP, SEXP estimate_varianceSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::List >::type forest_object(forest_objectSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type outcome_index(outcome_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type treatment_index(treatment_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type instrument_index(instrument_indexSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type test_matrix(test_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type test_matrix(test_matrixSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     Rcpp::traits::input_parameter< bool >::type estimate_variance(estimate_varianceSEXP);
     rcpp_result_gen = Rcpp::wrap(instrumental_predict(forest_object, train_matrix, outcome_index, treatment_index, instrument_index, test_matrix, num_threads, estimate_variance));
@@ -274,13 +274,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // instrumental_predict_oob
-Rcpp::List instrumental_predict_oob(Rcpp::List forest_object, Rcpp::NumericMatrix train_matrix, size_t outcome_index, size_t treatment_index, size_t instrument_index, unsigned int num_threads, bool estimate_variance);
+Rcpp::List instrumental_predict_oob(Rcpp::List forest_object, const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, size_t treatment_index, size_t instrument_index, unsigned int num_threads, bool estimate_variance);
 RcppExport SEXP _grf_instrumental_predict_oob(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP treatment_indexSEXP, SEXP instrument_indexSEXP, SEXP num_threadsSEXP, SEXP estimate_varianceSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::List >::type forest_object(forest_objectSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type outcome_index(outcome_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type treatment_index(treatment_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type instrument_index(instrument_indexSEXP);
@@ -291,12 +291,12 @@ BEGIN_RCPP
 END_RCPP
 }
 // multi_causal_train
-Rcpp::List multi_causal_train(Rcpp::NumericMatrix train_matrix, const std::vector<size_t>& outcome_index, const std::vector<size_t>& treatment_index, size_t sample_weight_index, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double alpha, double imbalance_penalty, bool stabilize_splits, std::vector<size_t> clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, unsigned int num_threads, unsigned int seed);
+Rcpp::List multi_causal_train(const Rcpp::NumericMatrix& train_matrix, const std::vector<size_t>& outcome_index, const std::vector<size_t>& treatment_index, size_t sample_weight_index, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double alpha, double imbalance_penalty, bool stabilize_splits, std::vector<size_t> clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, unsigned int num_threads, unsigned int seed);
 RcppExport SEXP _grf_multi_causal_train(SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP treatment_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP ci_group_sizeSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP stabilize_splitsSEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP compute_oob_predictionsSEXP, SEXP num_threadsSEXP, SEXP seedSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< const std::vector<size_t>& >::type outcome_index(outcome_indexSEXP);
     Rcpp::traits::input_parameter< const std::vector<size_t>& >::type treatment_index(treatment_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type sample_weight_index(sample_weight_indexSEXP);
@@ -322,14 +322,14 @@ BEGIN_RCPP
 END_RCPP
 }
 // multi_causal_predict
-Rcpp::List multi_causal_predict(Rcpp::List forest_object, Rcpp::NumericMatrix train_matrix, Rcpp::NumericMatrix test_matrix, size_t num_outcomes, size_t num_treatments, unsigned int num_threads, bool estimate_variance);
+Rcpp::List multi_causal_predict(Rcpp::List forest_object, const Rcpp::NumericMatrix& train_matrix, const Rcpp::NumericMatrix& test_matrix, size_t num_outcomes, size_t num_treatments, unsigned int num_threads, bool estimate_variance);
 RcppExport SEXP _grf_multi_causal_predict(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP test_matrixSEXP, SEXP num_outcomesSEXP, SEXP num_treatmentsSEXP, SEXP num_threadsSEXP, SEXP estimate_varianceSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::List >::type forest_object(forest_objectSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type train_matrix(train_matrixSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type test_matrix(test_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type test_matrix(test_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type num_outcomes(num_outcomesSEXP);
     Rcpp::traits::input_parameter< size_t >::type num_treatments(num_treatmentsSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
@@ -339,13 +339,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // multi_causal_predict_oob
-Rcpp::List multi_causal_predict_oob(Rcpp::List forest_object, Rcpp::NumericMatrix train_matrix, size_t num_outcomes, size_t num_treatments, unsigned int num_threads, bool estimate_variance);
+Rcpp::List multi_causal_predict_oob(Rcpp::List forest_object, const Rcpp::NumericMatrix& train_matrix, size_t num_outcomes, size_t num_treatments, unsigned int num_threads, bool estimate_variance);
 RcppExport SEXP _grf_multi_causal_predict_oob(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP num_outcomesSEXP, SEXP num_treatmentsSEXP, SEXP num_threadsSEXP, SEXP estimate_varianceSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::List >::type forest_object(forest_objectSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type num_outcomes(num_outcomesSEXP);
     Rcpp::traits::input_parameter< size_t >::type num_treatments(num_treatmentsSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
@@ -475,14 +475,14 @@ BEGIN_RCPP
 END_RCPP
 }
 // quantile_train
-Rcpp::List quantile_train(std::vector<double> quantiles, bool regression_splitting, Rcpp::NumericMatrix train_matrix, size_t outcome_index, unsigned int mtry, unsigned int num_trees, int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double alpha, double imbalance_penalty, std::vector<size_t> clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, int num_threads, unsigned int seed);
+Rcpp::List quantile_train(std::vector<double> quantiles, bool regression_splitting, const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, unsigned int mtry, unsigned int num_trees, int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double alpha, double imbalance_penalty, std::vector<size_t> clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, int num_threads, unsigned int seed);
 RcppExport SEXP _grf_quantile_train(SEXP quantilesSEXP, SEXP regression_splittingSEXP, SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP ci_group_sizeSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP compute_oob_predictionsSEXP, SEXP num_threadsSEXP, SEXP seedSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< std::vector<double> >::type quantiles(quantilesSEXP);
     Rcpp::traits::input_parameter< bool >::type regression_splitting(regression_splittingSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type outcome_index(outcome_indexSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type mtry(mtrySEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_trees(num_treesSEXP);
@@ -504,30 +504,30 @@ BEGIN_RCPP
 END_RCPP
 }
 // quantile_predict
-Rcpp::NumericMatrix quantile_predict(Rcpp::List forest_object, std::vector<double> quantiles, Rcpp::NumericMatrix train_matrix, size_t outcome_index, Rcpp::NumericMatrix test_matrix, unsigned int num_threads);
+Rcpp::NumericMatrix quantile_predict(Rcpp::List forest_object, std::vector<double> quantiles, const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, const Rcpp::NumericMatrix& test_matrix, unsigned int num_threads);
 RcppExport SEXP _grf_quantile_predict(SEXP forest_objectSEXP, SEXP quantilesSEXP, SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP test_matrixSEXP, SEXP num_threadsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::List >::type forest_object(forest_objectSEXP);
     Rcpp::traits::input_parameter< std::vector<double> >::type quantiles(quantilesSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type outcome_index(outcome_indexSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type test_matrix(test_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type test_matrix(test_matrixSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     rcpp_result_gen = Rcpp::wrap(quantile_predict(forest_object, quantiles, train_matrix, outcome_index, test_matrix, num_threads));
     return rcpp_result_gen;
 END_RCPP
 }
 // quantile_predict_oob
-Rcpp::NumericMatrix quantile_predict_oob(Rcpp::List forest_object, std::vector<double> quantiles, Rcpp::NumericMatrix train_matrix, size_t outcome_index, unsigned int num_threads);
+Rcpp::NumericMatrix quantile_predict_oob(Rcpp::List forest_object, std::vector<double> quantiles, const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, unsigned int num_threads);
 RcppExport SEXP _grf_quantile_predict_oob(SEXP forest_objectSEXP, SEXP quantilesSEXP, SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP num_threadsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::List >::type forest_object(forest_objectSEXP);
     Rcpp::traits::input_parameter< std::vector<double> >::type quantiles(quantilesSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type outcome_index(outcome_indexSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     rcpp_result_gen = Rcpp::wrap(quantile_predict_oob(forest_object, quantiles, train_matrix, outcome_index, num_threads));
@@ -535,12 +535,12 @@ BEGIN_RCPP
 END_RCPP
 }
 // regression_train
-Rcpp::List regression_train(Rcpp::NumericMatrix train_matrix, size_t outcome_index, size_t sample_weight_index, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double alpha, double imbalance_penalty, std::vector<size_t> clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, unsigned int num_threads, unsigned int seed);
+Rcpp::List regression_train(const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, size_t sample_weight_index, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double alpha, double imbalance_penalty, std::vector<size_t> clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, unsigned int num_threads, unsigned int seed);
 RcppExport SEXP _grf_regression_train(SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP ci_group_sizeSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP compute_oob_predictionsSEXP, SEXP num_threadsSEXP, SEXP seedSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type outcome_index(outcome_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type sample_weight_index(sample_weight_indexSEXP);
     Rcpp::traits::input_parameter< bool >::type use_sample_weights(use_sample_weightsSEXP);
@@ -564,15 +564,15 @@ BEGIN_RCPP
 END_RCPP
 }
 // regression_predict
-Rcpp::List regression_predict(Rcpp::List forest_object, Rcpp::NumericMatrix train_matrix, size_t outcome_index, Rcpp::NumericMatrix test_matrix, unsigned int num_threads, unsigned int estimate_variance);
+Rcpp::List regression_predict(Rcpp::List forest_object, const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, const Rcpp::NumericMatrix& test_matrix, unsigned int num_threads, unsigned int estimate_variance);
 RcppExport SEXP _grf_regression_predict(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP test_matrixSEXP, SEXP num_threadsSEXP, SEXP estimate_varianceSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::List >::type forest_object(forest_objectSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type outcome_index(outcome_indexSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type test_matrix(test_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type test_matrix(test_matrixSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type estimate_variance(estimate_varianceSEXP);
     rcpp_result_gen = Rcpp::wrap(regression_predict(forest_object, train_matrix, outcome_index, test_matrix, num_threads, estimate_variance));
@@ -580,13 +580,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // regression_predict_oob
-Rcpp::List regression_predict_oob(Rcpp::List forest_object, Rcpp::NumericMatrix train_matrix, size_t outcome_index, unsigned int num_threads, bool estimate_variance);
+Rcpp::List regression_predict_oob(Rcpp::List forest_object, const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, unsigned int num_threads, bool estimate_variance);
 RcppExport SEXP _grf_regression_predict_oob(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP num_threadsSEXP, SEXP estimate_varianceSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::List >::type forest_object(forest_objectSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type outcome_index(outcome_indexSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     Rcpp::traits::input_parameter< bool >::type estimate_variance(estimate_varianceSEXP);
@@ -595,12 +595,12 @@ BEGIN_RCPP
 END_RCPP
 }
 // ll_regression_train
-Rcpp::List ll_regression_train(Rcpp::NumericMatrix train_matrix, size_t outcome_index, double ll_split_lambda, bool ll_split_weight_penalty, std::vector<size_t> ll_split_variables, size_t ll_split_cutoff, std::vector<double> overall_beta, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double alpha, double imbalance_penalty, std::vector<size_t> clusters, unsigned int samples_per_cluster, unsigned int num_threads, unsigned int seed);
+Rcpp::List ll_regression_train(const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, double ll_split_lambda, bool ll_split_weight_penalty, std::vector<size_t> ll_split_variables, size_t ll_split_cutoff, std::vector<double> overall_beta, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double alpha, double imbalance_penalty, std::vector<size_t> clusters, unsigned int samples_per_cluster, unsigned int num_threads, unsigned int seed);
 RcppExport SEXP _grf_ll_regression_train(SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP ll_split_lambdaSEXP, SEXP ll_split_weight_penaltySEXP, SEXP ll_split_variablesSEXP, SEXP ll_split_cutoffSEXP, SEXP overall_betaSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP ci_group_sizeSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP num_threadsSEXP, SEXP seedSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type outcome_index(outcome_indexSEXP);
     Rcpp::traits::input_parameter< double >::type ll_split_lambda(ll_split_lambdaSEXP);
     Rcpp::traits::input_parameter< bool >::type ll_split_weight_penalty(ll_split_weight_penaltySEXP);
@@ -626,15 +626,15 @@ BEGIN_RCPP
 END_RCPP
 }
 // ll_regression_predict
-Rcpp::List ll_regression_predict(Rcpp::List forest_object, Rcpp::NumericMatrix train_matrix, size_t outcome_index, Rcpp::NumericMatrix test_matrix, std::vector<double> ll_lambda, bool ll_weight_penalty, std::vector<size_t> linear_correction_variables, unsigned int num_threads, bool estimate_variance);
+Rcpp::List ll_regression_predict(Rcpp::List forest_object, const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, const Rcpp::NumericMatrix& test_matrix, std::vector<double> ll_lambda, bool ll_weight_penalty, std::vector<size_t> linear_correction_variables, unsigned int num_threads, bool estimate_variance);
 RcppExport SEXP _grf_ll_regression_predict(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP test_matrixSEXP, SEXP ll_lambdaSEXP, SEXP ll_weight_penaltySEXP, SEXP linear_correction_variablesSEXP, SEXP num_threadsSEXP, SEXP estimate_varianceSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::List >::type forest_object(forest_objectSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type outcome_index(outcome_indexSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type test_matrix(test_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type test_matrix(test_matrixSEXP);
     Rcpp::traits::input_parameter< std::vector<double> >::type ll_lambda(ll_lambdaSEXP);
     Rcpp::traits::input_parameter< bool >::type ll_weight_penalty(ll_weight_penaltySEXP);
     Rcpp::traits::input_parameter< std::vector<size_t> >::type linear_correction_variables(linear_correction_variablesSEXP);
@@ -645,13 +645,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // ll_regression_predict_oob
-Rcpp::List ll_regression_predict_oob(Rcpp::List forest_object, Rcpp::NumericMatrix train_matrix, size_t outcome_index, std::vector<double> ll_lambda, bool ll_weight_penalty, std::vector<size_t> linear_correction_variables, unsigned int num_threads, bool estimate_variance);
+Rcpp::List ll_regression_predict_oob(Rcpp::List forest_object, const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, std::vector<double> ll_lambda, bool ll_weight_penalty, std::vector<size_t> linear_correction_variables, unsigned int num_threads, bool estimate_variance);
 RcppExport SEXP _grf_ll_regression_predict_oob(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP ll_lambdaSEXP, SEXP ll_weight_penaltySEXP, SEXP linear_correction_variablesSEXP, SEXP num_threadsSEXP, SEXP estimate_varianceSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::List >::type forest_object(forest_objectSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type outcome_index(outcome_indexSEXP);
     Rcpp::traits::input_parameter< std::vector<double> >::type ll_lambda(ll_lambdaSEXP);
     Rcpp::traits::input_parameter< bool >::type ll_weight_penalty(ll_weight_penaltySEXP);
@@ -663,12 +663,12 @@ BEGIN_RCPP
 END_RCPP
 }
 // survival_train
-Rcpp::List survival_train(Rcpp::NumericMatrix train_matrix, size_t outcome_index, size_t censor_index, size_t sample_weight_index, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, double alpha, size_t num_failures, std::vector<size_t> clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, int prediction_type, unsigned int num_threads, unsigned int seed);
+Rcpp::List survival_train(const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, size_t censor_index, size_t sample_weight_index, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, double alpha, size_t num_failures, std::vector<size_t> clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, int prediction_type, unsigned int num_threads, unsigned int seed);
 RcppExport SEXP _grf_survival_train(SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP censor_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP alphaSEXP, SEXP num_failuresSEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP compute_oob_predictionsSEXP, SEXP prediction_typeSEXP, SEXP num_threadsSEXP, SEXP seedSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type outcome_index(outcome_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type censor_index(censor_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type sample_weight_index(sample_weight_indexSEXP);
@@ -693,17 +693,17 @@ BEGIN_RCPP
 END_RCPP
 }
 // survival_predict
-Rcpp::List survival_predict(Rcpp::List forest_object, Rcpp::NumericMatrix train_matrix, size_t outcome_index, size_t censor_index, int prediction_type, Rcpp::NumericMatrix test_matrix, unsigned int num_threads, size_t num_failures);
+Rcpp::List survival_predict(Rcpp::List forest_object, const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, size_t censor_index, int prediction_type, const Rcpp::NumericMatrix& test_matrix, unsigned int num_threads, size_t num_failures);
 RcppExport SEXP _grf_survival_predict(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP censor_indexSEXP, SEXP prediction_typeSEXP, SEXP test_matrixSEXP, SEXP num_threadsSEXP, SEXP num_failuresSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::List >::type forest_object(forest_objectSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type outcome_index(outcome_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type censor_index(censor_indexSEXP);
     Rcpp::traits::input_parameter< int >::type prediction_type(prediction_typeSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type test_matrix(test_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type test_matrix(test_matrixSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     Rcpp::traits::input_parameter< size_t >::type num_failures(num_failuresSEXP);
     rcpp_result_gen = Rcpp::wrap(survival_predict(forest_object, train_matrix, outcome_index, censor_index, prediction_type, test_matrix, num_threads, num_failures));
@@ -711,13 +711,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // survival_predict_oob
-Rcpp::List survival_predict_oob(Rcpp::List forest_object, Rcpp::NumericMatrix train_matrix, size_t outcome_index, size_t censor_index, int prediction_type, unsigned int num_threads, size_t num_failures);
+Rcpp::List survival_predict_oob(Rcpp::List forest_object, const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, size_t censor_index, int prediction_type, unsigned int num_threads, size_t num_failures);
 RcppExport SEXP _grf_survival_predict_oob(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP censor_indexSEXP, SEXP prediction_typeSEXP, SEXP num_threadsSEXP, SEXP num_failuresSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::List >::type forest_object(forest_objectSEXP);
-    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type train_matrix(train_matrixSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type outcome_index(outcome_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type censor_index(censor_indexSEXP);
     Rcpp::traits::input_parameter< int >::type prediction_type(prediction_typeSEXP);


### PR DESCRIPTION
Rcpp data types are already light wrappers, however stick with this C++ idiom to keep it crystal clear no data is modified.

Training/test data in R is already copied when the data matrices are created in the input utilities (where all data is copied into a contiguous chunk)