### PR TITLE
survival_forest: return placeholder predictions when all sample weights = 0

### DIFF
--- a/core/src/prediction/SurvivalPredictionStrategy.cpp
+++ b/core/src/prediction/SurvivalPredictionStrategy.cpp
@@ -45,6 +45,7 @@ std::vector<double> SurvivalPredictionStrategy::predict(size_t prediction_sample
   std::vector<double> count_failure(num_failures + 1);
   std::vector<double> count_censor(num_failures + 1);
   double sum = 0;
+  double sum_weight = 0;
   for (const auto& entry : weights_by_sample) {
     size_t sample = entry.first;
     double forest_weight = entry.second;
@@ -56,6 +57,11 @@ std::vector<double> SurvivalPredictionStrategy::predict(size_t prediction_sample
      count_censor[failure_time] += forest_weight * sample_weight;
     }
     sum += forest_weight * sample_weight;
+    sum_weight += sample_weight;
+  }
+
+  if (std::abs(sum_weight) <= 1e-16) {
+    return std::vector<double>();
   }
 
   if (prediction_type == NELSON_AALEN) {


### PR DESCRIPTION
In the rare event all sample weights for a test sample sum to zero, return empty predictions. This mimics behavior of other forests implementing sample weighted predictions.