### PR TITLE
Convert implicit to explicits casts

### DIFF
--- a/core/src/forest/ForestTrainer.cpp
+++ b/core/src/forest/ForestTrainer.cpp
@@ -58,7 +58,7 @@ std::vector<std::unique_ptr<Tree>> ForestTrainer::train_trees(const Data& data,
     throw std::runtime_error("The honesty fraction is too close to 1 or 0, as no observations will be sampled.");
   }
 
-  uint num_groups = (uint) num_trees / options.get_ci_group_size();
+  uint num_groups = static_cast<uint>(num_trees / options.get_ci_group_size());
 
   std::vector<uint> thread_ranges;
   split_sequence(thread_ranges, 0, num_groups - 1, options.get_num_threads());

--- a/core/src/prediction/MultiCausalPredictionStrategy.cpp
+++ b/core/src/prediction/MultiCausalPredictionStrategy.cpp
@@ -138,7 +138,7 @@ std::vector<double> MultiCausalPredictionStrategy::compute_variance(
       group_rho += rho;
     }
 
-    group_rho /= ci_group_size;
+    group_rho /= static_cast<double>(ci_group_size);
     rho_grouped_squared += group_rho.array().square().matrix();
   }
 

--- a/core/src/prediction/ProbabilityPredictionStrategy.cpp
+++ b/core/src/prediction/ProbabilityPredictionStrategy.cpp
@@ -116,7 +116,7 @@ PredictionValues ProbabilityPredictionStrategy::precompute_prediction_values(
     double weight_sum = 0.0;
     for (auto& sample : leaf_node) {
       // The data Yi will be relabeled to integers {0, ..., num_classes - 1}
-      size_t sample_class = data.get_outcome(sample);
+      size_t sample_class = static_cast<size_t>(data.get_outcome(sample));
       averages[sample_class] += data.get_weight(sample);
       weight_sum += data.get_weight(sample);
     }

--- a/core/src/prediction/SurvivalPredictionStrategy.cpp
+++ b/core/src/prediction/SurvivalPredictionStrategy.cpp
@@ -49,7 +49,7 @@ std::vector<double> SurvivalPredictionStrategy::predict(size_t prediction_sample
   for (const auto& entry : weights_by_sample) {
     size_t sample = entry.first;
     double forest_weight = entry.second;
-    size_t failure_time = train_data.get_outcome(sample);
+    size_t failure_time = static_cast<size_t>(train_data.get_outcome(sample));
     double sample_weight = train_data.get_weight(sample);
     if (train_data.is_failure(sample)) {
      count_failure[failure_time] += forest_weight * sample_weight;

--- a/core/src/prediction/collector/DefaultPredictionCollector.cpp
+++ b/core/src/prediction/collector/DefaultPredictionCollector.cpp
@@ -38,7 +38,7 @@ std::vector<Prediction> DefaultPredictionCollector::collect_predictions(
 
   size_t num_samples = data.get_num_rows();
   std::vector<uint> thread_ranges;
-  split_sequence(thread_ranges, 0, num_samples - 1, num_threads);
+  split_sequence(thread_ranges, 0, static_cast<uint>(num_samples - 1), num_threads);
 
   std::vector<std::future<std::vector<Prediction>>> futures;
   futures.reserve(thread_ranges.size());

--- a/core/src/prediction/collector/OptimizedPredictionCollector.cpp
+++ b/core/src/prediction/collector/OptimizedPredictionCollector.cpp
@@ -35,7 +35,7 @@ std::vector<Prediction> OptimizedPredictionCollector::collect_predictions(const 
                                                                           bool estimate_error) const {
   size_t num_samples = data.get_num_rows();
   std::vector<uint> thread_ranges;
-  split_sequence(thread_ranges, 0, num_samples - 1, num_threads);
+  split_sequence(thread_ranges, 0, static_cast<uint>(num_samples - 1), num_threads);
 
   std::vector<std::future<std::vector<Prediction>>> futures;
   futures.reserve(thread_ranges.size());

--- a/core/src/prediction/collector/TreeTraverser.cpp
+++ b/core/src/prediction/collector/TreeTraverser.cpp
@@ -35,7 +35,7 @@ std::vector<std::vector<size_t>> TreeTraverser::get_leaf_nodes(
   leaf_nodes_by_tree.reserve(num_trees);
 
   std::vector<uint> thread_ranges;
-  split_sequence(thread_ranges, 0, num_trees - 1, num_threads);
+  split_sequence(thread_ranges, 0, static_cast<uint>(num_trees - 1), num_threads);
 
   std::vector<std::future<
       std::vector<std::vector<size_t>>>> futures;

--- a/core/src/relabeling/QuantileRelabelingStrategy.cpp
+++ b/core/src/relabeling/QuantileRelabelingStrategy.cpp
@@ -55,7 +55,7 @@ bool QuantileRelabelingStrategy::relabel(
                                      quantile_cutoffs.end(),
                                      outcome);
     long quantile_index = static_cast<long>(quantile - quantile_cutoffs.begin());
-    responses_by_sample(sample, 0) = (uint) quantile_index;
+    responses_by_sample(sample, 0) = static_cast<uint>(quantile_index);
   }
   return false;
 }

--- a/core/src/relabeling/QuantileRelabelingStrategy.cpp
+++ b/core/src/relabeling/QuantileRelabelingStrategy.cpp
@@ -54,7 +54,7 @@ bool QuantileRelabelingStrategy::relabel(
     auto quantile = std::lower_bound(quantile_cutoffs.begin(),
                                      quantile_cutoffs.end(),
                                      outcome);
-    long quantile_index = quantile - quantile_cutoffs.begin();
+    long quantile_index = static_cast<long>(quantile - quantile_cutoffs.begin());
     responses_by_sample(sample, 0) = (uint) quantile_index;
   }
   return false;

--- a/core/src/sampling/RandomSampler.cpp
+++ b/core/src/sampling/RandomSampler.cpp
@@ -39,7 +39,7 @@ void RandomSampler::sample_clusters(size_t num_rows,
 void RandomSampler::sample(size_t num_samples,
                            double sample_fraction,
                            std::vector<size_t>& samples) {
-  size_t num_samples_inbag = (size_t) num_samples * sample_fraction;
+  size_t num_samples_inbag = static_cast<size_t>(num_samples * sample_fraction);
   shuffle_and_split(samples, num_samples, num_samples_inbag);
 }
 
@@ -187,7 +187,7 @@ void RandomSampler::draw_fisher_yates(std::vector<size_t>& result,
   // Draw without replacement using Fisher Yates algorithm
   nonstd::uniform_real_distribution<double> distribution(0.0, 1.0);
   for (size_t i = 0; i < num_samples; ++i) {
-    size_t j = i + distribution(random_number_generator) * (max - skip.size() - i);
+    size_t j = static_cast<size_t>(i + distribution(random_number_generator) * (max - skip.size() - i));
     std::swap(result[i], result[j]);
   }
 
@@ -195,7 +195,7 @@ void RandomSampler::draw_fisher_yates(std::vector<size_t>& result,
 }
 
 size_t RandomSampler::sample_poisson(size_t mean) {
-  nonstd::poisson_distribution<size_t> distribution(mean);
+  nonstd::poisson_distribution<size_t> distribution(static_cast<double>(mean));
   return distribution(random_number_generator);
 }
 

--- a/core/src/splitting/CausalSurvivalSplittingRule.cpp
+++ b/core/src/splitting/CausalSurvivalSplittingRule.cpp
@@ -94,7 +94,7 @@ bool CausalSurvivalSplittingRule::find_best_split(const Data& data,
 
   double size_node = sum_node_z_squared - sum_node_z * sum_node_z / weight_sum_node;
   double min_child_size = size_node * alpha;
-  size_t min_child_size_survival = std::max<size_t>(std::ceil(num_samples * alpha), 1uL);
+  size_t min_child_size_survival = std::max<size_t>(static_cast<size_t>(std::ceil(num_samples * alpha)), 1uL);
 
   double mean_z_node = sum_node_z / weight_sum_node;
   size_t num_node_small_z = 0;

--- a/core/src/splitting/MultiRegressionSplittingRule.cpp
+++ b/core/src/splitting/MultiRegressionSplittingRule.cpp
@@ -52,7 +52,7 @@ bool MultiRegressionSplittingRule::find_best_split(const Data& data,
                                                    std::vector<bool>& send_missing_left) {
 
   size_t size_node = samples[node].size();
-  size_t min_child_size = std::max<size_t>(std::ceil(size_node * alpha), 1uL);
+  size_t min_child_size = std::max<size_t>(static_cast<size_t>(std::ceil(size_node * alpha)), 1uL);
 
   // Precompute the sum of outcomes in this node.
   Eigen::ArrayXd sum_node = Eigen::ArrayXd::Zero(num_outcomes);

--- a/core/src/splitting/ProbabilitySplittingRule.cpp
+++ b/core/src/splitting/ProbabilitySplittingRule.cpp
@@ -53,7 +53,7 @@ bool ProbabilitySplittingRule::find_best_split(const Data& data,
                                                std::vector<double>& split_values,
                                                std::vector<bool>& send_missing_left) {
   size_t size_node = samples[node].size();
-  size_t min_child_size = std::max<size_t>(std::ceil(size_node * alpha), 1uL);
+  size_t min_child_size = std::max<size_t>(static_cast<size_t>(std::ceil(size_node * alpha)), 1uL);
 
   double* class_counts = new double[num_classes]();
   for (size_t i = 0; i < size_node; ++i) {
@@ -123,7 +123,7 @@ void ProbabilitySplittingRule::find_best_split_value(const Data& data,
     size_t sample = sorted_samples[i];
     size_t next_sample = sorted_samples[i + 1];
     double sample_value = data.get(sample, var);
-    uint sample_class = responses_by_sample(sample, 0);
+    uint sample_class = static_cast<uint>(responses_by_sample(sample, 0));
     double sample_weight = data.get_weight(sample);
 
     if (std::isnan(sample_value)) {

--- a/core/src/splitting/RegressionSplittingRule.cpp
+++ b/core/src/splitting/RegressionSplittingRule.cpp
@@ -53,7 +53,7 @@ bool RegressionSplittingRule::find_best_split(const Data& data,
                                               std::vector<bool>& send_missing_left) {
 
   size_t size_node = samples[node].size();
-  size_t min_child_size = std::max<size_t>(std::ceil(size_node * alpha), 1uL);
+  size_t min_child_size = std::max<size_t>(static_cast<size_t>(std::ceil(size_node * alpha)), 1uL);
 
   // Precompute the sum of outcomes in this node.
   double sum_node = 0.0;

--- a/core/src/splitting/SurvivalSplittingRule.cpp
+++ b/core/src/splitting/SurvivalSplittingRule.cpp
@@ -65,7 +65,7 @@ void SurvivalSplittingRule::find_best_split_internal(const Data& data,
                                                      bool& best_send_missing_left,
                                                      double& best_logrank) {
   size_t size_node = samples.size();
-  size_t min_child_size = std::max<size_t>(std::ceil(size_node * alpha), 1uL);
+  size_t min_child_size = std::max<size_t>(static_cast<size_t>(std::ceil(size_node * alpha)), 1uL);
 
   // Get the failure values t1, ..., tm in this node
   std::vector<double> failure_values;
@@ -95,7 +95,7 @@ void SurvivalSplittingRule::find_best_split_internal(const Data& data,
   // with observed time greater than or equal to the given failure time. Entry 0 will be equal to the number
   // of samples (and the entries will always be monotonically decreasing)
   std::vector<double> at_risk(num_failures + 1);
-  at_risk[0] = size_node;
+  at_risk[0] = static_cast<double>(size_node);
 
   // allocating an N-sized (full data set size) array is faster than a hash table
   std::vector<size_t> relabeled_failures(data.get_num_rows());


### PR DESCRIPTION
Only aesthetic update for GRF: address some MSVC warnings - explicitly declare type conversions in order to be good C++ citizen. Related issue: #231 

(A future PR could replace other old C-style casts with modern C++ static_casts)