### PR TITLE
Add a concordance example to docstring

### DIFF
--- a/r-package/grf/DESCRIPTION
+++ b/r-package/grf/DESCRIPTION
@@ -32,7 +32,7 @@ RoxygenNote: 7.1.1
 Suggests:
     DiagrammeR,
     MASS,
-    survival,
+    survival (>= 3.2-8),
     testthat
 SystemRequirements: GNU make
 URL: https://github.com/grf-labs/grf

--- a/r-package/grf/DESCRIPTION
+++ b/r-package/grf/DESCRIPTION
@@ -31,7 +31,8 @@ Imports:
 RoxygenNote: 7.1.1
 Suggests:
     DiagrammeR,
-    testthat,
-    MASS
+    MASS,
+    survival,
+    testthat
 SystemRequirements: GNU make
 URL: https://github.com/grf-labs/grf

--- a/r-package/grf/R/survival_forest.R
+++ b/r-package/grf/R/survival_forest.R
@@ -107,8 +107,7 @@
 #' # This number is between zero and one, where zero indicates perfect predictions.
 #' s.pred.nelson.aalen <- predict(s.forest, prediction.type = "Nelson-Aalen")
 #' chf.score <- rowSums(-log(s.pred.nelson.aalen$predictions))
-#' if (requireNamespace("survival", quietly = TRUE)) {
-#'  library(survival)
+#' if (require("survival", quietly = TRUE)) {
 #'  concordance(Surv(Y, D) ~ chf.score)
 #' }
 #' }
@@ -260,8 +259,7 @@ survival_forest <- function(X, Y, D,
 #' # This number is between zero and one, where zero indicates perfect predictions.
 #' s.pred.nelson.aalen <- predict(s.forest, prediction.type = "Nelson-Aalen")
 #' chf.score <- rowSums(-log(s.pred.nelson.aalen$predictions))
-#' if (requireNamespace("survival", quietly = TRUE)) {
-#'  library(survival)
+#' if (require("survival", quietly = TRUE)) {
 #'  concordance(Surv(Y, D) ~ chf.score)
 #' }
 #' }

--- a/r-package/grf/R/survival_forest.R
+++ b/r-package/grf/R/survival_forest.R
@@ -102,6 +102,15 @@
 #' s.pred.grid <- predict(s.forest.grid)
 #' matpoints(s.pred.grid$failure.times, t(s.pred.grid$predictions[1:5, ]),
 #'           type = "l", lty = 2)
+#'
+#' # Compute OOB concordance based on the mortality score in Ishwaran et al. (2008).
+#' # This number is between zero and one, where zero indicates perfect predictions.
+#' s.pred.nelson.aalen <- predict(s.forest, prediction.type = "Nelson-Aalen")
+#' chf.score <- rowSums(-log(s.pred.nelson.aalen$predictions))
+#' if (requireNamespace("survival", quietly = TRUE)) {
+#'  library(survival)
+#'  concordance(Surv(Y, D) ~ chf.score)
+#' }
 #' }
 #'
 #' @export
@@ -246,6 +255,15 @@ survival_forest <- function(X, Y, D,
 #' s.pred.grid <- predict(s.forest.grid)
 #' matpoints(s.pred.grid$failure.times, t(s.pred.grid$predictions[1:5, ]),
 #'           type = "l", lty = 2)
+#'
+#' # Compute OOB concordance based on the mortality score in Ishwaran et al. (2008).
+#' # This number is between zero and one, where zero indicates perfect predictions.
+#' s.pred.nelson.aalen <- predict(s.forest, prediction.type = "Nelson-Aalen")
+#' chf.score <- rowSums(-log(s.pred.nelson.aalen$predictions))
+#' if (requireNamespace("survival", quietly = TRUE)) {
+#'  library(survival)
+#'  concordance(Surv(Y, D) ~ chf.score)
+#' }
 #' }
 #'
 #' @method predict survival_forest

--- a/r-package/grf/R/survival_forest.R
+++ b/r-package/grf/R/survival_forest.R
@@ -107,6 +107,8 @@
 #' # This number is between zero and one, where zero indicates perfect predictions.
 #' s.pred.nelson.aalen <- predict(s.forest, prediction.type = "Nelson-Aalen")
 #' chf.score <- rowSums(-log(s.pred.nelson.aalen$predictions))
+#' # In case the forest is trained with optional clusters or sample weights,
+#' # these can be passed on to the following function:
 #' if (require("survival", quietly = TRUE)) {
 #'  concordance(Surv(Y, D) ~ chf.score)
 #' }
@@ -259,6 +261,8 @@ survival_forest <- function(X, Y, D,
 #' # This number is between zero and one, where zero indicates perfect predictions.
 #' s.pred.nelson.aalen <- predict(s.forest, prediction.type = "Nelson-Aalen")
 #' chf.score <- rowSums(-log(s.pred.nelson.aalen$predictions))
+#' # In case the forest is trained with optional clusters or sample weights,
+#' # these can be passed on to the following function:
 #' if (require("survival", quietly = TRUE)) {
 #'  concordance(Surv(Y, D) ~ chf.score)
 #' }

--- a/r-package/grf/man/predict.survival_forest.Rd
+++ b/r-package/grf/man/predict.survival_forest.Rd
@@ -89,6 +89,8 @@ matpoints(s.pred.grid$failure.times, t(s.pred.grid$predictions[1:5, ]),
 # This number is between zero and one, where zero indicates perfect predictions.
 s.pred.nelson.aalen <- predict(s.forest, prediction.type = "Nelson-Aalen")
 chf.score <- rowSums(-log(s.pred.nelson.aalen$predictions))
+# In case the forest is trained with optional clusters or sample weights,
+# these can be passed on to the following function:
 if (require("survival", quietly = TRUE)) {
  concordance(Surv(Y, D) ~ chf.score)
 }

--- a/r-package/grf/man/predict.survival_forest.Rd
+++ b/r-package/grf/man/predict.survival_forest.Rd
@@ -89,8 +89,7 @@ matpoints(s.pred.grid$failure.times, t(s.pred.grid$predictions[1:5, ]),
 # This number is between zero and one, where zero indicates perfect predictions.
 s.pred.nelson.aalen <- predict(s.forest, prediction.type = "Nelson-Aalen")
 chf.score <- rowSums(-log(s.pred.nelson.aalen$predictions))
-if (requireNamespace("survival", quietly = TRUE)) {
- library(survival)
+if (require("survival", quietly = TRUE)) {
  concordance(Surv(Y, D) ~ chf.score)
 }
 }

--- a/r-package/grf/man/predict.survival_forest.Rd
+++ b/r-package/grf/man/predict.survival_forest.Rd
@@ -84,6 +84,15 @@ s.forest.grid <- survival_forest(X, Y, D, failure.times = events)
 s.pred.grid <- predict(s.forest.grid)
 matpoints(s.pred.grid$failure.times, t(s.pred.grid$predictions[1:5, ]),
           type = "l", lty = 2)
+
+# Compute OOB concordance based on the mortality score in Ishwaran et al. (2008).
+# This number is between zero and one, where zero indicates perfect predictions.
+s.pred.nelson.aalen <- predict(s.forest, prediction.type = "Nelson-Aalen")
+chf.score <- rowSums(-log(s.pred.nelson.aalen$predictions))
+if (requireNamespace("survival", quietly = TRUE)) {
+ library(survival)
+ concordance(Surv(Y, D) ~ chf.score)
+}
 }
 
 }

--- a/r-package/grf/man/survival_forest.Rd
+++ b/r-package/grf/man/survival_forest.Rd
@@ -148,8 +148,7 @@ matpoints(s.pred.grid$failure.times, t(s.pred.grid$predictions[1:5, ]),
 # This number is between zero and one, where zero indicates perfect predictions.
 s.pred.nelson.aalen <- predict(s.forest, prediction.type = "Nelson-Aalen")
 chf.score <- rowSums(-log(s.pred.nelson.aalen$predictions))
-if (requireNamespace("survival", quietly = TRUE)) {
- library(survival)
+if (require("survival", quietly = TRUE)) {
  concordance(Surv(Y, D) ~ chf.score)
 }
 }

--- a/r-package/grf/man/survival_forest.Rd
+++ b/r-package/grf/man/survival_forest.Rd
@@ -143,6 +143,15 @@ s.forest.grid <- survival_forest(X, Y, D, failure.times = events)
 s.pred.grid <- predict(s.forest.grid)
 matpoints(s.pred.grid$failure.times, t(s.pred.grid$predictions[1:5, ]),
           type = "l", lty = 2)
+
+# Compute OOB concordance based on the mortality score in Ishwaran et al. (2008).
+# This number is between zero and one, where zero indicates perfect predictions.
+s.pred.nelson.aalen <- predict(s.forest, prediction.type = "Nelson-Aalen")
+chf.score <- rowSums(-log(s.pred.nelson.aalen$predictions))
+if (requireNamespace("survival", quietly = TRUE)) {
+ library(survival)
+ concordance(Surv(Y, D) ~ chf.score)
+}
 }
 
 }

--- a/r-package/grf/man/survival_forest.Rd
+++ b/r-package/grf/man/survival_forest.Rd
@@ -148,6 +148,8 @@ matpoints(s.pred.grid$failure.times, t(s.pred.grid$predictions[1:5, ]),
 # This number is between zero and one, where zero indicates perfect predictions.
 s.pred.nelson.aalen <- predict(s.forest, prediction.type = "Nelson-Aalen")
 chf.score <- rowSums(-log(s.pred.nelson.aalen$predictions))
+# In case the forest is trained with optional clusters or sample weights,
+# these can be passed on to the following function:
 if (require("survival", quietly = TRUE)) {
  concordance(Surv(Y, D) ~ chf.score)
 }


### PR DESCRIPTION
Add a docstring example on how to calculate an error rate based on concordance, using the optional `survival` package.

We delegate to this package since it facilitates easy comparison between any other method, as the exact handling of ties etc may vary between definitions (to compare with for example randomForestSRC just replace `chf.score` with `rowSums(forest.src$chf)`). `survival` (@therneau) also does it efficiently in O(nlogn) time, which would be a non-trivial addition to grf.

The docstring example uses survival predictions based on the mortality score suggested in Ishwaran (2008) section 4.1, which is the sum of the cumulative hazard function.

We can add this as a separate GRF function calling into `survival` in a future release pending user interest.

