### PR TITLE
Fix `multi_arm_causal_forest` IPW calculation

### DIFF
--- a/r-package/grf/R/get_scores.R
+++ b/r-package/grf/R/get_scores.R
@@ -254,6 +254,8 @@ get_scores.multi_arm_causal_forest <- function(forest,
       "."
     ))
   }
+  # Fill in a [NxK] IPW matrix with inverse propensity estimates of the observed arm
+  # using the subsetting syntax "matrix[index.matrix]".
   IPW <- matrix(0, length(subset), nlevels(W.orig))
   IPW[observed.treatment.idx] <- 1 / W.hat[observed.treatment.idx]
   control <- IPW[, 1] != 0

--- a/r-package/grf/R/get_scores.R
+++ b/r-package/grf/R/get_scores.R
@@ -254,9 +254,13 @@ get_scores.multi_arm_causal_forest <- function(forest,
       "."
     ))
   }
+  IPW <- matrix(0, length(subset), nlevels(W.orig))
+  IPW[observed.treatment.idx] <- 1 / W.hat[observed.treatment.idx]
+  control <- IPW[, 1] != 0
+  IPW[control, -1] <- -1 * IPW[control, 1]
+
+  IPW <- IPW[, -1, drop = FALSE]
   W.hat <- W.hat[, -1, drop = FALSE]
-  W.matrix <- stats::model.matrix(~ W.orig - 1)
-  IPW <- (W.matrix[, -1] - W.hat) / (W.hat * (1 - W.hat))
   forest.pp <- predict(forest)
 
   .get.scores <- function(outcome) {


### PR DESCRIPTION
See #1020. This affects the standard error output of `average_treatment_effect`.

For the GRF 2.0.2 CRAN release, correct AIPW standard errors can be obtained by using `policytree`'s `double_robust_scores` method, which is correct, see #1020.

<details>
  <summary>Re-run of the included gist by @halflearned:</summary>

```
library(grf)

set.seed(1)

n <- 1000
p <- 7

make_data <- function(n, p) {
  X <- round(matrix(rnorm(n*p), n, p), 2)
  mu <- c(1,2,3)
  mu.all <- matrix(mu, nrow=n, ncol=3, byrow=TRUE)
  W <- factor(sample(3, size=n, replace=TRUE), levels=seq(1, 3))
  Y <- mu.all[cbind(1:n, W)] + rnorm(n)
  list(X=X, W=W, Y=Y, mu=mu, mu.all=mu.all)
}


tab <- do.call(rbind, lapply(seq(500), function(i) {
  print(i)
  data <- make_data(n, p)
  X <- data$X
  W <- data$W
  Y <- data$Y
  delta.truth <- data$mu[-1] - data$mu[1]
  
  mgrf <- multi_arm_causal_forest(X, Y, W, seed=1)
  mgrf.scores <- get_scores(mgrf)[,,1]
  mgrf.coverage <- sapply(seq(2), function(k) t.test(mgrf.scores[,k], mu=delta.truth[k])$p.value)
  
  # Output
  data.frame(
    mgrf.cov1=mgrf.coverage[1],
    mgrf.cov2=mgrf.coverage[2])
}))


# These should all be around 0.05
print(colMeans(tab < .05))
# mgrf.cov1 mgrf.cov2 
# 0.042     0.052 
```

</details>
