### PR TITLE
Update MGRF API

### DIFF
--- a/r-package/grf/R/average_treatment_effect.R
+++ b/r-package/grf/R/average_treatment_effect.R
@@ -226,7 +226,8 @@ average_treatment_effect <- function(forest,
         estimate = unlist(tau.hats),
         std.err = sqrt(unlist(sigma2.hats)),
         contrast = names(unlist(tau.hats)),
-        outcome = dimnames(DR.scores)[[3]][rep(1:NCOL(forest$Y.orig), each = dim(DR.scores)[2])]
+        outcome = dimnames(DR.scores)[[3]][rep(1:NCOL(forest$Y.orig), each = dim(DR.scores)[2])],
+        stringsAsFactors = FALSE
       )
       return(out) # rownames will be `contrast` when suitable, allowing a convenient `ate["contrast", "estimate"]` access.
     } else {

--- a/r-package/grf/R/average_treatment_effect.R
+++ b/r-package/grf/R/average_treatment_effect.R
@@ -198,10 +198,8 @@ average_treatment_effect <- function(forest,
     # and other average effect estimators.
 
     .sigma2.hat <- function(DR.scores, tau.hat) {
-      correction.clust <- Matrix::sparse.model.matrix(
-        ~ factor(subset.clusters) + 0,
-        transpose = TRUE
-      ) %*% (sweep(as.matrix(DR.scores), 2, tau.hat, "-") * subset.weights)
+      correction.clust <- Matrix::sparse.model.matrix(~ factor(subset.clusters) + 0, transpose = TRUE) %*%
+       (sweep(as.matrix(DR.scores), 2, tau.hat, "-") * subset.weights)
 
       Matrix::colSums(correction.clust^2) / sum(subset.weights)^2 *
         nrow(correction.clust) / (nrow(correction.clust) - 1)

--- a/r-package/grf/R/average_treatment_effect.R
+++ b/r-package/grf/R/average_treatment_effect.R
@@ -199,7 +199,7 @@ average_treatment_effect <- function(forest,
 
     .sigma2.hat <- function(DR.scores, tau.hat) {
       correction.clust <- Matrix::sparse.model.matrix(~ factor(subset.clusters) + 0, transpose = TRUE) %*%
-       (sweep(as.matrix(DR.scores), 2, tau.hat, "-") * subset.weights)
+        (sweep(as.matrix(DR.scores), 2, tau.hat, "-") * subset.weights)
 
       Matrix::colSums(correction.clust^2) / sum(subset.weights)^2 *
         nrow(correction.clust) / (nrow(correction.clust) - 1)

--- a/r-package/grf/R/get_scores.R
+++ b/r-package/grf/R/get_scores.R
@@ -273,7 +273,7 @@ get_scores.multi_arm_causal_forest <- function(forest,
 
   scores <- lapply(1:NCOL(forest$Y.orig), function(col) .get.scores(col))
 
-  array(unlist(scores), dim = dim(forest.pp$predictions), dimnames = dimnames(forest.pp$predictions))
+  array(unlist(scores), dim = c(length(subset), dim(forest.pp$predictions)[-1]), dimnames = dimnames(forest.pp$predictions))
 }
 
 #' Compute doubly robust scores for a causal survival forest.

--- a/r-package/grf/R/multi_arm_causal_forest.R
+++ b/r-package/grf/R/multi_arm_causal_forest.R
@@ -132,8 +132,6 @@
 #' legend("topleft", c("B - A", "C - A"), col = c("black", "blue"), pch = 19)
 #'
 #' # The average treatment effect of the arms with "A" as baseline.
-#' # (in the event the forest is fit with multiple Ys, specify the
-#' # response variable with the `outcome` argument)
 #' average_treatment_effect(mc.forest)
 #'
 #' # The conditional response surfaces mu_k(X) can be reconstructed from the
@@ -333,8 +331,6 @@ multi_arm_causal_forest <- function(X, Y, W,
 #' legend("topleft", c("B - A", "C - A"), col = c("black", "blue"), pch = 19)
 #'
 #' # The average treatment effect of the arms with "A" as baseline.
-#' # (in the event the forest is fit with multiple Ys, specify the
-#' # response variable with the `outcome` argument)
 #' average_treatment_effect(mc.forest)
 #'
 #' # The conditional response surfaces mu_k(X) can be reconstructed from the

--- a/r-package/grf/man/average_treatment_effect.Rd
+++ b/r-package/grf/man/average_treatment_effect.Rd
@@ -11,8 +11,7 @@ average_treatment_effect(
   subset = NULL,
   debiasing.weights = NULL,
   compliance.score = NULL,
-  num.trees.for.weights = 500,
-  outcome = 1
+  num.trees.for.weights = 500
 )
 }
 \arguments{
@@ -47,9 +46,6 @@ this is estimated via an auxiliary causal forest.}
 treatment), we need to train auxiliary forests to learn debiasing weights.
 This is the number of trees used for this task. Note: this argument is only
 used when debiasing.weights = NULL.}
-
-\item{outcome}{Only used with multi arm causal forets. In the event the forest is trained
-with multiple outcomes Y, a column number/name specifying the outcome of interest. Default is 1.}
 }
 \value{
 An estimate of the average treatment effect, along with standard error.

--- a/r-package/grf/man/get_scores.multi_arm_causal_forest.Rd
+++ b/r-package/grf/man/get_scores.multi_arm_causal_forest.Rd
@@ -4,7 +4,7 @@
 \alias{get_scores.multi_arm_causal_forest}
 \title{Compute doubly robust scores for a multi arm causal forest.}
 \usage{
-\method{get_scores}{multi_arm_causal_forest}(forest, subset = NULL, outcome = 1, ...)
+\method{get_scores}{multi_arm_causal_forest}(forest, subset = NULL, ...)
 }
 \arguments{
 \item{forest}{A trained multi arm causal forest.}
@@ -14,13 +14,10 @@ estimate the ATE. WARNING: For valid statistical performance,
 the subset should be defined only using features Xi, not using
 the treatment Wi or the outcome Yi.}
 
-\item{outcome}{In the event the forest is trained with multiple outcomes Y,
-a column number/name specifying the outcome of interest. Default is 1.}
-
 \item{...}{Additional arguments (currently ignored).}
 }
 \value{
-A matrix of scores for each contrast.
+An array of scores for each contrast and outcome.
 }
 \description{
 Compute doubly robust (AIPW) scores for average treatment effect estimation

--- a/r-package/grf/man/multi_arm_causal_forest.Rd
+++ b/r-package/grf/man/multi_arm_causal_forest.Rd
@@ -180,8 +180,6 @@ abline(0, -1.5, col = "red")
 legend("topleft", c("B - A", "C - A"), col = c("black", "blue"), pch = 19)
 
 # The average treatment effect of the arms with "A" as baseline.
-# (in the event the forest is fit with multiple Ys, specify the
-# response variable with the `outcome` argument)
 average_treatment_effect(mc.forest)
 
 # The conditional response surfaces mu_k(X) can be reconstructed from the

--- a/r-package/grf/man/predict.multi_arm_causal_forest.Rd
+++ b/r-package/grf/man/predict.multi_arm_causal_forest.Rd
@@ -66,8 +66,6 @@ abline(0, -1.5, col = "red")
 legend("topleft", c("B - A", "C - A"), col = c("black", "blue"), pch = 19)
 
 # The average treatment effect of the arms with "A" as baseline.
-# (in the event the forest is fit with multiple Ys, specify the
-# response variable with the `outcome` argument)
 average_treatment_effect(mc.forest)
 
 # The conditional response surfaces mu_k(X) can be reconstructed from the

--- a/r-package/grf/tests/testthat/test_multi_arm_causal_forest.R
+++ b/r-package/grf/tests/testthat/test_multi_arm_causal_forest.R
@@ -244,32 +244,40 @@ test_that("multi_arm_causal_forest with multiple outcomes works as expected", {
   # A multi arm causal forest trained on Y is identical to one trained on [Y 0]
   rf <- multi_arm_causal_forest(X, Y, W, Y.hat = 0, W.hat = c(1/3, 1/3, 1/3),
                                 num.trees = 200, seed = 42)
-  mrf <- multi_arm_causal_forest(X, cbind(Y, 0), W, Y.hat = c(0, 0), W.hat = c(1/3, 1/3, 1/3),
+  ate.rf <- average_treatment_effect(rf)
+  row.names(ate.rf) <- NULL
+  mrf <- multi_arm_causal_forest(X, cbind(Y.1 = Y, 0), W, Y.hat = c(0, 0), W.hat = c(1/3, 1/3, 1/3),
                                  num.trees = 200, seed = 42)
 
   expect_equal(predict(rf)$predictions[,,], predict(mrf)$predictions[, , 1])
   expect_equal(predict(rf, X)$predictions[,,], predict(mrf, X)$predictions[, , 1])
   expect_equal(dim(predict(mrf)$predictions), c(n, 2, 2))
-  expect_equal(average_treatment_effect(rf), average_treatment_effect(mrf))
+  ate.mrf <- average_treatment_effect(mrf)[1:2, ]
+  row.names(mrf) <- NULL
+  expect_equal(ate.rf, ate.mrf)
 
   # The above logic holds "symmetrically"
   # A multi arm causal forest trained on Y is identical to one trained on [0 Y]
-  mrf <- multi_arm_causal_forest(X, cbind(0, Y), W, Y.hat = c(0, 0), W.hat = c(1/3, 1/3, 1/3),
+  mrf <- multi_arm_causal_forest(X, cbind(0, Y.1 = Y), W, Y.hat = c(0, 0), W.hat = c(1/3, 1/3, 1/3),
                                  num.trees = 200, seed = 42)
 
   expect_equal(predict(rf)$predictions[,,], predict(mrf)$predictions[, , 2])
   expect_equal(predict(rf, X)$predictions[,,], predict(mrf, X)$predictions[, , 2])
   expect_equal(dim(predict(mrf)$predictions), c(n, 2, 2))
-  expect_equal(average_treatment_effect(rf), average_treatment_effect(mrf, outcome = 2))
+  ate.mrf <- average_treatment_effect(mrf)[3:4, ]
+  row.names(ate.mrf) <- NULL
+  expect_equal(ate.rf, ate.mrf)
 
   # A multi arm causal forest trained on Y is identical to one trained on [0 0 Y 0 0 0]
-  mrf <- multi_arm_causal_forest(X, cbind(0, 0, Y, 0, 0, 0), W, Y.hat = rep(0, 6), W.hat = c(1/3, 1/3, 1/3),
+  mrf <- multi_arm_causal_forest(X, cbind(0, 0, Y.1 = Y, 0, 0, 0), W, Y.hat = rep(0, 6), W.hat = c(1/3, 1/3, 1/3),
                                  num.trees = 200, seed = 42)
 
   expect_equal(predict(rf)$predictions[,,], predict(mrf)$predictions[, , 3])
   expect_equal(predict(rf, X)$predictions[,,], predict(mrf, X)$predictions[, , 3])
   expect_equal(dim(predict(mrf)$predictions), c(n, 2, 6))
-  expect_equal(average_treatment_effect(rf), average_treatment_effect(mrf, outcome = 3))
+  ate.mrf <- average_treatment_effect(mrf)[5:6, ]
+  row.names(ate.mrf) <- NULL
+  expect_equal(ate.rf, ate.mrf)
 
   # A multi arm causal forest trained on duplicated Y's yields the same result
   n <- 500
@@ -283,20 +291,13 @@ test_that("multi_arm_causal_forest with multiple outcomes works as expected", {
   mrf.dup <- multi_arm_causal_forest(X, cbind(YY, YY), W, Y.hat = rep(0, 4), W.hat = c(1/3, 1/3, 1/3),
                                      num.trees = 200, seed = 42)
 
-  expect_equal(predict(mrf)$predictions, predict(mrf.dup)$predictions[, , 1:2])
-  expect_equal(predict(mrf)$predictions, predict(mrf.dup)$predictions[, , 3:4])
-  expect_equal(average_treatment_effect(mrf, outcome = 1), average_treatment_effect(mrf.dup, outcome = 1))
-  expect_equal(average_treatment_effect(mrf, outcome = 1), average_treatment_effect(mrf.dup, outcome = 3))
-  expect_equal(average_treatment_effect(mrf, outcome = 2), average_treatment_effect(mrf.dup, outcome = 2))
-  expect_equal(average_treatment_effect(mrf, outcome = 2), average_treatment_effect(mrf.dup, outcome = 4))
-
-  # Named outcome argument works as expected
-  mrf.Yname <- multi_arm_causal_forest(X, cbind(runif(n), orange = runif(n), apple = rnorm(n)),
-                                       W, Y.hat = rep(0, 3), W.hat = c(1/3, 1/3, 1/3),
-                                       num.trees = 200, seed = 42)
-  expect_equal(average_treatment_effect(mrf.Yname, outcome = 1), average_treatment_effect(mrf.Yname, outcome = "1"))
-  expect_equal(average_treatment_effect(mrf.Yname, outcome = 2), average_treatment_effect(mrf.Yname, outcome = "orange"))
-  expect_equal(average_treatment_effect(mrf.Yname, outcome = 3), average_treatment_effect(mrf.Yname, outcome = "apple"))
+  expect_equal(unname(predict(mrf)$predictions), unname(predict(mrf.dup)$predictions[, , 1:2]))
+  expect_equal(unname(predict(mrf)$predictions), unname(predict(mrf.dup)$predictions[, , 3:4]))
+  expect_equal(average_treatment_effect(mrf), average_treatment_effect(mrf.dup)[1:4, ])
+  df1 <- average_treatment_effect(mrf)[, -4]
+  df2 <- average_treatment_effect(mrf.dup)[5:8, -4]
+  row.names(df2) <- NULL
+  expect_equal(df1, df2)
 })
 
 test_that("multi_arm_causal_forest with multiple outcomes is well calibrated", {

--- a/r-package/grf/tests/testthat/test_multi_arm_causal_forest.R
+++ b/r-package/grf/tests/testthat/test_multi_arm_causal_forest.R
@@ -25,7 +25,8 @@ test_that("single treatment multi_arm_causal_forest is similar to causal_forest"
   expect_equal(mean(pp.cf$predictions), mean(pp.mcf$predictions), tolerance = 0.05)
   expect_equal(mean((predict(cf, X)$predictions - predict(mcf, X)$predictions)^2), 0, tolerance = 0.05)
   expect_equal(mean(predict(cf, X)$predictions), mean(predict(mcf, X)$predictions), tolerance = 0.05)
-  expect_equal(average_treatment_effect(cf), average_treatment_effect(mcf)[,], tolerance = 0.001)
+  expect_equal(average_treatment_effect(cf)[["estimate"]], average_treatment_effect(mcf)[["estimate"]], tolerance = 0.001)
+  expect_equal(average_treatment_effect(cf)[["std.err"]], average_treatment_effect(mcf)[["std.err"]], tolerance = 0.001)
 
   # Same checks with standard unconstrained regression splits.
   cf.rsplit <- causal_forest(X, Y, W, W.hat = 1/2, Y.hat = 0, seed = 42, num.trees = 500, stabilize.splits = FALSE)
@@ -41,7 +42,8 @@ test_that("single treatment multi_arm_causal_forest is similar to causal_forest"
   expect_equal(mean(pp.cf.rsplit$predictions), mean(pp.mcf.rsplit$predictions), tolerance = 0.05)
   expect_equal(mean((predict(cf.rsplit, X)$predictions - predict(mcf.rsplit, X)$predictions)^2), 0, tolerance = 0.05)
   expect_equal(mean(predict(cf.rsplit, X)$predictions), mean(predict(mcf.rsplit, X)$predictions), tolerance = 0.05)
-  expect_equal(average_treatment_effect(cf.rsplit), average_treatment_effect(mcf.rsplit)[,], tolerance = 0.001)
+  expect_equal(average_treatment_effect(cf.rsplit)[["estimate"]], average_treatment_effect(mcf.rsplit)[["estimate"]], tolerance = 0.001)
+  expect_equal(average_treatment_effect(cf.rsplit)[["estimate"]], average_treatment_effect(mcf.rsplit)[["estimate"]], tolerance = 0.001)
 })
 
 test_that("multi_arm_causal_forest contrasts works as expected", {
@@ -151,7 +153,7 @@ test_that("multi_arm_causal_forest ATE standard errors are consistent with rest 
   ate <- average_treatment_effect(mcf)
   DR.scores <- get_scores(mcf)
 
-  lm.test <- lmtest::coeftest(lm(DR.scores ~ 1),
+  lm.test <- lmtest::coeftest(lm(DR.scores[,,] ~ 1),
                               vcov = sandwich::vcovCL,
                               type = "HC3",
                               cluster = clusters <- if (length(mcf$clusters) > 0)

--- a/r-package/grf/tests/testthat/test_multi_arm_causal_forest.R
+++ b/r-package/grf/tests/testthat/test_multi_arm_causal_forest.R
@@ -43,7 +43,7 @@ test_that("single treatment multi_arm_causal_forest is similar to causal_forest"
   expect_equal(mean((predict(cf.rsplit, X)$predictions - predict(mcf.rsplit, X)$predictions)^2), 0, tolerance = 0.05)
   expect_equal(mean(predict(cf.rsplit, X)$predictions), mean(predict(mcf.rsplit, X)$predictions), tolerance = 0.05)
   expect_equal(average_treatment_effect(cf.rsplit)[["estimate"]], average_treatment_effect(mcf.rsplit)[["estimate"]], tolerance = 0.001)
-  expect_equal(average_treatment_effect(cf.rsplit)[["estimate"]], average_treatment_effect(mcf.rsplit)[["estimate"]], tolerance = 0.001)
+  expect_equal(average_treatment_effect(cf.rsplit)[["std.err"]], average_treatment_effect(mcf.rsplit)[["std.err"]], tolerance = 0.001)
 })
 
 test_that("multi_arm_causal_forest contrasts works as expected", {


### PR DESCRIPTION
As discussed with @halflearned, re-design ATE output for multiple treatments. For a binary treatment, access with `[[` allows it to be a drop-in replacement for causal_forest. 

```R
n <- 500
p <- 10
X <- matrix(rnorm(n * p), n, p)
W <- as.factor(sample(c("A", "B", "C"), n, replace = TRUE))
Y1 <- X[, 1] + X[, 2] * (W == "B") - 1.5 * X[, 2] * (W == "C") + rnorm(n)
Y2 <- X[, 2] + X[, 3] * (W == "B") - 1.5 * X[, 4] * (W == "C") + rnorm(n)
mc.forest <- multi_arm_causal_forest(X, cbind(Y1=Y, Y2=Y2), W)
average_treatment_effect(mc.forest)
#     estimate   std.err contrast outcome
# 1 0.35759195 0.1755994    B - A      Y1
# 2 0.04621586 0.1768737    C - A      Y1
# 3 0.06727357 0.1296876    B - A      Y2
# 4 0.10254803 0.1398678    C - A      Y2

# Single outcome
mc.forest <- multi_arm_causal_forest(X, Y1, W)
average_treatment_effect(mc.forest)
#           estimate   std.err contrast outcome
# B - A -0.313808965 0.1151307    B - A     Y.1
# C - A -0.002008471 0.1327722    C - A     Y.1
(note by default R makes the rownames of the DF equal to `contrast` when suitable (i.e. one outcome), allowing a convenient `ate["contrast", "estimate"]` access.)
```

This removes the need for an `outcome` argument, and `get_scores` now return the same type of 3d array as `predict`.