### PR TITLE
Account for empty predictions in DefaultPredictionCollector

### DIFF
--- a/core/src/prediction/collector/DefaultPredictionCollector.cpp
+++ b/core/src/prediction/collector/DefaultPredictionCollector.cpp
@@ -123,6 +123,16 @@ std::vector<Prediction> DefaultPredictionCollector::collect_predictions_batch(
         ? strategy->compute_variance(sample, samples_by_tree, weights_by_sample, train_data, data, forest.get_ci_group_size())
         : std::vector<double>();
 
+    // If the returned predictions are empty, then return placeholder predictions.
+    // This can occur if for example all case sample weights are zero,
+    // and the prediction strategy opts to predict nothing.
+    if (point_prediction.empty()) {
+      std::vector<double> nan(strategy->prediction_length(), NAN);
+      std::vector<double> empty;
+      predictions.emplace_back(nan, estimate_variance ? nan : empty, empty, empty);
+      continue;
+    }
+
     Prediction prediction(point_prediction, variance, {}, {});
     validate_prediction(sample, point_prediction);
     predictions.push_back(prediction);


### PR DESCRIPTION
This makes the behavior of `DefaultPredictionCollector` and `OptimizedPredictionCollector` identical in the case when computed predictions are empty.

The (rare) use case is if a `DefaultPredictionStrategy` decides to return nothing, such as when the sum of case sample weights in a leaf is zero (which can be the case for `SurvivalPredictionStrategy`. 

