### PR TITLE
Extend MultiCausalSplittingRule tests

### DIFF
--- a/core/test/splitting/MultiCausalSplittingRuleTest.cpp
+++ b/core/test/splitting/MultiCausalSplittingRuleTest.cpp
@@ -28,8 +28,8 @@
 
 using namespace grf;
 
-// Splitting rule input setup to emulate one run of node zero (all data) splitting on all features
-// returning a vector containing the best split variable, best split value, and missing direction.
+// Splitting rule input setup to emulate one run of node zero (first `size_node` observations) splitting
+// on all features returning a vector containing the best split variable, best split value, and missing direction.
 std::vector<double> run_splits_multi(const Data& data,
                                      size_t size_node,
                                      const TreeOptions& options,
@@ -91,12 +91,14 @@ TEST_CASE("multi causal splitting with one treatment is identical to instrumenta
       num_treatments));
 
 
-  std::vector<double> inst = run_splits_multi(data, data.get_num_rows(), options, inst_splitting_rule, relabeling_strategy, num_features);
-  std::vector<double> multi = run_splits_multi(data, data.get_num_rows(), options, multi_splitting_rule, relabeling_strategy, num_features);
+  for (auto size_node : {1000, 500, 250, 113, 25, 10, 3}) {
+    std::vector<double> inst = run_splits_multi(data, size_node, options, inst_splitting_rule, relabeling_strategy, num_features);
+    std::vector<double> multi = run_splits_multi(data, size_node, options, multi_splitting_rule, relabeling_strategy, num_features);
 
-  REQUIRE(equal_doubles(inst[0], multi[0], 1e-6));
-  REQUIRE(equal_doubles(inst[1], multi[1], 1e-6));
-  REQUIRE(equal_doubles(inst[2], multi[2], 1e-6));
+    REQUIRE(equal_doubles(inst[0], multi[0], 1e-6));
+    REQUIRE(equal_doubles(inst[1], multi[1], 1e-6));
+    REQUIRE(equal_doubles(inst[2], multi[2], 1e-6));
+  }
 }
 
 TEST_CASE("multi causal splitting with one treatment on NaN data is identical to instrumental splitting", "[multi_causal], [splitting], [NaN]") {
@@ -124,13 +126,14 @@ TEST_CASE("multi causal splitting with one treatment on NaN data is identical to
       1,
       num_treatments));
 
+  for (auto size_node : {1000, 500, 250, 113, 25, 10, 3}) {
+    std::vector<double> inst = run_splits_multi(data, size_node, options, inst_splitting_rule, relabeling_strategy, num_features);
+    std::vector<double> multi = run_splits_multi(data, size_node, options, multi_splitting_rule, relabeling_strategy, num_features);
 
-  std::vector<double> inst = run_splits_multi(data, data.get_num_rows(), options, inst_splitting_rule, relabeling_strategy, num_features);
-  std::vector<double> multi = run_splits_multi(data, data.get_num_rows(), options, multi_splitting_rule, relabeling_strategy, num_features);
-
-  REQUIRE(equal_doubles(inst[0], multi[0], 1e-6));
-  REQUIRE(equal_doubles(inst[1], multi[1], 1e-6));
-  REQUIRE(equal_doubles(inst[2], multi[2], 1e-6));
+    REQUIRE(equal_doubles(inst[0], multi[0], 1e-6));
+    REQUIRE(equal_doubles(inst[1], multi[1], 1e-6));
+    REQUIRE(equal_doubles(inst[2], multi[2], 1e-6));
+  }
 }
 
 TEST_CASE("multi causal splitting with many identical treatments is identical to instrumental splitting", "[multi_causal], [splitting]") {
@@ -160,12 +163,14 @@ TEST_CASE("multi causal splitting with many identical treatments is identical to
       num_treatments));
 
 
-  std::vector<double> inst = run_splits_multi(data, data.get_num_rows(), options, inst_splitting_rule, relabeling_strategy, num_features);
-  std::vector<double> multi = run_splits_multi(data, data.get_num_rows(), options, multi_splitting_rule, relabeling_strategy, num_features);
+  for (auto size_node : {1000, 500, 250, 113, 25, 10, 3}) {
+    std::vector<double> inst = run_splits_multi(data, size_node, options, inst_splitting_rule, relabeling_strategy, num_features);
+    std::vector<double> multi = run_splits_multi(data, size_node, options, multi_splitting_rule, relabeling_strategy, num_features);
 
-  REQUIRE(equal_doubles(inst[0], multi[0], 1e-6));
-  REQUIRE(equal_doubles(inst[1], multi[1], 1e-6));
-  REQUIRE(equal_doubles(inst[2], multi[2], 1e-6));
+    REQUIRE(equal_doubles(inst[0], multi[0], 1e-6));
+    REQUIRE(equal_doubles(inst[1], multi[1], 1e-6));
+    REQUIRE(equal_doubles(inst[2], multi[2], 1e-6));
+  }
 }
 
 TEST_CASE("multi causal splitting with many identical treatments on NaN data is identical to instrumental splitting", "[multi_causal], [splitting], [NaN]") {
@@ -193,11 +198,12 @@ TEST_CASE("multi causal splitting with many identical treatments on NaN data is 
       1,
       num_treatments));
 
+  for (auto size_node : {1000, 500, 250, 113, 25, 10, 3}) {
+    std::vector<double> inst = run_splits_multi(data, size_node, options, inst_splitting_rule, relabeling_strategy, num_features);
+    std::vector<double> multi = run_splits_multi(data, size_node, options, multi_splitting_rule, relabeling_strategy, num_features);
 
-  std::vector<double> inst = run_splits_multi(data, data.get_num_rows(), options, inst_splitting_rule, relabeling_strategy, num_features);
-  std::vector<double> multi = run_splits_multi(data, data.get_num_rows(), options, multi_splitting_rule, relabeling_strategy, num_features);
-
-  REQUIRE(equal_doubles(inst[0], multi[0], 1e-6));
-  REQUIRE(equal_doubles(inst[1], multi[1], 1e-6));
-  REQUIRE(equal_doubles(inst[2], multi[2], 1e-6));
+    REQUIRE(equal_doubles(inst[0], multi[0], 1e-6));
+    REQUIRE(equal_doubles(inst[1], multi[1], 1e-6));
+    REQUIRE(equal_doubles(inst[2], multi[2], 1e-6));
+  }
 }

--- a/core/test/splitting/MultiCausalSplittingRuleTest.cpp
+++ b/core/test/splitting/MultiCausalSplittingRuleTest.cpp
@@ -31,12 +31,12 @@ using namespace grf;
 // Splitting rule input setup to emulate one run of node zero (all data) splitting on all features
 // returning a vector containing the best split variable, best split value, and missing direction.
 std::vector<double> run_splits_multi(const Data& data,
+                                     size_t size_node,
                                      const TreeOptions& options,
                                      const std::unique_ptr<SplittingRule>& splitting_rule,
                                      const std::unique_ptr<RelabelingStrategy>& relabeling_strategy,
                                      size_t num_features) {
   size_t node = 0;
-  size_t size_node = data.get_num_rows();
   Eigen::ArrayXXd responses_by_sample(size_node, data.get_num_outcomes());
   std::vector<std::vector<size_t>> samples(1);
   for (size_t sample = 0; sample < size_node; ++sample) {
@@ -71,6 +71,7 @@ TEST_CASE("multi causal splitting with one treatment is identical to instrumenta
   data.set_treatment_index(11);
   data.set_instrument_index(11);
   size_t num_features = 10;
+  size_t num_treatments = data.get_num_treatments();
 
   TreeOptions options = ForestTestUtilities::default_options().get_tree_options();
 
@@ -87,11 +88,11 @@ TEST_CASE("multi causal splitting with one treatment is identical to instrumenta
       options.get_alpha(),
       options.get_imbalance_penalty(),
       1,
-      1));
+      num_treatments));
 
 
-  std::vector<double> inst = run_splits_multi(data, options, inst_splitting_rule, relabeling_strategy, num_features);
-  std::vector<double> multi = run_splits_multi(data, options, multi_splitting_rule, relabeling_strategy, num_features);
+  std::vector<double> inst = run_splits_multi(data, data.get_num_rows(), options, inst_splitting_rule, relabeling_strategy, num_features);
+  std::vector<double> multi = run_splits_multi(data, data.get_num_rows(), options, multi_splitting_rule, relabeling_strategy, num_features);
 
   REQUIRE(equal_doubles(inst[0], multi[0], 1e-6));
   REQUIRE(equal_doubles(inst[1], multi[1], 1e-6));
@@ -105,6 +106,7 @@ TEST_CASE("multi causal splitting with one treatment on NaN data is identical to
   data.set_treatment_index(11);
   data.set_instrument_index(11);
   size_t num_features = 10;
+  size_t num_treatments = data.get_num_treatments();
 
   TreeOptions options = ForestTestUtilities::default_options().get_tree_options();
 
@@ -120,11 +122,11 @@ TEST_CASE("multi causal splitting with one treatment on NaN data is identical to
       options.get_alpha(),
       options.get_imbalance_penalty(),
       1,
-      1));
+      num_treatments));
 
 
-  std::vector<double> inst = run_splits_multi(data, options, inst_splitting_rule, relabeling_strategy, num_features);
-  std::vector<double> multi = run_splits_multi(data, options, multi_splitting_rule, relabeling_strategy, num_features);
+  std::vector<double> inst = run_splits_multi(data, data.get_num_rows(), options, inst_splitting_rule, relabeling_strategy, num_features);
+  std::vector<double> multi = run_splits_multi(data, data.get_num_rows(), options, multi_splitting_rule, relabeling_strategy, num_features);
 
   REQUIRE(equal_doubles(inst[0], multi[0], 1e-6));
   REQUIRE(equal_doubles(inst[1], multi[1], 1e-6));
@@ -138,6 +140,7 @@ TEST_CASE("multi causal splitting with many identical treatments is identical to
   data.set_treatment_index({11, 11, 11});
   data.set_instrument_index(11);
   size_t num_features = 10;
+  size_t num_treatments = data.get_num_treatments();
 
   TreeOptions options = ForestTestUtilities::default_options().get_tree_options();
 
@@ -154,11 +157,11 @@ TEST_CASE("multi causal splitting with many identical treatments is identical to
       options.get_alpha(),
       options.get_imbalance_penalty(),
       1,
-      1));
+      num_treatments));
 
 
-  std::vector<double> inst = run_splits_multi(data, options, inst_splitting_rule, relabeling_strategy, num_features);
-  std::vector<double> multi = run_splits_multi(data, options, multi_splitting_rule, relabeling_strategy, num_features);
+  std::vector<double> inst = run_splits_multi(data, data.get_num_rows(), options, inst_splitting_rule, relabeling_strategy, num_features);
+  std::vector<double> multi = run_splits_multi(data, data.get_num_rows(), options, multi_splitting_rule, relabeling_strategy, num_features);
 
   REQUIRE(equal_doubles(inst[0], multi[0], 1e-6));
   REQUIRE(equal_doubles(inst[1], multi[1], 1e-6));
@@ -172,6 +175,7 @@ TEST_CASE("multi causal splitting with many identical treatments on NaN data is 
   data.set_treatment_index({11, 11, 11, 11, 11});
   data.set_instrument_index(11);
   size_t num_features = 10;
+  size_t num_treatments = data.get_num_treatments();
 
   TreeOptions options = ForestTestUtilities::default_options().get_tree_options();
 
@@ -187,11 +191,11 @@ TEST_CASE("multi causal splitting with many identical treatments on NaN data is 
       options.get_alpha(),
       options.get_imbalance_penalty(),
       1,
-      1));
+      num_treatments));
 
 
-  std::vector<double> inst = run_splits_multi(data, options, inst_splitting_rule, relabeling_strategy, num_features);
-  std::vector<double> multi = run_splits_multi(data, options, multi_splitting_rule, relabeling_strategy, num_features);
+  std::vector<double> inst = run_splits_multi(data, data.get_num_rows(), options, inst_splitting_rule, relabeling_strategy, num_features);
+  std::vector<double> multi = run_splits_multi(data, data.get_num_rows(), options, multi_splitting_rule, relabeling_strategy, num_features);
 
   REQUIRE(equal_doubles(inst[0], multi[0], 1e-6));
   REQUIRE(equal_doubles(inst[1], multi[1], 1e-6));


### PR DESCRIPTION
Just bumping up some test coverage by repeating this splitting test on the first `{500, 250, 113, 25, 10, 3}` samples in addition of doing it on the full data.