### PR TITLE
Avoid `unreferenced variable` MSVC warning

### DIFF
--- a/core/test/forest/ForestSmokeTest.cpp
+++ b/core/test/forest/ForestSmokeTest.cpp
@@ -105,7 +105,7 @@ TEST_CASE("forests with different ci_group_size cannot be merged", "[regression,
   try {
     Forest big_forest = Forest::merge(forests);
     FAIL();
-  } catch (const std::runtime_error& e) {
+  } catch (const std::runtime_error&) {
     // Expected exception.
   }
 }


### PR DESCRIPTION
Avoid the catch clause's warning in ForestSmokeTest.cpp:

```  D:\a\1\s\core\test\forest\ForestSmokeTest.cpp(108,38): warning C4101: 'e': unreferenced local variable [D:\a\1\s\core\build\grf.vcxproj]```

with the idiom from https://groups.google.com/g/mongodb-user/c/C97StGxNIow