### PR TITLE
Fix survival_forest test set predictions with sample weights

### DIFF
--- a/r-package/grf/R/RcppExports.R
+++ b/r-package/grf/R/RcppExports.R
@@ -137,11 +137,11 @@ survival_train <- function(train_matrix, outcome_index, censor_index, sample_wei
     .Call('_grf_survival_train', PACKAGE = 'grf', train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, alpha, num_failures, clusters, samples_per_cluster, compute_oob_predictions, prediction_type, num_threads, seed)
 }
 
-survival_predict <- function(forest_object, train_matrix, outcome_index, censor_index, prediction_type, test_matrix, num_threads, num_failures) {
-    .Call('_grf_survival_predict', PACKAGE = 'grf', forest_object, train_matrix, outcome_index, censor_index, prediction_type, test_matrix, num_threads, num_failures)
+survival_predict <- function(forest_object, train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, prediction_type, test_matrix, num_threads, num_failures) {
+    .Call('_grf_survival_predict', PACKAGE = 'grf', forest_object, train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, prediction_type, test_matrix, num_threads, num_failures)
 }
 
-survival_predict_oob <- function(forest_object, train_matrix, outcome_index, censor_index, prediction_type, num_threads, num_failures) {
-    .Call('_grf_survival_predict_oob', PACKAGE = 'grf', forest_object, train_matrix, outcome_index, censor_index, prediction_type, num_threads, num_failures)
+survival_predict_oob <- function(forest_object, train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, prediction_type, num_threads, num_failures) {
+    .Call('_grf_survival_predict_oob', PACKAGE = 'grf', forest_object, train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, prediction_type, num_threads, num_failures)
 }
 

--- a/r-package/grf/R/survival_forest.R
+++ b/r-package/grf/R/survival_forest.R
@@ -305,7 +305,8 @@ predict.survival_forest <- function(object,
   X <- object[["X.orig"]]
   train.data <- create_train_matrices(X,
                                       outcome = Y.relabeled,
-                                      censor = object[["D.orig"]])
+                                      censor = object[["D.orig"]],
+                                      sample.weights = object[["sample.weights"]])
 
   args <- list(forest.object = forest.short,
                num.threads = num.threads,

--- a/r-package/grf/bindings/SurvivalForestBindings.cpp
+++ b/r-package/grf/bindings/SurvivalForestBindings.cpp
@@ -75,6 +75,8 @@ Rcpp::List survival_predict(const Rcpp::List& forest_object,
                             const Rcpp::NumericMatrix& train_matrix,
                             size_t outcome_index,
                             size_t censor_index,
+                            size_t sample_weight_index,
+                            bool use_sample_weights,
                             int prediction_type,
                             const Rcpp::NumericMatrix& test_matrix,
                             unsigned int num_threads,
@@ -82,6 +84,9 @@ Rcpp::List survival_predict(const Rcpp::List& forest_object,
   Data train_data = RcppUtilities::convert_data(train_matrix);
   train_data.set_outcome_index(outcome_index);
   train_data.set_censor_index(censor_index);
+  if (use_sample_weights) {
+    train_data.set_weight_index(sample_weight_index);
+  }
 
   Data data = RcppUtilities::convert_data(test_matrix);
   Forest forest = RcppUtilities::deserialize_forest(forest_object);
@@ -98,12 +103,17 @@ Rcpp::List survival_predict_oob(const Rcpp::List& forest_object,
                                 const Rcpp::NumericMatrix& train_matrix,
                                 size_t outcome_index,
                                 size_t censor_index,
+                                size_t sample_weight_index,
+                                bool use_sample_weights,
                                 int prediction_type,
                                 unsigned int num_threads,
                                 size_t num_failures) {
   Data data = RcppUtilities::convert_data(train_matrix);
   data.set_outcome_index(outcome_index);
   data.set_censor_index(censor_index);
+  if (use_sample_weights) {
+    data.set_weight_index(sample_weight_index);
+  }
 
   Forest forest = RcppUtilities::deserialize_forest(forest_object);
 

--- a/r-package/grf/src/RcppExports.cpp
+++ b/r-package/grf/src/RcppExports.cpp
@@ -693,8 +693,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // survival_predict
-Rcpp::List survival_predict(const Rcpp::List& forest_object, const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, size_t censor_index, int prediction_type, const Rcpp::NumericMatrix& test_matrix, unsigned int num_threads, size_t num_failures);
-RcppExport SEXP _grf_survival_predict(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP censor_indexSEXP, SEXP prediction_typeSEXP, SEXP test_matrixSEXP, SEXP num_threadsSEXP, SEXP num_failuresSEXP) {
+Rcpp::List survival_predict(const Rcpp::List& forest_object, const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, size_t censor_index, size_t sample_weight_index, bool use_sample_weights, int prediction_type, const Rcpp::NumericMatrix& test_matrix, unsigned int num_threads, size_t num_failures);
+RcppExport SEXP _grf_survival_predict(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP censor_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP prediction_typeSEXP, SEXP test_matrixSEXP, SEXP num_threadsSEXP, SEXP num_failuresSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -702,17 +702,19 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type outcome_index(outcome_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type censor_index(censor_indexSEXP);
+    Rcpp::traits::input_parameter< size_t >::type sample_weight_index(sample_weight_indexSEXP);
+    Rcpp::traits::input_parameter< bool >::type use_sample_weights(use_sample_weightsSEXP);
     Rcpp::traits::input_parameter< int >::type prediction_type(prediction_typeSEXP);
     Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type test_matrix(test_matrixSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     Rcpp::traits::input_parameter< size_t >::type num_failures(num_failuresSEXP);
-    rcpp_result_gen = Rcpp::wrap(survival_predict(forest_object, train_matrix, outcome_index, censor_index, prediction_type, test_matrix, num_threads, num_failures));
+    rcpp_result_gen = Rcpp::wrap(survival_predict(forest_object, train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, prediction_type, test_matrix, num_threads, num_failures));
     return rcpp_result_gen;
 END_RCPP
 }
 // survival_predict_oob
-Rcpp::List survival_predict_oob(const Rcpp::List& forest_object, const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, size_t censor_index, int prediction_type, unsigned int num_threads, size_t num_failures);
-RcppExport SEXP _grf_survival_predict_oob(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP censor_indexSEXP, SEXP prediction_typeSEXP, SEXP num_threadsSEXP, SEXP num_failuresSEXP) {
+Rcpp::List survival_predict_oob(const Rcpp::List& forest_object, const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, size_t censor_index, size_t sample_weight_index, bool use_sample_weights, int prediction_type, unsigned int num_threads, size_t num_failures);
+RcppExport SEXP _grf_survival_predict_oob(SEXP forest_objectSEXP, SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP censor_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP prediction_typeSEXP, SEXP num_threadsSEXP, SEXP num_failuresSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -720,10 +722,12 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const Rcpp::NumericMatrix& >::type train_matrix(train_matrixSEXP);
     Rcpp::traits::input_parameter< size_t >::type outcome_index(outcome_indexSEXP);
     Rcpp::traits::input_parameter< size_t >::type censor_index(censor_indexSEXP);
+    Rcpp::traits::input_parameter< size_t >::type sample_weight_index(sample_weight_indexSEXP);
+    Rcpp::traits::input_parameter< bool >::type use_sample_weights(use_sample_weightsSEXP);
     Rcpp::traits::input_parameter< int >::type prediction_type(prediction_typeSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     Rcpp::traits::input_parameter< size_t >::type num_failures(num_failuresSEXP);
-    rcpp_result_gen = Rcpp::wrap(survival_predict_oob(forest_object, train_matrix, outcome_index, censor_index, prediction_type, num_threads, num_failures));
+    rcpp_result_gen = Rcpp::wrap(survival_predict_oob(forest_object, train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, prediction_type, num_threads, num_failures));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -763,8 +767,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_grf_ll_regression_predict", (DL_FUNC) &_grf_ll_regression_predict, 9},
     {"_grf_ll_regression_predict_oob", (DL_FUNC) &_grf_ll_regression_predict_oob, 8},
     {"_grf_survival_train", (DL_FUNC) &_grf_survival_train, 20},
-    {"_grf_survival_predict", (DL_FUNC) &_grf_survival_predict, 8},
-    {"_grf_survival_predict_oob", (DL_FUNC) &_grf_survival_predict_oob, 7},
+    {"_grf_survival_predict", (DL_FUNC) &_grf_survival_predict, 10},
+    {"_grf_survival_predict_oob", (DL_FUNC) &_grf_survival_predict_oob, 9},
     {NULL, NULL, 0}
 };
 

--- a/r-package/grf/tests/testthat/test_survival_forest.R
+++ b/r-package/grf/tests/testthat/test_survival_forest.R
@@ -78,9 +78,13 @@ test_that("sample weighted survival prediction is invariant to weight rescaling"
                         num.trees = 50,
                         seed = 1)
   type <- "Kaplan-Meier"
+  expect_equal(predict(sf1, prediction.type = type)$predictions,
+               predict(sf2, prediction.type = type)$predictions, tolerance = 1e-8)
   expect_equal(predict(sf1, X, prediction.type = type)$predictions,
                predict(sf2, X, prediction.type = type)$predictions, tolerance = 1e-8)
   type <- "Nelson-Aalen"
+  expect_equal(predict(sf1, prediction.type = type)$predictions,
+               predict(sf2, prediction.type = type)$predictions, tolerance = 1e-8)
   expect_equal(predict(sf1, X, prediction.type = type)$predictions,
                predict(sf2, X, prediction.type = type)$predictions, tolerance = 1e-8)
 })


### PR DESCRIPTION
In the event the forest was trained with sample weights, they where accidentally omitted when calling predict on a test set or oob with precompute set to false.