### PR TITLE
Bump instrumental_forest test tolerance

### DIFF
--- a/r-package/grf/tests/testthat/test_instrumental_forest.R
+++ b/r-package/grf/tests/testthat/test_instrumental_forest.R
@@ -37,8 +37,8 @@ test_that("instrumental forests give reasonable estimates", {
   Z <- error / sqrt(preds.iv$variance.estimate)
   Z.oob <- error.oob / sqrt(preds.iv.oob$variance.estimate)
 
-  expect_lt(mean(abs(Z) > 1), 0.5)
-  expect_lt(mean(abs(Z.oob) > 1), 0.5)
+  expect_lt(mean(abs(Z) > 1), 0.75)
+  expect_lt(mean(abs(Z.oob) > 1), 0.75)
 })
 
 test_that("sample weighted instrumental forest is estimated with kernel weights `forest.weights * sample.weights`", {


### PR DESCRIPTION
#774 removed a `set.seed` (bad practice) from this test case, bump tolerance in line with the expected worse case behavior:

```
library(grf)
library(testthat)

set.seed(123)
res=replicate(50, {
p <- 6
n <- 2000
n.test <- 2000

X <- matrix(rnorm(n * p), n, p)

eps <- rnorm(n)
Z <- rbinom(n, 1, 2 / 3)
filter <- rbinom(n, 1, 1 / (1 + exp(-1 * eps)))
W <- Z * filter

tau <- apply(X[, 1:2], 1, function(xx) sum(pmax(0, xx)))
mu <- apply(X[, 2 + 1:2], 1, function(xx) sum(pmax(0, xx)))

Y <- (2 * W - 1) / 2 * tau + mu + eps

X.test <- matrix(rnorm(n.test * p), n.test, p)
tau.true <- apply(X.test[, 1:2], 1, function(xx) sum(pmax(0, xx)))

forest.iv <- instrumental_forest(X, Y, W, Z, num.trees = 4000)

preds.iv.oob <- predict(forest.iv, estimate.variance = TRUE)
preds.iv <- predict(forest.iv, X.test, estimate.variance = TRUE)

expect_true(all(preds.iv$variance.estimate > 0))
expect_true(all(preds.iv.oob$variance.estimate > 0))

error <- preds.iv$predictions - tau.true
expect_lt(mean(error^2), 0.4)

error.oob <- preds.iv.oob$predictions - tau
expect_lt(mean(error.oob^2), 0.4)

Z <- error / sqrt(preds.iv$variance.estimate)
Z.oob <- error.oob / sqrt(preds.iv.oob$variance.estimate)

c(
  mean(abs(Z) > 1),
  mean(abs(Z.oob) > 1)
)
})
summary(res[1, ])
# Min. 1st Qu.  Median    Mean 3rd Qu.    Max.
# 0.2365  0.3966  0.5282  0.4988  0.5686  0.7375
summary(res[2, ])
# Min. 1st Qu.  Median    Mean 3rd Qu.    Max.
# 0.2635  0.3815  0.5145  0.4898  0.5583  0.7440
```