### PR TITLE
Provide option for progress estimation when training a forest

### DIFF
--- a/core/.gitignore
+++ b/core/.gitignore
@@ -13,3 +13,4 @@
 .settings/*
 .project
 .cproject
+cmake-build-debug/

--- a/core/src/commons/ProgressBar.cpp
+++ b/core/src/commons/ProgressBar.cpp
@@ -1,0 +1,9 @@
+
+#include "ProgressBar.h"
+
+ProgressBar::ProgressBar(std::string op_str, size_t max_prog, bool v) {
+    operation = std::move(op_str);
+    max_progress = max_prog;
+    verbose = v;
+}
+

--- a/core/src/commons/ProgressBar.h
+++ b/core/src/commons/ProgressBar.h
@@ -1,0 +1,125 @@
+#ifndef GRF_PROGRESSBAR_H
+#define GRF_PROGRESSBAR_H
+#include <atomic>
+#include <mutex>
+#include <iostream>
+#include <utility>
+#include "commons/utility.h"
+#include "commons/globals.h"
+
+
+using std::chrono::steady_clock;
+using std::chrono::duration_cast;
+using std::chrono::seconds;
+
+
+
+class ProgressBar {
+
+    public:
+        ProgressBar (std::string, size_t, bool);
+
+        void set_progress(float value_pct, size_t value_int) {
+            std::unique_lock<std::mutex> lock{mutex_};
+            progress_pct_ = value_pct;
+            progress_ += value_int;
+        }
+
+        void set_initial_times() {
+            start_time_ = steady_clock::now();
+            last_time_ = steady_clock::now();
+        }
+
+        void set_bar_width(size_t width) {
+            std::unique_lock<std::mutex> lock{mutex_};
+            bar_width_ = width;
+        }
+
+        void fill_bar_progress_with(const std::string &chars) {
+            std::unique_lock<std::mutex> lock{mutex_};
+            fill_ = chars;
+        }
+
+        void fill_bar_remainder_with(const std::string &chars) {
+            std::unique_lock<std::mutex> lock{mutex_};
+            remainder_ = chars;
+        }
+
+        void set_status_text(const std::string &status) {
+            std::unique_lock<std::mutex> lock{mutex_};
+            status_text_ = status;
+        }
+
+        void update(float value_pct, size_t value_int, std::ostream &os = std::cout) {
+            set_progress(value_pct, value_int);
+//            write_progress(os);
+            write_time_estimate(os);
+        }
+
+        void write_time_estimate(std::ostream &os = std::cout) {
+            std::unique_lock<std::mutex> lock{mutex_};
+            elapsed_time_ = duration_cast<seconds>(steady_clock::now() - last_time_);
+            if (progress_ > 0 && elapsed_time_.count() > grf::STATUS_INTERVAL){
+                double relative_progress = (double) progress_ / (double) max_progress;
+                seconds time_from_start = duration_cast<seconds>(steady_clock::now() - start_time_);
+                os << " progress: " << progress_<< std::endl;
+                os << " max_progress: " << max_progress<< std::endl;
+                os << " relative_progress: " << relative_progress<< std::endl;
+                os << " time_from_start: " << time_from_start.count() << std::endl;
+                uint remaining_time = (1 / relative_progress - 1) * time_from_start.count();
+                if (verbose) {
+                    os << operation << " Progress: " << round(100 * relative_progress) << "%. Estimated remaining time: "
+                        << grf::beautifyTime(remaining_time) << "." << std::endl;
+                }
+                last_time_ = steady_clock::now();
+            }
+        }
+
+        void write_progress(std::ostream &os = std::cout) {
+            std::unique_lock<std::mutex> lock{mutex_};
+
+            // No need to write once progress is 100%
+            if (progress_pct_ > 100.0f) return;
+
+            // Move cursor to the first position on the same line and flush
+            os << "\r" << std::flush;
+
+            // Start bar
+            os << "[";
+
+            const auto completed = static_cast<size_t>(progress_pct_ * static_cast<float>(bar_width_) / 100.0);
+            for (size_t i = 0; i < bar_width_; ++i) {
+                if (i <= completed)
+                    os << fill_;
+                else
+                    os << remainder_;
+            }
+
+            // End bar
+            os << "]";
+
+            // Write progress percentage
+            os << " " << std::min(static_cast<size_t>(progress_pct_), size_t(100)) << "%";
+
+            // Write status text
+            os << " " << status_text_;
+        }
+
+    private:
+        std::string operation;
+        size_t max_progress;
+        bool verbose;
+        steady_clock::time_point start_time_;
+        steady_clock::time_point last_time_;
+        seconds elapsed_time_{};
+        std::mutex mutex_;
+        size_t progress_{0};
+        float progress_pct_{0.0f};
+        size_t bar_width_{60};
+        std::string fill_{"#"}, remainder_{" "}, status_text_{""};
+};
+
+
+
+
+#endif //GRF_PROGRESSBAR_H

--- a/core/src/commons/ProgressBar.h
+++ b/core/src/commons/ProgressBar.h
@@ -6,7 +6,7 @@
 #include <utility>
 #include "commons/utility.h"
 #include "commons/globals.h"
-
+#include <Rcpp.h>
 
 using std::chrono::steady_clock;
 using std::chrono::duration_cast;
@@ -56,16 +56,12 @@ class ProgressBar {
             write_time_estimate(os);
         }
 
-        void write_time_estimate(std::ostream &os = std::cout) {
+        void write_time_estimate(std::ostream &os = Rcpp::Rcout) {
             std::unique_lock<std::mutex> lock{mutex_};
             elapsed_time_ = duration_cast<seconds>(steady_clock::now() - last_time_);
             if (progress_ > 0 && elapsed_time_.count() > grf::STATUS_INTERVAL){
                 double relative_progress = (double) progress_ / (double) max_progress;
                 seconds time_from_start = duration_cast<seconds>(steady_clock::now() - start_time_);
-                os << " progress: " << progress_<< std::endl;
-                os << " max_progress: " << max_progress<< std::endl;
-                os << " relative_progress: " << relative_progress<< std::endl;
-                os << " time_from_start: " << time_from_start.count() << std::endl;
                 uint remaining_time = (1 / relative_progress - 1) * time_from_start.count();
                 if (verbose) {
                     os << operation << " Progress: " << round(100 * relative_progress) << "%. Estimated remaining time: "

--- a/core/src/commons/ProgressBar.h
+++ b/core/src/commons/ProgressBar.h
@@ -58,9 +58,6 @@ class ProgressBar {
         seconds elapsed_time_{};
         std::mutex mutex_;
         size_t progress_{0};
-        float progress_pct_{0.0f};
-        size_t bar_width_{60};
-        std::string fill_{"#"}, remainder_{" "}, status_text_{""};
 };
 
 

--- a/core/src/commons/globals.h
+++ b/core/src/commons/globals.h
@@ -11,5 +11,7 @@ typedef unsigned int uint;
 
 static const uint DEFAULT_NUM_THREADS = 0;
 
+const double STATUS_INTERVAL = 2.0;
+
 } // namespace grf
 #endif /* GRF_GLOBALS_H_ */

--- a/core/src/commons/globals.h
+++ b/core/src/commons/globals.h
@@ -11,7 +11,8 @@ typedef unsigned int uint;
 
 static const uint DEFAULT_NUM_THREADS = 0;
 
-const double STATUS_INTERVAL = 2.0;
+// default in ranger is 30.0
+const double STATUS_INTERVAL = 30.0;
 
 } // namespace grf
 #endif /* GRF_GLOBALS_H_ */

--- a/core/src/commons/utility.cpp
+++ b/core/src/commons/utility.cpp
@@ -132,4 +132,41 @@ void set_data(std::pair<std::vector<double>, std::vector<size_t>>& data, size_t 
   data.first.at(col * num_rows + row) = value;
 }
 
+std::string uintToString(uint number) {
+    return std::to_string(number);
+}
+
+std::string beautifyTime(uint seconds) {
+  std::string result;
+
+  // Add seconds, minutes, hours, days if larger than zero
+  uint out_seconds = (uint) seconds % 60;
+  result = uintToString(out_seconds) + " seconds";
+  uint out_minutes = (seconds / 60) % 60;
+  if (seconds / 60 == 0) {
+    return result;
+  } else if (out_minutes == 1) {
+    result = "1 minute, " + result;
+  } else {
+    result = uintToString(out_minutes) + " minutes, " + result;
+  }
+  uint out_hours = (seconds / 3600) % 24;
+  if (seconds / 3600 == 0) {
+    return result;
+  } else if (out_hours == 1) {
+    result = "1 hour, " + result;
+  } else {
+    result = uintToString(out_hours) + " hours, " + result;
+  }
+  uint out_days = (seconds / 86400);
+  if (out_days == 0) {
+    return result;
+  } else if (out_days == 1) {
+    result = "1 day, " + result;
+  } else {
+    result = uintToString(out_days) + " days, " + result;
+  }
+  return result;
+}
+
 } // namespace grf

--- a/core/src/commons/utility.h
+++ b/core/src/commons/utility.h
@@ -59,6 +59,13 @@ std::string uintToString(uint number);
  */
 std::string beautifyTime(uint seconds);
 
+/**
+ * Add make_unique function for C++11
+ */
+template<typename T, typename... Args>
+std::unique_ptr<T> make_unique(Args&&... args) {
+    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
 
 } // namespace grf
 

--- a/core/src/commons/utility.h
+++ b/core/src/commons/utility.h
@@ -45,6 +45,21 @@ std::pair<std::vector<double>, std::vector<size_t>> load_data(const std::string&
 
 void set_data(std::pair<std::vector<double>, std::vector<size_t>>& data, size_t row, size_t col, double value);
 
+/**
+ * Convert a unsigned integer to string
+ * @param number Number to convert
+ * @return Converted number as string
+ */
+std::string uintToString(uint number);
+
+/**
+ * Beautify output of time.
+ * @param seconds Time in seconds
+ * @return Time in days, hours, minutes and seconds as string
+ */
+std::string beautifyTime(uint seconds);
+
+
 } // namespace grf
 
 #endif /* GRF_UTILITY_H_ */

--- a/core/src/forest/ForestOptions.cpp
+++ b/core/src/forest/ForestOptions.cpp
@@ -37,11 +37,12 @@ ForestOptions::ForestOptions(uint num_trees,
                              uint num_threads,
                              uint random_seed,
                              const std::vector<size_t>& sample_clusters,
-                             uint samples_per_cluster):
+                             uint samples_per_cluster,
+                             bool verbose):
     ci_group_size(ci_group_size),
     sample_fraction(sample_fraction),
     tree_options(mtry, min_node_size, honesty, honesty_fraction, honesty_prune_leaves, alpha, imbalance_penalty),
-    sampling_options(samples_per_cluster, sample_clusters) {
+    sampling_options(samples_per_cluster, sample_clusters), verbose(verbose){
 
   this->num_threads = validate_num_threads(num_threads);
 
@@ -60,6 +61,12 @@ ForestOptions::ForestOptions(uint num_trees,
     std::random_device random_device;
     this->random_seed = random_device();
   }
+
+  this->verbose = get_verbosity();
+}
+
+bool ForestOptions::get_verbosity() const {
+    return verbose;
 }
 
 uint ForestOptions::get_num_trees() const {

--- a/core/src/forest/ForestOptions.h
+++ b/core/src/forest/ForestOptions.h
@@ -40,7 +40,8 @@ public:
                 uint num_threads,
                 uint random_seed,
                 const std::vector<size_t>& sample_clusters,
-                uint samples_per_cluster);
+                uint samples_per_cluster,
+                bool verbose);
 
   static uint validate_num_threads(uint num_threads);
 
@@ -54,6 +55,8 @@ public:
   uint get_num_threads() const;
   uint get_random_seed() const;
 
+  bool get_verbosity() const;
+
 private:
   uint num_trees;
   size_t ci_group_size;
@@ -64,6 +67,7 @@ private:
 
   uint num_threads;
   uint random_seed;
+  bool verbose;
 };
 
 } // namespace grf

--- a/core/src/forest/ForestTrainer.cpp
+++ b/core/src/forest/ForestTrainer.cpp
@@ -54,9 +54,6 @@ std::vector<std::unique_ptr<Tree>> ForestTrainer::train_trees(const Data& data,
 
   ProgressBar bar(operation_name, num_trees, verbose);
   bar.set_initial_times();
-  bar.set_bar_width(50); // way to more adaptively set width?
-  bar.fill_bar_progress_with("■");
-  bar.fill_bar_remainder_with(" ");
 
   // Ensure that the sample fraction is not too small and honesty fraction is not too extreme.
   const TreeOptions& tree_options = options.get_tree_options();
@@ -129,11 +126,8 @@ std::vector<std::unique_ptr<Tree>> ForestTrainer::train_batch(
           std::make_move_iterator(group.begin()),
           std::make_move_iterator(group.end()));
     }
-  // temporarily display percentage and estimated time remaining
-  float progress_pct;
-  progress_pct = (i + 1.0) / num_trees * 100.0;
   // when a tree finishes, increment by 1 * ci_group_size
-  bar.update(progress_pct, 1 * ci_group_size);
+  bar.update(1 * ci_group_size);
   }
   return trees;
 }

--- a/core/src/forest/ForestTrainer.h
+++ b/core/src/forest/ForestTrainer.h
@@ -67,6 +67,10 @@ private:
   TreeTrainer tree_trainer;
 
   std::string operation_name;
+  std::unique_ptr<std::mutex> m_pMutex;
+  std::unique_ptr<std::condition_variable> m_pConditionVar;
+//  std::mutex mutex;
+//  std::condition_variable condition_var;
 };
 
 } // namespace grf

--- a/core/src/forest/ForestTrainer.h
+++ b/core/src/forest/ForestTrainer.h
@@ -19,11 +19,15 @@
 #define GRF_FORESTTRAINER_H
 
 #include <memory>
+#include <chrono>
+#include <mutex>
+#include <condition_variable>
 
 #include "prediction/OptimizedPredictionStrategy.h"
 #include "relabeling/RelabelingStrategy.h"
 #include "splitting/factory/SplittingRuleFactory.h"
 
+#include "commons/ProgressBar.h"
 #include "tree/Tree.h"
 #include "tree/TreeTrainer.h"
 #include "forest/Forest.h"
@@ -47,6 +51,7 @@ private:
   std::vector<std::unique_ptr<Tree>> train_batch(
       size_t start,
       size_t num_trees,
+      ProgressBar& bar,
       const Data& data,
       const ForestOptions& options) const;
 

--- a/core/src/forest/ForestTrainer.h
+++ b/core/src/forest/ForestTrainer.h
@@ -39,7 +39,8 @@ class ForestTrainer {
 public:
   ForestTrainer(std::unique_ptr<RelabelingStrategy> relabeling_strategy,
                 std::unique_ptr<SplittingRuleFactory> splitting_rule_factory,
-                std::unique_ptr<OptimizedPredictionStrategy> prediction_strategy);
+                std::unique_ptr<OptimizedPredictionStrategy> prediction_strategy,
+                std::string verbose_operation_name);
 
   Forest train(const Data& data, const ForestOptions& options) const;
 
@@ -64,6 +65,8 @@ private:
                                                     const ForestOptions& options) const;
 
   TreeTrainer tree_trainer;
+
+  std::string operation_name;
 };
 
 } // namespace grf

--- a/core/src/forest/ForestTrainers.cpp
+++ b/core/src/forest/ForestTrainers.cpp
@@ -48,9 +48,12 @@ ForestTrainer instrumental_trainer(double reduced_form_weight,
           : std::unique_ptr<SplittingRuleFactory>(new RegressionSplittingRuleFactory());
   std::unique_ptr<OptimizedPredictionStrategy> prediction_strategy(new InstrumentalPredictionStrategy());
 
+  std::string verbose_operation_name = "Growing instrumental forest";
+
   return ForestTrainer(std::move(relabeling_strategy),
                        std::move(splitting_rule_factory),
-                       std::move(prediction_strategy));
+                       std::move(prediction_strategy),
+                       verbose_operation_name);
 }
 
 ForestTrainer multi_causal_trainer(size_t num_treatments,
@@ -63,9 +66,12 @@ ForestTrainer multi_causal_trainer(size_t num_treatments,
     : std::unique_ptr<SplittingRuleFactory>(new MultiRegressionSplittingRuleFactory(response_length));
   std::unique_ptr<OptimizedPredictionStrategy> prediction_strategy(new MultiCausalPredictionStrategy(num_treatments, num_outcomes));
 
+  std::string verbose_operation_name = "Growing multi-causal forest";
+
   return ForestTrainer(std::move(relabeling_strategy),
                        std::move(splitting_rule_factory),
-                       std::move(prediction_strategy));
+                       std::move(prediction_strategy),
+                       verbose_operation_name);
 }
 
 ForestTrainer quantile_trainer(const std::vector<double>& quantiles) {
@@ -73,9 +79,12 @@ ForestTrainer quantile_trainer(const std::vector<double>& quantiles) {
   std::unique_ptr<SplittingRuleFactory> splitting_rule_factory(
       new ProbabilitySplittingRuleFactory(quantiles.size() + 1));
 
+  std::string verbose_operation_name = "Growing quantile forest";
+
   return ForestTrainer(std::move(relabeling_strategy),
                        std::move(splitting_rule_factory),
-                       nullptr);
+                       nullptr,
+                       verbose_operation_name);
 }
 
 ForestTrainer probability_trainer(size_t num_classes) {
@@ -83,9 +92,12 @@ ForestTrainer probability_trainer(size_t num_classes) {
   std::unique_ptr<SplittingRuleFactory> splitting_rule_factory(new ProbabilitySplittingRuleFactory(num_classes));
   std::unique_ptr<OptimizedPredictionStrategy> prediction_strategy(new ProbabilityPredictionStrategy(num_classes));
 
+  std::string verbose_operation_name = "Growing probability forest";
+
   return ForestTrainer(std::move(relabeling_strategy),
                        std::move(splitting_rule_factory),
-                       std::move(prediction_strategy));
+                       std::move(prediction_strategy),
+                       verbose_operation_name);
 }
 
 ForestTrainer regression_trainer() {
@@ -93,9 +105,12 @@ ForestTrainer regression_trainer() {
   std::unique_ptr<SplittingRuleFactory> splitting_rule_factory(new RegressionSplittingRuleFactory());
   std::unique_ptr<OptimizedPredictionStrategy> prediction_strategy(new RegressionPredictionStrategy());
 
+  std::string verbose_operation_name = "Growing regression forest";
+
   return ForestTrainer(std::move(relabeling_strategy),
                        std::move(splitting_rule_factory),
-                       std::move(prediction_strategy));
+                       std::move(prediction_strategy),
+                       verbose_operation_name);
 }
 
 ForestTrainer multi_regression_trainer(size_t num_outcomes) {
@@ -103,9 +118,12 @@ ForestTrainer multi_regression_trainer(size_t num_outcomes) {
   std::unique_ptr<SplittingRuleFactory> splitting_rule_factory(new MultiRegressionSplittingRuleFactory(num_outcomes));
   std::unique_ptr<OptimizedPredictionStrategy> prediction_strategy(new MultiRegressionPredictionStrategy(num_outcomes));
 
+  std::string verbose_operation_name = "Growing multi-regression forest";
+
   return ForestTrainer(std::move(relabeling_strategy),
                        std::move(splitting_rule_factory),
-                       std::move(prediction_strategy));
+                       std::move(prediction_strategy),
+                       verbose_operation_name);
 }
 
 ForestTrainer ll_regression_trainer(double split_lambda,
@@ -118,18 +136,24 @@ ForestTrainer ll_regression_trainer(double split_lambda,
   std::unique_ptr<SplittingRuleFactory> splitting_rule_factory(new RegressionSplittingRuleFactory());
   std::unique_ptr<OptimizedPredictionStrategy> prediction_strategy(new RegressionPredictionStrategy());
 
+  std::string verbose_operation_name = "Growing local linear regression forest";
+
   return ForestTrainer(std::move(relabeling_strategy),
                        std::move(splitting_rule_factory),
-                       std::move(prediction_strategy));
+                       std::move(prediction_strategy),
+                       verbose_operation_name);
 }
 
 ForestTrainer survival_trainer() {
   std::unique_ptr<RelabelingStrategy> relabeling_strategy(new NoopRelabelingStrategy());
   std::unique_ptr<SplittingRuleFactory> splitting_rule_factory(new SurvivalSplittingRuleFactory());
 
+  std::string verbose_operation_name = "Growing survival forest";
+
   return ForestTrainer(std::move(relabeling_strategy),
                        std::move(splitting_rule_factory),
-                       nullptr);
+                       nullptr,
+                       verbose_operation_name);
 }
 
 ForestTrainer causal_survival_trainer(bool stabilize_splits) {
@@ -139,10 +163,12 @@ ForestTrainer causal_survival_trainer(bool stabilize_splits) {
           ? std::unique_ptr<SplittingRuleFactory>(new CausalSurvivalSplittingRuleFactory())
           : std::unique_ptr<SplittingRuleFactory>(new RegressionSplittingRuleFactory());
   std::unique_ptr<OptimizedPredictionStrategy> prediction_strategy(new CausalSurvivalPredictionStrategy());
+  std::string verbose_operation_name = "Growing causal survival forest";
 
   return ForestTrainer(std::move(relabeling_strategy),
                        std::move(splitting_rule_factory),
-                       std::move(prediction_strategy));
+                       std::move(prediction_strategy),
+                       verbose_operation_name);
 }
 
 } // namespace grf

--- a/core/test/forest/ForestSmokeTest.cpp
+++ b/core/test/forest/ForestSmokeTest.cpp
@@ -48,9 +48,10 @@ TEST_CASE("forests don't crash when there are fewer trees than threads", "[fores
   double imbalance_penalty = 0.07;
   std::vector<size_t> empty_clusters;
   uint samples_per_cluster = 0;
+  bool verbose = false;
 
   ForestOptions options(num_trees, ci_group_size, sample_fraction, mtry, min_node_size, honesty, honesty_fraction,
-          prune, alpha, imbalance_penalty, num_threads, seed, empty_clusters, samples_per_cluster);
+          prune, alpha, imbalance_penalty, num_threads, seed, empty_clusters, samples_per_cluster, verbose);
 
   Forest forest = trainer.train(data, options);
   ForestPredictor predictor = regression_predictor(4);

--- a/core/test/forest/LocalLinearForestTest.cpp
+++ b/core/test/forest/LocalLinearForestTest.cpp
@@ -44,10 +44,11 @@ TEST_CASE("LLF gives reasonable prediction on friedman data", "[local linear], [
   uint num_threads = 1;
   size_t ci_group_size = 1;
   uint seed = 42;
+  bool verbose = false;
   ForestOptions options (
       num_trees, ci_group_size, sample_fraction,
       mtry, min_node_size, honesty, honesty_fraction, prune,
-      alpha, imbalance_penalty, num_threads, seed, empty_clusters, samples_per_cluster);
+      alpha, imbalance_penalty, num_threads, seed, empty_clusters, samples_per_cluster, verbose);
   ForestTrainer trainer = regression_trainer();
   Forest forest = trainer.train(data, options);
 
@@ -131,10 +132,11 @@ TEST_CASE("local linear forests give reasonable variance estimates", "[regressio
   uint num_threads = 1;
   size_t ci_group_size = 2;
   uint seed = 42;
+  bool verbose = false;
   ForestOptions options (
       num_trees, ci_group_size, sample_fraction,
       mtry, min_node_size, honesty, honesty_fraction, prune,
-      alpha, imbalance_penalty, num_threads, seed, empty_clusters, samples_per_cluster);
+      alpha, imbalance_penalty, num_threads, seed, empty_clusters, samples_per_cluster, verbose);
   ForestTrainer trainer = regression_trainer();
   Forest forest = trainer.train(data, options);
 

--- a/core/test/utilities/ForestTestUtilities.cpp
+++ b/core/test/utilities/ForestTestUtilities.cpp
@@ -40,8 +40,9 @@ ForestOptions ForestTestUtilities::default_options(bool honesty,
   uint samples_per_cluster = 0;
   uint num_threads = 4;
   uint seed = 42;
+  bool verbose = false;
 
   return ForestOptions(num_trees,
           ci_group_size, sample_fraction, mtry, min_node_size, honesty, honesty_fraction,
-      prune, alpha, imbalance_penalty, num_threads, seed, empty_clusters, samples_per_cluster);
+      prune, alpha, imbalance_penalty, num_threads, seed, empty_clusters, samples_per_cluster, verbose);
 }

--- a/r-package/grf/R/RcppExports.R
+++ b/r-package/grf/R/RcppExports.R
@@ -17,8 +17,8 @@ merge <- function(forest_objects) {
     .Call('_grf_merge', PACKAGE = 'grf', forest_objects)
 }
 
-causal_train <- function(train_matrix, outcome_index, treatment_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, reduced_form_weight, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed) {
-    .Call('_grf_causal_train', PACKAGE = 'grf', train_matrix, outcome_index, treatment_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, reduced_form_weight, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed)
+causal_train <- function(train_matrix, outcome_index, treatment_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, reduced_form_weight, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed, verbose) {
+    .Call('_grf_causal_train', PACKAGE = 'grf', train_matrix, outcome_index, treatment_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, reduced_form_weight, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed, verbose)
 }
 
 causal_predict <- function(forest_object, train_matrix, outcome_index, treatment_index, test_matrix, num_threads, estimate_variance) {
@@ -37,8 +37,8 @@ ll_causal_predict_oob <- function(forest_object, train_matrix, outcome_index, tr
     .Call('_grf_ll_causal_predict_oob', PACKAGE = 'grf', forest_object, train_matrix, outcome_index, treatment_index, ll_lambda, ll_weight_penalty, linear_correction_variables, num_threads, estimate_variance)
 }
 
-causal_survival_train <- function(train_matrix, causal_survival_numerator_index, causal_survival_denominator_index, treatment_index, censor_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed) {
-    .Call('_grf_causal_survival_train', PACKAGE = 'grf', train_matrix, causal_survival_numerator_index, causal_survival_denominator_index, treatment_index, censor_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed)
+causal_survival_train <- function(train_matrix, causal_survival_numerator_index, causal_survival_denominator_index, treatment_index, censor_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed, verbose) {
+    .Call('_grf_causal_survival_train', PACKAGE = 'grf', train_matrix, causal_survival_numerator_index, causal_survival_denominator_index, treatment_index, censor_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed, verbose)
 }
 
 causal_survival_predict <- function(forest_object, train_matrix, test_matrix, num_threads, estimate_variance) {
@@ -49,8 +49,8 @@ causal_survival_predict_oob <- function(forest_object, train_matrix, num_threads
     .Call('_grf_causal_survival_predict_oob', PACKAGE = 'grf', forest_object, train_matrix, num_threads, estimate_variance)
 }
 
-instrumental_train <- function(train_matrix, outcome_index, treatment_index, instrument_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, reduced_form_weight, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed) {
-    .Call('_grf_instrumental_train', PACKAGE = 'grf', train_matrix, outcome_index, treatment_index, instrument_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, reduced_form_weight, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed)
+instrumental_train <- function(train_matrix, outcome_index, treatment_index, instrument_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, reduced_form_weight, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed, verbose) {
+    .Call('_grf_instrumental_train', PACKAGE = 'grf', train_matrix, outcome_index, treatment_index, instrument_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, reduced_form_weight, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed, verbose)
 }
 
 instrumental_predict <- function(forest_object, train_matrix, outcome_index, treatment_index, instrument_index, test_matrix, num_threads, estimate_variance) {
@@ -61,8 +61,8 @@ instrumental_predict_oob <- function(forest_object, train_matrix, outcome_index,
     .Call('_grf_instrumental_predict_oob', PACKAGE = 'grf', forest_object, train_matrix, outcome_index, treatment_index, instrument_index, num_threads, estimate_variance)
 }
 
-multi_causal_train <- function(train_matrix, outcome_index, treatment_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed) {
-    .Call('_grf_multi_causal_train', PACKAGE = 'grf', train_matrix, outcome_index, treatment_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed)
+multi_causal_train <- function(train_matrix, outcome_index, treatment_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed, verbose) {
+    .Call('_grf_multi_causal_train', PACKAGE = 'grf', train_matrix, outcome_index, treatment_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed, verbose)
 }
 
 multi_causal_predict <- function(forest_object, train_matrix, test_matrix, num_outcomes, num_treatments, num_threads, estimate_variance) {
@@ -73,8 +73,8 @@ multi_causal_predict_oob <- function(forest_object, train_matrix, num_outcomes, 
     .Call('_grf_multi_causal_predict_oob', PACKAGE = 'grf', forest_object, train_matrix, num_outcomes, num_treatments, num_threads, estimate_variance)
 }
 
-multi_regression_train <- function(train_matrix, outcome_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed) {
-    .Call('_grf_multi_regression_train', PACKAGE = 'grf', train_matrix, outcome_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed)
+multi_regression_train <- function(train_matrix, outcome_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed, verbose) {
+    .Call('_grf_multi_regression_train', PACKAGE = 'grf', train_matrix, outcome_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed, verbose)
 }
 
 multi_regression_predict <- function(forest_object, train_matrix, test_matrix, num_outcomes, num_threads) {
@@ -85,8 +85,8 @@ multi_regression_predict_oob <- function(forest_object, train_matrix, num_outcom
     .Call('_grf_multi_regression_predict_oob', PACKAGE = 'grf', forest_object, train_matrix, num_outcomes, num_threads)
 }
 
-probability_train <- function(train_matrix, outcome_index, sample_weight_index, use_sample_weights, num_classes, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed) {
-    .Call('_grf_probability_train', PACKAGE = 'grf', train_matrix, outcome_index, sample_weight_index, use_sample_weights, num_classes, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed)
+probability_train <- function(train_matrix, outcome_index, sample_weight_index, use_sample_weights, num_classes, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed, verbose) {
+    .Call('_grf_probability_train', PACKAGE = 'grf', train_matrix, outcome_index, sample_weight_index, use_sample_weights, num_classes, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed, verbose)
 }
 
 probability_predict <- function(forest_object, train_matrix, outcome_index, num_classes, test_matrix, num_threads, estimate_variance) {
@@ -97,8 +97,8 @@ probability_predict_oob <- function(forest_object, train_matrix, outcome_index, 
     .Call('_grf_probability_predict_oob', PACKAGE = 'grf', forest_object, train_matrix, outcome_index, num_classes, num_threads, estimate_variance)
 }
 
-quantile_train <- function(quantiles, regression_splitting, train_matrix, outcome_index, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed) {
-    .Call('_grf_quantile_train', PACKAGE = 'grf', quantiles, regression_splitting, train_matrix, outcome_index, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed)
+quantile_train <- function(quantiles, regression_splitting, train_matrix, outcome_index, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed, verbose) {
+    .Call('_grf_quantile_train', PACKAGE = 'grf', quantiles, regression_splitting, train_matrix, outcome_index, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed, verbose)
 }
 
 quantile_predict <- function(forest_object, quantiles, train_matrix, outcome_index, test_matrix, num_threads) {
@@ -109,8 +109,8 @@ quantile_predict_oob <- function(forest_object, quantiles, train_matrix, outcome
     .Call('_grf_quantile_predict_oob', PACKAGE = 'grf', forest_object, quantiles, train_matrix, outcome_index, num_threads)
 }
 
-regression_train <- function(train_matrix, outcome_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed) {
-    .Call('_grf_regression_train', PACKAGE = 'grf', train_matrix, outcome_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed)
+regression_train <- function(train_matrix, outcome_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed, verbose) {
+    .Call('_grf_regression_train', PACKAGE = 'grf', train_matrix, outcome_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed, verbose)
 }
 
 regression_predict <- function(forest_object, train_matrix, outcome_index, test_matrix, num_threads, estimate_variance) {
@@ -121,8 +121,8 @@ regression_predict_oob <- function(forest_object, train_matrix, outcome_index, n
     .Call('_grf_regression_predict_oob', PACKAGE = 'grf', forest_object, train_matrix, outcome_index, num_threads, estimate_variance)
 }
 
-ll_regression_train <- function(train_matrix, outcome_index, ll_split_lambda, ll_split_weight_penalty, ll_split_variables, ll_split_cutoff, overall_beta, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, num_threads, seed) {
-    .Call('_grf_ll_regression_train', PACKAGE = 'grf', train_matrix, outcome_index, ll_split_lambda, ll_split_weight_penalty, ll_split_variables, ll_split_cutoff, overall_beta, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, num_threads, seed)
+ll_regression_train <- function(train_matrix, outcome_index, ll_split_lambda, ll_split_weight_penalty, ll_split_variables, ll_split_cutoff, overall_beta, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, num_threads, seed, verbose) {
+    .Call('_grf_ll_regression_train', PACKAGE = 'grf', train_matrix, outcome_index, ll_split_lambda, ll_split_weight_penalty, ll_split_variables, ll_split_cutoff, overall_beta, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, num_threads, seed, verbose)
 }
 
 ll_regression_predict <- function(forest_object, train_matrix, outcome_index, test_matrix, ll_lambda, ll_weight_penalty, linear_correction_variables, num_threads, estimate_variance) {
@@ -133,8 +133,8 @@ ll_regression_predict_oob <- function(forest_object, train_matrix, outcome_index
     .Call('_grf_ll_regression_predict_oob', PACKAGE = 'grf', forest_object, train_matrix, outcome_index, ll_lambda, ll_weight_penalty, linear_correction_variables, num_threads, estimate_variance)
 }
 
-survival_train <- function(train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, alpha, num_failures, clusters, samples_per_cluster, compute_oob_predictions, prediction_type, num_threads, seed) {
-    .Call('_grf_survival_train', PACKAGE = 'grf', train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, alpha, num_failures, clusters, samples_per_cluster, compute_oob_predictions, prediction_type, num_threads, seed)
+survival_train <- function(train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, alpha, num_failures, clusters, samples_per_cluster, compute_oob_predictions, prediction_type, num_threads, seed, verbose) {
+    .Call('_grf_survival_train', PACKAGE = 'grf', train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, alpha, num_failures, clusters, samples_per_cluster, compute_oob_predictions, prediction_type, num_threads, seed, verbose)
 }
 
 survival_predict <- function(forest_object, train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, prediction_type, test_matrix, num_threads, num_failures) {

--- a/r-package/grf/R/causal_forest.R
+++ b/r-package/grf/R/causal_forest.R
@@ -75,6 +75,7 @@
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency.
 #' @param seed The seed of the C++ random number generator.
+#' @param verbose Boolean variable for displaying training progress.
 #'
 #' @return A trained causal forest object. If tune.parameters is enabled,
 #'  then tuning information will be included through the `tuning.output` attribute.
@@ -156,7 +157,8 @@ causal_forest <- function(X, Y, W,
                           tune.num.draws = 1000,
                           compute.oob.predictions = TRUE,
                           num.threads = NULL,
-                          seed = runif(1, 0, .Machine$integer.max)) {
+                          seed = runif(1, 0, .Machine$integer.max),
+                          verbose = FALSE) {
   has.missing.values <- validate_X(X, allow.na = TRUE)
   validate_sample_weights(sample.weights, X)
   Y <- validate_observations(Y, X)
@@ -191,7 +193,8 @@ causal_forest <- function(X, Y, W,
                       ci.group.size = 1,
                       tune.parameters = tune.parameters,
                       num.threads = num.threads,
-                      seed = seed)
+                      seed = seed,
+                      verbose = verbose)
 
   if (is.null(Y.hat)) {
     forest.Y <- do.call(regression_forest, c(Y = list(Y), args.orthog))
@@ -231,6 +234,7 @@ causal_forest <- function(X, Y, W,
                compute.oob.predictions = compute.oob.predictions,
                num.threads = num.threads,
                seed = seed,
+               verbose = verbose,
                reduced.form.weight = 0)
 
   tuning.output <- NULL

--- a/r-package/grf/R/causal_survival_forest.R
+++ b/r-package/grf/R/causal_survival_forest.R
@@ -105,6 +105,7 @@
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency.
 #' @param seed The seed of the C++ random number generator.
+#' @param verbose Boolean variable for displaying training progress.
 #'
 #' @return A trained causal_survival_forest forest object.
 #'
@@ -182,7 +183,8 @@ causal_survival_forest <- function(X, Y, W, D,
                                    tune.parameters = "none",
                                    compute.oob.predictions = TRUE,
                                    num.threads = NULL,
-                                   seed = runif(1, 0, .Machine$integer.max)) {
+                                   seed = runif(1, 0, .Machine$integer.max),
+                                   verbose = FALSE) {
   has.missing.values <- validate_X(X, allow.na = TRUE)
   validate_sample_weights(sample.weights, X)
   Y <- validate_observations(Y, X)
@@ -236,7 +238,8 @@ causal_survival_forest <- function(X, Y, W, D,
                       tune.parameters = tune.parameters,
                       compute.oob.predictions = TRUE,
                       num.threads = num.threads,
-                      seed = seed)
+                      seed = seed,
+                      verbose = verbose)
 
   if (is.null(W.hat)) {
     forest.W <- do.call(regression_forest, args.orthog)
@@ -263,7 +266,8 @@ causal_survival_forest <- function(X, Y, W, D,
                         prediction.type = "Nelson-Aalen",
                         compute.oob.predictions = FALSE,
                         num.threads = num.threads,
-                        seed = seed)
+                        seed = seed,
+                        verbose = verbose)
 
   # The survival function conditioning on being treated S(t, x, 1) estimated with an "S-learner".
   if (is.null(E1.hat)) {
@@ -363,7 +367,8 @@ causal_survival_forest <- function(X, Y, W, D,
                ci.group.size = ci.group.size,
                compute.oob.predictions = compute.oob.predictions,
                num.threads = num.threads,
-               seed = seed)
+               seed = seed,
+               verbose = verbose)
 
   forest <- do.call.rcpp(causal_survival_train, c(data, args))
   class(forest) <- c("causal_survival_forest", "grf")

--- a/r-package/grf/R/instrumental_forest.R
+++ b/r-package/grf/R/instrumental_forest.R
@@ -76,6 +76,7 @@
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency.
 #' @param seed The seed of the C++ random number generator.
+#' @param verbose Boolean variable for displaying training progress.
 #'
 #' @return A trained instrumental forest object.
 #'
@@ -122,7 +123,8 @@ instrumental_forest <- function(X, Y, W, Z,
                                 tune.num.draws = 1000,
                                 compute.oob.predictions = TRUE,
                                 num.threads = NULL,
-                                seed = runif(1, 0, .Machine$integer.max)) {
+                                seed = runif(1, 0, .Machine$integer.max),
+                                verbose = FALSE) {
   has.missing.values <- validate_X(X, allow.na = TRUE)
   validate_sample_weights(sample.weights, X)
   Y <- validate_observations(Y, X)
@@ -162,7 +164,8 @@ instrumental_forest <- function(X, Y, W, Z,
                      ci.group.size = 1,
                      tune.parameters = tune.parameters,
                      num.threads = num.threads,
-                     seed = seed)
+                     seed = seed,
+                     verbose = verbose)
 
   if (is.null(Y.hat)) {
     forest.Y <- do.call(regression_forest, c(Y = list(Y), args.orthog))
@@ -209,7 +212,8 @@ instrumental_forest <- function(X, Y, W, Z,
               reduced.form.weight = reduced.form.weight,
               compute.oob.predictions = compute.oob.predictions,
               num.threads = num.threads,
-              seed = seed)
+              seed = seed,
+              verbose = verbose)
 
   tuning.output <- NULL
   if (!identical(tune.parameters, "none")) {

--- a/r-package/grf/R/ll_regression_forest.R
+++ b/r-package/grf/R/ll_regression_forest.R
@@ -61,6 +61,7 @@
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency.
 #' @param seed The seed of the C++ random number generator.
+#' @param verbose Boolean variable for displaying training progress.
 #'
 #' @return A trained local linear forest object.
 #'
@@ -98,7 +99,8 @@ ll_regression_forest <- function(X, Y,
                                 tune.num.reps = 100,
                                 tune.num.draws = 1000,
                                 num.threads = NULL,
-                                seed = runif(1, 0, .Machine$integer.max)) {
+                                seed = runif(1, 0, .Machine$integer.max),
+                                verbose = FALSE) {
 
   has.missing.values <- validate_X(X)
   Y <- validate_observations(Y, X)
@@ -137,7 +139,8 @@ ll_regression_forest <- function(X, Y,
                imbalance.penalty = imbalance.penalty,
                ci.group.size = ci.group.size,
                num.threads = num.threads,
-               seed = seed)
+               seed = seed,
+               verbose = verbose)
   if (enable.ll.split && ll.split.cutoff > 0) {
     # find overall beta
     J <- diag(ncol(X) + 1)

--- a/r-package/grf/R/multi_arm_causal_forest.R
+++ b/r-package/grf/R/multi_arm_causal_forest.R
@@ -97,6 +97,7 @@
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency.
 #' @param seed The seed of the C++ random number generator.
+#' @param verbose Boolean variable for displaying training progress.
 #'
 #' @return A trained multi arm causal forest object.
 #'
@@ -183,7 +184,8 @@ multi_arm_causal_forest <- function(X, Y, W,
                                     ci.group.size = 2,
                                     compute.oob.predictions = TRUE,
                                     num.threads = NULL,
-                                    seed = runif(1, 0, .Machine$integer.max)) {
+                                    seed = runif(1, 0, .Machine$integer.max),
+                                    verbose = FALSE) {
   has.missing.values <- validate_X(X, allow.na = TRUE)
   validate_sample_weights(sample.weights, X)
   Y <- validate_observations(Y, X, allow.matrix = TRUE)
@@ -217,7 +219,8 @@ multi_arm_causal_forest <- function(X, Y, W,
                       alpha = alpha,
                       imbalance.penalty = imbalance.penalty,
                       num.threads = num.threads,
-                      seed = seed)
+                      seed = seed,
+                      verbose = verbose)
 
   if (is.null(Y.hat)) {
     forest.Y <- do.call(multi_regression_forest, c(Y = list(Y), args.orthog))
@@ -263,7 +266,8 @@ multi_arm_causal_forest <- function(X, Y, W,
                ci.group.size = ci.group.size,
                compute.oob.predictions = compute.oob.predictions,
                num.threads = num.threads,
-               seed = seed)
+               seed = seed,
+               verbose = verbose)
 
   forest <- do.call.rcpp(multi_causal_train, c(data, args))
   class(forest) <- c("multi_arm_causal_forest", "grf")

--- a/r-package/grf/R/multi_regression_forest.R
+++ b/r-package/grf/R/multi_regression_forest.R
@@ -46,6 +46,7 @@
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency.
 #' @param seed The seed of the C++ random number generator.
+#' @param verbose Boolean variable for displaying training progress.
 #'
 #' @return A trained multi regression forest object.
 #'
@@ -83,7 +84,8 @@ multi_regression_forest <- function(X, Y,
                                     imbalance.penalty = 0,
                                     compute.oob.predictions = TRUE,
                                     num.threads = NULL,
-                                    seed = runif(1, 0, .Machine$integer.max)) {
+                                    seed = runif(1, 0, .Machine$integer.max),
+                                    verbose = FALSE) {
   has.missing.values <- validate_X(X, allow.na = TRUE)
   validate_sample_weights(sample.weights, X)
   Y <- validate_observations(Y, X, allow.matrix = TRUE)
@@ -105,7 +107,8 @@ multi_regression_forest <- function(X, Y,
                imbalance.penalty = imbalance.penalty,
                compute.oob.predictions = compute.oob.predictions,
                num.threads = num.threads,
-               seed = seed)
+               seed = seed,
+               verbose = verbose)
 
   forest <- do.call.rcpp(multi_regression_train, c(data, args))
   class(forest) <- c("multi_regression_forest", "grf")

--- a/r-package/grf/R/probability_forest.R
+++ b/r-package/grf/R/probability_forest.R
@@ -47,6 +47,7 @@
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency.
 #' @param seed The seed of the C++ random number generator.
+#' @param verbose Boolean variable for displaying training progress.
 #'
 #' @return A trained probability forest object.
 #'
@@ -94,7 +95,8 @@ probability_forest <- function(X, Y,
                                ci.group.size = 2,
                                compute.oob.predictions = TRUE,
                                num.threads = NULL,
-                               seed = runif(1, 0, .Machine$integer.max)) {
+                               seed = runif(1, 0, .Machine$integer.max),
+                               verbose = FALSE) {
   has.missing.values <- validate_X(X, allow.na = TRUE)
   validate_sample_weights(sample.weights, X)
   clusters <- validate_clusters(clusters, X)
@@ -129,7 +131,8 @@ probability_forest <- function(X, Y,
                ci.group.size = ci.group.size,
                compute.oob.predictions = compute.oob.predictions,
                num.threads = num.threads,
-               seed = seed)
+               seed = seed,
+               verbose = verbose)
 
   forest <- do.call.rcpp(probability_train, c(data, args))
   class(forest) <- c("probability_forest", "grf")

--- a/r-package/grf/R/quantile_forest.R
+++ b/r-package/grf/R/quantile_forest.R
@@ -47,6 +47,7 @@
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency.
 #' @param seed The seed of the C++ random number generator.
+#' @param verbose Boolean variable for displaying training progress.
 #'
 #' @return A trained quantile forest object.
 #'
@@ -94,7 +95,8 @@ quantile_forest <- function(X, Y,
                             imbalance.penalty = 0.0,
                             compute.oob.predictions = FALSE,
                             num.threads = NULL,
-                            seed = runif(1, 0, .Machine$integer.max)) {
+                            seed = runif(1, 0, .Machine$integer.max),
+                            verbose = FALSE) {
   if (!is.numeric(quantiles) || length(quantiles) < 1) {
     stop("Error: Must provide numeric quantiles")
   } else if (min(quantiles) <= 0 || max(quantiles) >= 1) {
@@ -124,7 +126,8 @@ quantile_forest <- function(X, Y,
                ci.group.size = 1,
                compute.oob.predictions = compute.oob.predictions,
                num.threads = num.threads,
-               seed = seed)
+               seed = seed,
+               verbose = verbose)
 
   forest <- do.call.rcpp(quantile_train, c(data, args))
   class(forest) <- c("quantile_forest", "grf")

--- a/r-package/grf/R/regression_forest.R
+++ b/r-package/grf/R/regression_forest.R
@@ -58,6 +58,7 @@
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency.
 #' @param seed The seed of the C++ random number generator.
+#' @param verbose Boolean variable for displaying training progress.
 #'
 #' @return A trained regression forest object. If tune.parameters is enabled,
 #'  then tuning information will be included through the `tuning.output` attribute.
@@ -105,7 +106,8 @@ regression_forest <- function(X, Y,
                               tune.num.draws = 1000,
                               compute.oob.predictions = TRUE,
                               num.threads = NULL,
-                              seed = runif(1, 0, .Machine$integer.max)) {
+                              seed = runif(1, 0, .Machine$integer.max),
+                              verbose = FALSE) {
   has.missing.values <- validate_X(X, allow.na = TRUE)
   validate_sample_weights(sample.weights, X)
   Y <- validate_observations(Y, X)
@@ -138,7 +140,8 @@ regression_forest <- function(X, Y,
                ci.group.size = ci.group.size,
                compute.oob.predictions = compute.oob.predictions,
                num.threads = num.threads,
-               seed = seed)
+               seed = seed,
+               verbose = verbose)
 
   tuning.output <- NULL
   if (!identical(tune.parameters, "none")) {

--- a/r-package/grf/R/survival_forest.R
+++ b/r-package/grf/R/survival_forest.R
@@ -51,6 +51,7 @@
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency.
 #' @param seed The seed of the C++ random number generator.
+#' @param verbose Boolean variable for displaying training progress.
 #'
 #' @return A trained survival_forest forest object.
 #'
@@ -128,7 +129,8 @@ survival_forest <- function(X, Y, D,
                             prediction.type = c("Kaplan-Meier", "Nelson-Aalen"),
                             compute.oob.predictions = TRUE,
                             num.threads = NULL,
-                            seed = runif(1, 0, .Machine$integer.max)) {
+                            seed = runif(1, 0, .Machine$integer.max),
+                            verbose = FALSE) {
   has.missing.values <- validate_X(X, allow.na = TRUE)
   validate_sample_weights(sample.weights, X)
   Y <- validate_observations(Y, X)
@@ -170,7 +172,8 @@ survival_forest <- function(X, Y, D,
                prediction.type = prediction.type,
                compute.oob.predictions = compute.oob.predictions,
                num.threads = num.threads,
-               seed = seed)
+               seed = seed,
+               verbose = verbose)
 
   forest <- do.call.rcpp(survival_train, c(data, args))
   class(forest) <- c("survival_forest", "grf")

--- a/r-package/grf/bindings/CausalForestBindings.cpp
+++ b/r-package/grf/bindings/CausalForestBindings.cpp
@@ -47,7 +47,8 @@ Rcpp::List causal_train(const Rcpp::NumericMatrix& train_matrix,
                         unsigned int samples_per_cluster,
                         bool compute_oob_predictions,
                         unsigned int num_threads,
-                        unsigned int seed) {
+                        unsigned int seed,
+                        bool verbose) {
   ForestTrainer trainer = instrumental_trainer(reduced_form_weight, stabilize_splits);
 
   Data data = RcppUtilities::convert_data(train_matrix);
@@ -59,7 +60,7 @@ Rcpp::List causal_train(const Rcpp::NumericMatrix& train_matrix,
   }
 
   ForestOptions options(num_trees, ci_group_size, sample_fraction, mtry, min_node_size, honesty,
-                        honesty_fraction, honesty_prune_leaves, alpha, imbalance_penalty, num_threads, seed, clusters, samples_per_cluster);
+                        honesty_fraction, honesty_prune_leaves, alpha, imbalance_penalty, num_threads, seed, clusters, samples_per_cluster, verbose);
   Forest forest = trainer.train(data, options);
 
   std::vector<Prediction> predictions;

--- a/r-package/grf/bindings/CausalSurvivalForestBindings.cpp
+++ b/r-package/grf/bindings/CausalSurvivalForestBindings.cpp
@@ -48,7 +48,8 @@ Rcpp::List causal_survival_train(const Rcpp::NumericMatrix& train_matrix,
                                  unsigned int samples_per_cluster,
                                  bool compute_oob_predictions,
                                  unsigned int num_threads,
-                                 unsigned int seed) {
+                                 unsigned int seed,
+                                 bool verbose) {
   ForestTrainer trainer = causal_survival_trainer(stabilize_splits);
 
   Data data = RcppUtilities::convert_data(train_matrix);
@@ -62,7 +63,7 @@ Rcpp::List causal_survival_train(const Rcpp::NumericMatrix& train_matrix,
   }
 
   ForestOptions options(num_trees, ci_group_size, sample_fraction, mtry, min_node_size, honesty,
-      honesty_fraction, honesty_prune_leaves, alpha, imbalance_penalty, num_threads, seed, clusters, samples_per_cluster);
+      honesty_fraction, honesty_prune_leaves, alpha, imbalance_penalty, num_threads, seed, clusters, samples_per_cluster, verbose);
   Forest forest = trainer.train(data, options);
 
   std::vector<Prediction> predictions;

--- a/r-package/grf/bindings/InstrumentalForestBindings.cpp
+++ b/r-package/grf/bindings/InstrumentalForestBindings.cpp
@@ -48,7 +48,8 @@ Rcpp::List instrumental_train(const Rcpp::NumericMatrix& train_matrix,
                               unsigned int samples_per_cluster,
                               bool compute_oob_predictions,
                               unsigned int num_threads,
-                              unsigned int seed) {
+                              unsigned int seed,
+                              bool verbose) {
   ForestTrainer trainer = instrumental_trainer(reduced_form_weight, stabilize_splits);
 
   Data data = RcppUtilities::convert_data(train_matrix);
@@ -60,7 +61,7 @@ Rcpp::List instrumental_train(const Rcpp::NumericMatrix& train_matrix,
   }
 
   ForestOptions options(num_trees, ci_group_size, sample_fraction, mtry, min_node_size, honesty,
-      honesty_fraction, honesty_prune_leaves, alpha, imbalance_penalty, num_threads, seed, clusters, samples_per_cluster);
+      honesty_fraction, honesty_prune_leaves, alpha, imbalance_penalty, num_threads, seed, clusters, samples_per_cluster, verbose);
   Forest forest = trainer.train(data, options);
 
   std::vector<Prediction> predictions;

--- a/r-package/grf/bindings/MultiCausalForestBindings.cpp
+++ b/r-package/grf/bindings/MultiCausalForestBindings.cpp
@@ -46,7 +46,8 @@ Rcpp::List multi_causal_train(const Rcpp::NumericMatrix& train_matrix,
                               unsigned int samples_per_cluster,
                               bool compute_oob_predictions,
                               unsigned int num_threads,
-                              unsigned int seed) {
+                              unsigned int seed,
+                              bool verbose) {
   size_t num_treatments = treatment_index.size();
   size_t num_outcomes = outcome_index.size();
   ForestTrainer trainer = multi_causal_trainer(num_treatments, num_outcomes, stabilize_splits);
@@ -59,7 +60,7 @@ Rcpp::List multi_causal_train(const Rcpp::NumericMatrix& train_matrix,
   }
 
   ForestOptions options(num_trees, ci_group_size, sample_fraction, mtry, min_node_size, honesty,
-      honesty_fraction, honesty_prune_leaves, alpha, imbalance_penalty, num_threads, seed, clusters, samples_per_cluster);
+      honesty_fraction, honesty_prune_leaves, alpha, imbalance_penalty, num_threads, seed, clusters, samples_per_cluster, verbose);
   Forest forest = trainer.train(data, options);
 
   std::vector<Prediction> predictions;

--- a/r-package/grf/bindings/MultiRegressionForestBindings.cpp
+++ b/r-package/grf/bindings/MultiRegressionForestBindings.cpp
@@ -43,7 +43,8 @@ Rcpp::List multi_regression_train(const Rcpp::NumericMatrix& train_matrix,
                                   unsigned int samples_per_cluster,
                                   bool compute_oob_predictions,
                                   unsigned int num_threads,
-                                  unsigned int seed) {
+                                  unsigned int seed,
+                                  bool verbose) {
   Data data = RcppUtilities::convert_data(train_matrix);
   data.set_outcome_index(outcome_index);
   if (use_sample_weights) {
@@ -52,7 +53,7 @@ Rcpp::List multi_regression_train(const Rcpp::NumericMatrix& train_matrix,
 
   size_t ci_group_size = 1;
   ForestOptions options(num_trees, ci_group_size, sample_fraction, mtry, min_node_size, honesty,
-      honesty_fraction, honesty_prune_leaves, alpha, imbalance_penalty, num_threads, seed, clusters, samples_per_cluster);
+      honesty_fraction, honesty_prune_leaves, alpha, imbalance_penalty, num_threads, seed, clusters, samples_per_cluster, verbose);
   ForestTrainer trainer = multi_regression_trainer(data.get_num_outcomes());
   Forest forest = trainer.train(data, options);
 

--- a/r-package/grf/bindings/ProbabilityForestBindings.cpp
+++ b/r-package/grf/bindings/ProbabilityForestBindings.cpp
@@ -45,7 +45,8 @@ Rcpp::List probability_train(const Rcpp::NumericMatrix& train_matrix,
                              unsigned int samples_per_cluster,
                              bool compute_oob_predictions,
                              int num_threads,
-                             unsigned int seed) {
+                             unsigned int seed,
+                             bool verbose) {
   ForestTrainer trainer = probability_trainer(num_classes);
 
   Data data = RcppUtilities::convert_data(train_matrix);
@@ -55,7 +56,7 @@ Rcpp::List probability_train(const Rcpp::NumericMatrix& train_matrix,
   }
 
   ForestOptions options(num_trees, ci_group_size, sample_fraction, mtry, min_node_size, honesty,
-      honesty_fraction, honesty_prune_leaves, alpha, imbalance_penalty, num_threads, seed, clusters, samples_per_cluster);
+      honesty_fraction, honesty_prune_leaves, alpha, imbalance_penalty, num_threads, seed, clusters, samples_per_cluster, verbose);
   Forest forest = trainer.train(data, options);
 
   std::vector<Prediction> predictions;

--- a/r-package/grf/bindings/QuantileForestBindings.cpp
+++ b/r-package/grf/bindings/QuantileForestBindings.cpp
@@ -44,7 +44,8 @@ Rcpp::List quantile_train(std::vector<double> quantiles,
                           unsigned int samples_per_cluster,
                           bool compute_oob_predictions,
                           int num_threads,
-                          unsigned int seed) {
+                          unsigned int seed,
+                          bool verbose) {
   ForestTrainer trainer = regression_splitting
       ? regression_trainer()
       : quantile_trainer(quantiles);
@@ -53,7 +54,7 @@ Rcpp::List quantile_train(std::vector<double> quantiles,
   data.set_outcome_index(outcome_index);
 
   ForestOptions options(num_trees, ci_group_size, sample_fraction, mtry, min_node_size, honesty,
-      honesty_fraction, honesty_prune_leaves, alpha, imbalance_penalty, num_threads, seed, clusters, samples_per_cluster);
+      honesty_fraction, honesty_prune_leaves, alpha, imbalance_penalty, num_threads, seed, clusters, samples_per_cluster, verbose);
   Forest forest = trainer.train(data, options);
 
   std::vector<Prediction> predictions;

--- a/r-package/grf/bindings/RegressionForestBindings.cpp
+++ b/r-package/grf/bindings/RegressionForestBindings.cpp
@@ -44,7 +44,8 @@ Rcpp::List regression_train(const Rcpp::NumericMatrix& train_matrix,
                             unsigned int samples_per_cluster,
                             bool compute_oob_predictions,
                             unsigned int num_threads,
-                            unsigned int seed) {
+                            unsigned int seed,
+                            bool verbose) {
   ForestTrainer trainer = regression_trainer();
 
   Data data = RcppUtilities::convert_data(train_matrix);
@@ -54,7 +55,7 @@ Rcpp::List regression_train(const Rcpp::NumericMatrix& train_matrix,
   }
 
   ForestOptions options(num_trees, ci_group_size, sample_fraction, mtry, min_node_size, honesty,
-      honesty_fraction, honesty_prune_leaves, alpha, imbalance_penalty, num_threads, seed, clusters, samples_per_cluster);
+      honesty_fraction, honesty_prune_leaves, alpha, imbalance_penalty, num_threads, seed, clusters, samples_per_cluster, verbose);
   Forest forest = trainer.train(data, options);
 
   std::vector<Prediction> predictions;
@@ -124,7 +125,8 @@ Rcpp::List ll_regression_train(const Rcpp::NumericMatrix& train_matrix,
                             std::vector<size_t> clusters,
                             unsigned int samples_per_cluster,
                             unsigned int num_threads,
-                            unsigned int seed) {
+                            unsigned int seed,
+                            bool verbose) {
   ForestTrainer trainer = ll_regression_trainer(ll_split_lambda, ll_split_weight_penalty, overall_beta,
                                                ll_split_cutoff, ll_split_variables);
 
@@ -132,7 +134,7 @@ Rcpp::List ll_regression_train(const Rcpp::NumericMatrix& train_matrix,
   data.set_outcome_index(outcome_index);
 
   ForestOptions options(num_trees, ci_group_size, sample_fraction, mtry, min_node_size, honesty,
-                        honesty_fraction, honesty_prune_leaves, alpha, imbalance_penalty, num_threads, seed, clusters, samples_per_cluster);
+                        honesty_fraction, honesty_prune_leaves, alpha, imbalance_penalty, num_threads, seed, clusters, samples_per_cluster, verbose);
   Forest forest = trainer.train(data, options);
 
   std::vector<Prediction> predictions;

--- a/r-package/grf/bindings/SurvivalForestBindings.cpp
+++ b/r-package/grf/bindings/SurvivalForestBindings.cpp
@@ -45,7 +45,8 @@ Rcpp::List survival_train(const Rcpp::NumericMatrix& train_matrix,
                           bool compute_oob_predictions,
                           int prediction_type,
                           unsigned int num_threads,
-                          unsigned int seed) {
+                          unsigned int seed,
+                          bool verbose) {
   ForestTrainer trainer = survival_trainer();
 
   Data data = RcppUtilities::convert_data(train_matrix);
@@ -58,7 +59,7 @@ Rcpp::List survival_train(const Rcpp::NumericMatrix& train_matrix,
   size_t ci_group_size = 1;
   size_t imbalance_penalty = 0;
   ForestOptions options(num_trees, ci_group_size, sample_fraction, mtry, min_node_size, honesty,
-      honesty_fraction, honesty_prune_leaves, alpha, imbalance_penalty, num_threads, seed, clusters, samples_per_cluster);
+      honesty_fraction, honesty_prune_leaves, alpha, imbalance_penalty, num_threads, seed, clusters, samples_per_cluster, verbose);
   Forest forest = trainer.train(data, options);
 
   std::vector<Prediction> predictions;

--- a/r-package/grf/man/causal_forest.Rd
+++ b/r-package/grf/man/causal_forest.Rd
@@ -30,7 +30,8 @@ causal_forest(
   tune.num.draws = 1000,
   compute.oob.predictions = TRUE,
   num.threads = NULL,
-  seed = runif(1, 0, .Machine$integer.max)
+  seed = runif(1, 0, .Machine$integer.max),
+  verbose = FALSE
 )
 }
 \arguments{
@@ -125,6 +126,8 @@ to select the optimal parameters. Default is 1000.}
 to the maximum hardware concurrency.}
 
 \item{seed}{The seed of the C++ random number generator.}
+
+\item{verbose}{Boolean variable for displaying training progress.}
 }
 \value{
 A trained causal forest object. If tune.parameters is enabled,

--- a/r-package/grf/man/causal_survival_forest.Rd
+++ b/r-package/grf/man/causal_survival_forest.Rd
@@ -33,7 +33,8 @@ causal_survival_forest(
   tune.parameters = "none",
   compute.oob.predictions = TRUE,
   num.threads = NULL,
-  seed = runif(1, 0, .Machine$integer.max)
+  seed = runif(1, 0, .Machine$integer.max),
+  verbose = FALSE
 )
 }
 \arguments{
@@ -150,6 +151,8 @@ Default is "none" (no parameters are tuned).}
 to the maximum hardware concurrency.}
 
 \item{seed}{The seed of the C++ random number generator.}
+
+\item{verbose}{Boolean variable for displaying training progress.}
 }
 \value{
 A trained causal_survival_forest forest object.

--- a/r-package/grf/man/instrumental_forest.Rd
+++ b/r-package/grf/man/instrumental_forest.Rd
@@ -33,7 +33,8 @@ instrumental_forest(
   tune.num.draws = 1000,
   compute.oob.predictions = TRUE,
   num.threads = NULL,
-  seed = runif(1, 0, .Machine$integer.max)
+  seed = runif(1, 0, .Machine$integer.max),
+  verbose = FALSE
 )
 }
 \arguments{
@@ -134,6 +135,8 @@ to select the optimal parameters. Default is 1000.}
 to the maximum hardware concurrency.}
 
 \item{seed}{The seed of the C++ random number generator.}
+
+\item{verbose}{Boolean variable for displaying training progress.}
 }
 \value{
 A trained instrumental forest object.

--- a/r-package/grf/man/ll_regression_forest.Rd
+++ b/r-package/grf/man/ll_regression_forest.Rd
@@ -29,7 +29,8 @@ ll_regression_forest(
   tune.num.reps = 100,
   tune.num.draws = 1000,
   num.threads = NULL,
-  seed = runif(1, 0, .Machine$integer.max)
+  seed = runif(1, 0, .Machine$integer.max),
+  verbose = FALSE
 )
 }
 \arguments{
@@ -115,6 +116,8 @@ to select the optimal parameters. Default is 1000.}
 to the maximum hardware concurrency.}
 
 \item{seed}{The seed of the C++ random number generator.}
+
+\item{verbose}{Boolean variable for displaying training progress.}
 }
 \value{
 A trained local linear forest object.

--- a/r-package/grf/man/multi_arm_causal_forest.Rd
+++ b/r-package/grf/man/multi_arm_causal_forest.Rd
@@ -26,7 +26,8 @@ multi_arm_causal_forest(
   ci.group.size = 2,
   compute.oob.predictions = TRUE,
   num.threads = NULL,
-  seed = runif(1, 0, .Machine$integer.max)
+  seed = runif(1, 0, .Machine$integer.max),
+  verbose = FALSE
 )
 }
 \arguments{
@@ -112,6 +113,8 @@ currently only supported for univariate outcomes Y).}
 to the maximum hardware concurrency.}
 
 \item{seed}{The seed of the C++ random number generator.}
+
+\item{verbose}{Boolean variable for displaying training progress.}
 }
 \value{
 A trained multi arm causal forest object.

--- a/r-package/grf/man/multi_regression_forest.Rd
+++ b/r-package/grf/man/multi_regression_forest.Rd
@@ -21,7 +21,8 @@ multi_regression_forest(
   imbalance.penalty = 0,
   compute.oob.predictions = TRUE,
   num.threads = NULL,
-  seed = runif(1, 0, .Machine$integer.max)
+  seed = runif(1, 0, .Machine$integer.max),
+  verbose = FALSE
 )
 }
 \arguments{
@@ -84,6 +85,8 @@ Only applies if honesty is enabled. Default is TRUE.}
 to the maximum hardware concurrency.}
 
 \item{seed}{The seed of the C++ random number generator.}
+
+\item{verbose}{Boolean variable for displaying training progress.}
 }
 \value{
 A trained multi regression forest object.

--- a/r-package/grf/man/probability_forest.Rd
+++ b/r-package/grf/man/probability_forest.Rd
@@ -22,7 +22,8 @@ probability_forest(
   ci.group.size = 2,
   compute.oob.predictions = TRUE,
   num.threads = NULL,
-  seed = runif(1, 0, .Machine$integer.max)
+  seed = runif(1, 0, .Machine$integer.max),
+  verbose = FALSE
 )
 }
 \arguments{
@@ -87,6 +88,8 @@ be at least 2. Default is 2.}
 to the maximum hardware concurrency.}
 
 \item{seed}{The seed of the C++ random number generator.}
+
+\item{verbose}{Boolean variable for displaying training progress.}
 }
 \value{
 A trained probability forest object.

--- a/r-package/grf/man/quantile_forest.Rd
+++ b/r-package/grf/man/quantile_forest.Rd
@@ -22,7 +22,8 @@ quantile_forest(
   imbalance.penalty = 0,
   compute.oob.predictions = FALSE,
   num.threads = NULL,
-  seed = runif(1, 0, .Machine$integer.max)
+  seed = runif(1, 0, .Machine$integer.max),
+  verbose = FALSE
 )
 }
 \arguments{
@@ -87,6 +88,8 @@ Only applies if honesty is enabled. Default is TRUE.}
 to the maximum hardware concurrency.}
 
 \item{seed}{The seed of the C++ random number generator.}
+
+\item{verbose}{Boolean variable for displaying training progress.}
 }
 \value{
 A trained quantile forest object.

--- a/r-package/grf/man/regression_forest.Rd
+++ b/r-package/grf/man/regression_forest.Rd
@@ -26,7 +26,8 @@ regression_forest(
   tune.num.draws = 1000,
   compute.oob.predictions = TRUE,
   num.threads = NULL,
-  seed = runif(1, 0, .Machine$integer.max)
+  seed = runif(1, 0, .Machine$integer.max),
+  verbose = FALSE
 )
 }
 \arguments{
@@ -106,6 +107,8 @@ to select the optimal parameters. Default is 1000.}
 to the maximum hardware concurrency.}
 
 \item{seed}{The seed of the C++ random number generator.}
+
+\item{verbose}{Boolean variable for displaying training progress.}
 }
 \value{
 A trained regression forest object. If tune.parameters is enabled,

--- a/r-package/grf/man/survival_forest.Rd
+++ b/r-package/grf/man/survival_forest.Rd
@@ -23,7 +23,8 @@ survival_forest(
   prediction.type = c("Kaplan-Meier", "Nelson-Aalen"),
   compute.oob.predictions = TRUE,
   num.threads = NULL,
-  seed = runif(1, 0, .Machine$integer.max)
+  seed = runif(1, 0, .Machine$integer.max),
+  verbose = FALSE
 )
 }
 \arguments{
@@ -93,6 +94,8 @@ Only relevant if `compute.oob.predictions` is TRUE. Default is "Kaplan-Meier".}
 to the maximum hardware concurrency.}
 
 \item{seed}{The seed of the C++ random number generator.}
+
+\item{verbose}{Boolean variable for displaying training progress.}
 }
 \value{
 A trained survival_forest forest object.

--- a/r-package/grf/src/RcppExports.cpp
+++ b/r-package/grf/src/RcppExports.cpp
@@ -62,8 +62,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // causal_train
-Rcpp::List causal_train(const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, size_t treatment_index, size_t sample_weight_index, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double reduced_form_weight, double alpha, double imbalance_penalty, bool stabilize_splits, std::vector<size_t> clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, unsigned int num_threads, unsigned int seed);
-RcppExport SEXP _grf_causal_train(SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP treatment_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP ci_group_sizeSEXP, SEXP reduced_form_weightSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP stabilize_splitsSEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP compute_oob_predictionsSEXP, SEXP num_threadsSEXP, SEXP seedSEXP) {
+Rcpp::List causal_train(const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, size_t treatment_index, size_t sample_weight_index, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double reduced_form_weight, double alpha, double imbalance_penalty, bool stabilize_splits, std::vector<size_t> clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, unsigned int num_threads, unsigned int seed, bool verbose);
+RcppExport SEXP _grf_causal_train(SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP treatment_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP ci_group_sizeSEXP, SEXP reduced_form_weightSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP stabilize_splitsSEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP compute_oob_predictionsSEXP, SEXP num_threadsSEXP, SEXP seedSEXP, SEXP verboseSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -89,7 +89,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type compute_oob_predictions(compute_oob_predictionsSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type seed(seedSEXP);
-    rcpp_result_gen = Rcpp::wrap(causal_train(train_matrix, outcome_index, treatment_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, reduced_form_weight, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed));
+    Rcpp::traits::input_parameter< bool >::type verbose(verboseSEXP);
+    rcpp_result_gen = Rcpp::wrap(causal_train(train_matrix, outcome_index, treatment_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, reduced_form_weight, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed, verbose));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -166,8 +167,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // causal_survival_train
-Rcpp::List causal_survival_train(const Rcpp::NumericMatrix& train_matrix, size_t causal_survival_numerator_index, size_t causal_survival_denominator_index, size_t treatment_index, size_t censor_index, size_t sample_weight_index, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double alpha, double imbalance_penalty, bool stabilize_splits, const std::vector<size_t>& clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, unsigned int num_threads, unsigned int seed);
-RcppExport SEXP _grf_causal_survival_train(SEXP train_matrixSEXP, SEXP causal_survival_numerator_indexSEXP, SEXP causal_survival_denominator_indexSEXP, SEXP treatment_indexSEXP, SEXP censor_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP ci_group_sizeSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP stabilize_splitsSEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP compute_oob_predictionsSEXP, SEXP num_threadsSEXP, SEXP seedSEXP) {
+Rcpp::List causal_survival_train(const Rcpp::NumericMatrix& train_matrix, size_t causal_survival_numerator_index, size_t causal_survival_denominator_index, size_t treatment_index, size_t censor_index, size_t sample_weight_index, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double alpha, double imbalance_penalty, bool stabilize_splits, const std::vector<size_t>& clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, unsigned int num_threads, unsigned int seed, bool verbose);
+RcppExport SEXP _grf_causal_survival_train(SEXP train_matrixSEXP, SEXP causal_survival_numerator_indexSEXP, SEXP causal_survival_denominator_indexSEXP, SEXP treatment_indexSEXP, SEXP censor_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP ci_group_sizeSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP stabilize_splitsSEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP compute_oob_predictionsSEXP, SEXP num_threadsSEXP, SEXP seedSEXP, SEXP verboseSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -194,7 +195,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type compute_oob_predictions(compute_oob_predictionsSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type seed(seedSEXP);
-    rcpp_result_gen = Rcpp::wrap(causal_survival_train(train_matrix, causal_survival_numerator_index, causal_survival_denominator_index, treatment_index, censor_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed));
+    Rcpp::traits::input_parameter< bool >::type verbose(verboseSEXP);
+    rcpp_result_gen = Rcpp::wrap(causal_survival_train(train_matrix, causal_survival_numerator_index, causal_survival_denominator_index, treatment_index, censor_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed, verbose));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -228,8 +230,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // instrumental_train
-Rcpp::List instrumental_train(const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, size_t treatment_index, size_t instrument_index, size_t sample_weight_index, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double reduced_form_weight, double alpha, double imbalance_penalty, bool stabilize_splits, std::vector<size_t> clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, unsigned int num_threads, unsigned int seed);
-RcppExport SEXP _grf_instrumental_train(SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP treatment_indexSEXP, SEXP instrument_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP ci_group_sizeSEXP, SEXP reduced_form_weightSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP stabilize_splitsSEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP compute_oob_predictionsSEXP, SEXP num_threadsSEXP, SEXP seedSEXP) {
+Rcpp::List instrumental_train(const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, size_t treatment_index, size_t instrument_index, size_t sample_weight_index, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double reduced_form_weight, double alpha, double imbalance_penalty, bool stabilize_splits, std::vector<size_t> clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, unsigned int num_threads, unsigned int seed, bool verbose);
+RcppExport SEXP _grf_instrumental_train(SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP treatment_indexSEXP, SEXP instrument_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP ci_group_sizeSEXP, SEXP reduced_form_weightSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP stabilize_splitsSEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP compute_oob_predictionsSEXP, SEXP num_threadsSEXP, SEXP seedSEXP, SEXP verboseSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -256,7 +258,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type compute_oob_predictions(compute_oob_predictionsSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type seed(seedSEXP);
-    rcpp_result_gen = Rcpp::wrap(instrumental_train(train_matrix, outcome_index, treatment_index, instrument_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, reduced_form_weight, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed));
+    Rcpp::traits::input_parameter< bool >::type verbose(verboseSEXP);
+    rcpp_result_gen = Rcpp::wrap(instrumental_train(train_matrix, outcome_index, treatment_index, instrument_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, reduced_form_weight, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed, verbose));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -296,8 +299,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // multi_causal_train
-Rcpp::List multi_causal_train(const Rcpp::NumericMatrix& train_matrix, const std::vector<size_t>& outcome_index, const std::vector<size_t>& treatment_index, size_t sample_weight_index, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double alpha, double imbalance_penalty, bool stabilize_splits, std::vector<size_t> clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, unsigned int num_threads, unsigned int seed);
-RcppExport SEXP _grf_multi_causal_train(SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP treatment_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP ci_group_sizeSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP stabilize_splitsSEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP compute_oob_predictionsSEXP, SEXP num_threadsSEXP, SEXP seedSEXP) {
+Rcpp::List multi_causal_train(const Rcpp::NumericMatrix& train_matrix, const std::vector<size_t>& outcome_index, const std::vector<size_t>& treatment_index, size_t sample_weight_index, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double alpha, double imbalance_penalty, bool stabilize_splits, std::vector<size_t> clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, unsigned int num_threads, unsigned int seed, bool verbose);
+RcppExport SEXP _grf_multi_causal_train(SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP treatment_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP ci_group_sizeSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP stabilize_splitsSEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP compute_oob_predictionsSEXP, SEXP num_threadsSEXP, SEXP seedSEXP, SEXP verboseSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -322,7 +325,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type compute_oob_predictions(compute_oob_predictionsSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type seed(seedSEXP);
-    rcpp_result_gen = Rcpp::wrap(multi_causal_train(train_matrix, outcome_index, treatment_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed));
+    Rcpp::traits::input_parameter< bool >::type verbose(verboseSEXP);
+    rcpp_result_gen = Rcpp::wrap(multi_causal_train(train_matrix, outcome_index, treatment_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, stabilize_splits, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed, verbose));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -360,8 +364,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // multi_regression_train
-Rcpp::List multi_regression_train(const Rcpp::NumericMatrix& train_matrix, const std::vector<size_t>& outcome_index, size_t sample_weight_index, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, double alpha, double imbalance_penalty, std::vector<size_t>& clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, unsigned int num_threads, unsigned int seed);
-RcppExport SEXP _grf_multi_regression_train(SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP compute_oob_predictionsSEXP, SEXP num_threadsSEXP, SEXP seedSEXP) {
+Rcpp::List multi_regression_train(const Rcpp::NumericMatrix& train_matrix, const std::vector<size_t>& outcome_index, size_t sample_weight_index, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, double alpha, double imbalance_penalty, std::vector<size_t>& clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, unsigned int num_threads, unsigned int seed, bool verbose);
+RcppExport SEXP _grf_multi_regression_train(SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP compute_oob_predictionsSEXP, SEXP num_threadsSEXP, SEXP seedSEXP, SEXP verboseSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -383,7 +387,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type compute_oob_predictions(compute_oob_predictionsSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type seed(seedSEXP);
-    rcpp_result_gen = Rcpp::wrap(multi_regression_train(train_matrix, outcome_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed));
+    Rcpp::traits::input_parameter< bool >::type verbose(verboseSEXP);
+    rcpp_result_gen = Rcpp::wrap(multi_regression_train(train_matrix, outcome_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed, verbose));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -417,8 +422,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // probability_train
-Rcpp::List probability_train(const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, size_t sample_weight_index, bool use_sample_weights, size_t num_classes, unsigned int mtry, unsigned int num_trees, int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double alpha, double imbalance_penalty, const std::vector<size_t>& clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, int num_threads, unsigned int seed);
-RcppExport SEXP _grf_probability_train(SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP num_classesSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP ci_group_sizeSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP compute_oob_predictionsSEXP, SEXP num_threadsSEXP, SEXP seedSEXP) {
+Rcpp::List probability_train(const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, size_t sample_weight_index, bool use_sample_weights, size_t num_classes, unsigned int mtry, unsigned int num_trees, int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double alpha, double imbalance_penalty, const std::vector<size_t>& clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, int num_threads, unsigned int seed, bool verbose);
+RcppExport SEXP _grf_probability_train(SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP num_classesSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP ci_group_sizeSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP compute_oob_predictionsSEXP, SEXP num_threadsSEXP, SEXP seedSEXP, SEXP verboseSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -442,7 +447,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type compute_oob_predictions(compute_oob_predictionsSEXP);
     Rcpp::traits::input_parameter< int >::type num_threads(num_threadsSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type seed(seedSEXP);
-    rcpp_result_gen = Rcpp::wrap(probability_train(train_matrix, outcome_index, sample_weight_index, use_sample_weights, num_classes, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed));
+    Rcpp::traits::input_parameter< bool >::type verbose(verboseSEXP);
+    rcpp_result_gen = Rcpp::wrap(probability_train(train_matrix, outcome_index, sample_weight_index, use_sample_weights, num_classes, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed, verbose));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -480,8 +486,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // quantile_train
-Rcpp::List quantile_train(std::vector<double> quantiles, bool regression_splitting, const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, unsigned int mtry, unsigned int num_trees, int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double alpha, double imbalance_penalty, std::vector<size_t> clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, int num_threads, unsigned int seed);
-RcppExport SEXP _grf_quantile_train(SEXP quantilesSEXP, SEXP regression_splittingSEXP, SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP ci_group_sizeSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP compute_oob_predictionsSEXP, SEXP num_threadsSEXP, SEXP seedSEXP) {
+Rcpp::List quantile_train(std::vector<double> quantiles, bool regression_splitting, const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, unsigned int mtry, unsigned int num_trees, int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double alpha, double imbalance_penalty, std::vector<size_t> clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, int num_threads, unsigned int seed, bool verbose);
+RcppExport SEXP _grf_quantile_train(SEXP quantilesSEXP, SEXP regression_splittingSEXP, SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP ci_group_sizeSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP compute_oob_predictionsSEXP, SEXP num_threadsSEXP, SEXP seedSEXP, SEXP verboseSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -504,7 +510,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type compute_oob_predictions(compute_oob_predictionsSEXP);
     Rcpp::traits::input_parameter< int >::type num_threads(num_threadsSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type seed(seedSEXP);
-    rcpp_result_gen = Rcpp::wrap(quantile_train(quantiles, regression_splitting, train_matrix, outcome_index, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed));
+    Rcpp::traits::input_parameter< bool >::type verbose(verboseSEXP);
+    rcpp_result_gen = Rcpp::wrap(quantile_train(quantiles, regression_splitting, train_matrix, outcome_index, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed, verbose));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -540,8 +547,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // regression_train
-Rcpp::List regression_train(const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, size_t sample_weight_index, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double alpha, double imbalance_penalty, std::vector<size_t> clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, unsigned int num_threads, unsigned int seed);
-RcppExport SEXP _grf_regression_train(SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP ci_group_sizeSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP compute_oob_predictionsSEXP, SEXP num_threadsSEXP, SEXP seedSEXP) {
+Rcpp::List regression_train(const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, size_t sample_weight_index, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double alpha, double imbalance_penalty, std::vector<size_t> clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, unsigned int num_threads, unsigned int seed, bool verbose);
+RcppExport SEXP _grf_regression_train(SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP ci_group_sizeSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP compute_oob_predictionsSEXP, SEXP num_threadsSEXP, SEXP seedSEXP, SEXP verboseSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -564,7 +571,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type compute_oob_predictions(compute_oob_predictionsSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type seed(seedSEXP);
-    rcpp_result_gen = Rcpp::wrap(regression_train(train_matrix, outcome_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed));
+    Rcpp::traits::input_parameter< bool >::type verbose(verboseSEXP);
+    rcpp_result_gen = Rcpp::wrap(regression_train(train_matrix, outcome_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, compute_oob_predictions, num_threads, seed, verbose));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -600,8 +608,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // ll_regression_train
-Rcpp::List ll_regression_train(const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, double ll_split_lambda, bool ll_split_weight_penalty, std::vector<size_t> ll_split_variables, size_t ll_split_cutoff, std::vector<double> overall_beta, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double alpha, double imbalance_penalty, std::vector<size_t> clusters, unsigned int samples_per_cluster, unsigned int num_threads, unsigned int seed);
-RcppExport SEXP _grf_ll_regression_train(SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP ll_split_lambdaSEXP, SEXP ll_split_weight_penaltySEXP, SEXP ll_split_variablesSEXP, SEXP ll_split_cutoffSEXP, SEXP overall_betaSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP ci_group_sizeSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP num_threadsSEXP, SEXP seedSEXP) {
+Rcpp::List ll_regression_train(const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, double ll_split_lambda, bool ll_split_weight_penalty, std::vector<size_t> ll_split_variables, size_t ll_split_cutoff, std::vector<double> overall_beta, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, size_t ci_group_size, double alpha, double imbalance_penalty, std::vector<size_t> clusters, unsigned int samples_per_cluster, unsigned int num_threads, unsigned int seed, bool verbose);
+RcppExport SEXP _grf_ll_regression_train(SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP ll_split_lambdaSEXP, SEXP ll_split_weight_penaltySEXP, SEXP ll_split_variablesSEXP, SEXP ll_split_cutoffSEXP, SEXP overall_betaSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP ci_group_sizeSEXP, SEXP alphaSEXP, SEXP imbalance_penaltySEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP num_threadsSEXP, SEXP seedSEXP, SEXP verboseSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -626,7 +634,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< unsigned int >::type samples_per_cluster(samples_per_clusterSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type seed(seedSEXP);
-    rcpp_result_gen = Rcpp::wrap(ll_regression_train(train_matrix, outcome_index, ll_split_lambda, ll_split_weight_penalty, ll_split_variables, ll_split_cutoff, overall_beta, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, num_threads, seed));
+    Rcpp::traits::input_parameter< bool >::type verbose(verboseSEXP);
+    rcpp_result_gen = Rcpp::wrap(ll_regression_train(train_matrix, outcome_index, ll_split_lambda, ll_split_weight_penalty, ll_split_variables, ll_split_cutoff, overall_beta, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, ci_group_size, alpha, imbalance_penalty, clusters, samples_per_cluster, num_threads, seed, verbose));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -668,8 +677,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // survival_train
-Rcpp::List survival_train(const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, size_t censor_index, size_t sample_weight_index, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, double alpha, size_t num_failures, std::vector<size_t> clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, int prediction_type, unsigned int num_threads, unsigned int seed);
-RcppExport SEXP _grf_survival_train(SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP censor_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP alphaSEXP, SEXP num_failuresSEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP compute_oob_predictionsSEXP, SEXP prediction_typeSEXP, SEXP num_threadsSEXP, SEXP seedSEXP) {
+Rcpp::List survival_train(const Rcpp::NumericMatrix& train_matrix, size_t outcome_index, size_t censor_index, size_t sample_weight_index, bool use_sample_weights, unsigned int mtry, unsigned int num_trees, unsigned int min_node_size, double sample_fraction, bool honesty, double honesty_fraction, bool honesty_prune_leaves, double alpha, size_t num_failures, std::vector<size_t> clusters, unsigned int samples_per_cluster, bool compute_oob_predictions, int prediction_type, unsigned int num_threads, unsigned int seed, bool verbose);
+RcppExport SEXP _grf_survival_train(SEXP train_matrixSEXP, SEXP outcome_indexSEXP, SEXP censor_indexSEXP, SEXP sample_weight_indexSEXP, SEXP use_sample_weightsSEXP, SEXP mtrySEXP, SEXP num_treesSEXP, SEXP min_node_sizeSEXP, SEXP sample_fractionSEXP, SEXP honestySEXP, SEXP honesty_fractionSEXP, SEXP honesty_prune_leavesSEXP, SEXP alphaSEXP, SEXP num_failuresSEXP, SEXP clustersSEXP, SEXP samples_per_clusterSEXP, SEXP compute_oob_predictionsSEXP, SEXP prediction_typeSEXP, SEXP num_threadsSEXP, SEXP seedSEXP, SEXP verboseSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -693,7 +702,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< int >::type prediction_type(prediction_typeSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type num_threads(num_threadsSEXP);
     Rcpp::traits::input_parameter< unsigned int >::type seed(seedSEXP);
-    rcpp_result_gen = Rcpp::wrap(survival_train(train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, alpha, num_failures, clusters, samples_per_cluster, compute_oob_predictions, prediction_type, num_threads, seed));
+    Rcpp::traits::input_parameter< bool >::type verbose(verboseSEXP);
+    rcpp_result_gen = Rcpp::wrap(survival_train(train_matrix, outcome_index, censor_index, sample_weight_index, use_sample_weights, mtry, num_trees, min_node_size, sample_fraction, honesty, honesty_fraction, honesty_prune_leaves, alpha, num_failures, clusters, samples_per_cluster, compute_oob_predictions, prediction_type, num_threads, seed, verbose));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -742,36 +752,36 @@ static const R_CallMethodDef CallEntries[] = {
     {"_grf_compute_weights", (DL_FUNC) &_grf_compute_weights, 4},
     {"_grf_compute_weights_oob", (DL_FUNC) &_grf_compute_weights_oob, 3},
     {"_grf_merge", (DL_FUNC) &_grf_merge, 1},
-    {"_grf_causal_train", (DL_FUNC) &_grf_causal_train, 22},
+    {"_grf_causal_train", (DL_FUNC) &_grf_causal_train, 23},
     {"_grf_causal_predict", (DL_FUNC) &_grf_causal_predict, 7},
     {"_grf_causal_predict_oob", (DL_FUNC) &_grf_causal_predict_oob, 6},
     {"_grf_ll_causal_predict", (DL_FUNC) &_grf_ll_causal_predict, 10},
     {"_grf_ll_causal_predict_oob", (DL_FUNC) &_grf_ll_causal_predict_oob, 9},
-    {"_grf_causal_survival_train", (DL_FUNC) &_grf_causal_survival_train, 23},
+    {"_grf_causal_survival_train", (DL_FUNC) &_grf_causal_survival_train, 24},
     {"_grf_causal_survival_predict", (DL_FUNC) &_grf_causal_survival_predict, 5},
     {"_grf_causal_survival_predict_oob", (DL_FUNC) &_grf_causal_survival_predict_oob, 4},
-    {"_grf_instrumental_train", (DL_FUNC) &_grf_instrumental_train, 23},
+    {"_grf_instrumental_train", (DL_FUNC) &_grf_instrumental_train, 24},
     {"_grf_instrumental_predict", (DL_FUNC) &_grf_instrumental_predict, 8},
     {"_grf_instrumental_predict_oob", (DL_FUNC) &_grf_instrumental_predict_oob, 7},
-    {"_grf_multi_causal_train", (DL_FUNC) &_grf_multi_causal_train, 21},
+    {"_grf_multi_causal_train", (DL_FUNC) &_grf_multi_causal_train, 22},
     {"_grf_multi_causal_predict", (DL_FUNC) &_grf_multi_causal_predict, 7},
     {"_grf_multi_causal_predict_oob", (DL_FUNC) &_grf_multi_causal_predict_oob, 6},
-    {"_grf_multi_regression_train", (DL_FUNC) &_grf_multi_regression_train, 18},
+    {"_grf_multi_regression_train", (DL_FUNC) &_grf_multi_regression_train, 19},
     {"_grf_multi_regression_predict", (DL_FUNC) &_grf_multi_regression_predict, 5},
     {"_grf_multi_regression_predict_oob", (DL_FUNC) &_grf_multi_regression_predict_oob, 4},
-    {"_grf_probability_train", (DL_FUNC) &_grf_probability_train, 20},
+    {"_grf_probability_train", (DL_FUNC) &_grf_probability_train, 21},
     {"_grf_probability_predict", (DL_FUNC) &_grf_probability_predict, 7},
     {"_grf_probability_predict_oob", (DL_FUNC) &_grf_probability_predict_oob, 6},
-    {"_grf_quantile_train", (DL_FUNC) &_grf_quantile_train, 19},
+    {"_grf_quantile_train", (DL_FUNC) &_grf_quantile_train, 20},
     {"_grf_quantile_predict", (DL_FUNC) &_grf_quantile_predict, 6},
     {"_grf_quantile_predict_oob", (DL_FUNC) &_grf_quantile_predict_oob, 5},
-    {"_grf_regression_train", (DL_FUNC) &_grf_regression_train, 19},
+    {"_grf_regression_train", (DL_FUNC) &_grf_regression_train, 20},
     {"_grf_regression_predict", (DL_FUNC) &_grf_regression_predict, 6},
     {"_grf_regression_predict_oob", (DL_FUNC) &_grf_regression_predict_oob, 5},
-    {"_grf_ll_regression_train", (DL_FUNC) &_grf_ll_regression_train, 21},
+    {"_grf_ll_regression_train", (DL_FUNC) &_grf_ll_regression_train, 22},
     {"_grf_ll_regression_predict", (DL_FUNC) &_grf_ll_regression_predict, 9},
     {"_grf_ll_regression_predict_oob", (DL_FUNC) &_grf_ll_regression_predict_oob, 8},
-    {"_grf_survival_train", (DL_FUNC) &_grf_survival_train, 20},
+    {"_grf_survival_train", (DL_FUNC) &_grf_survival_train, 21},
     {"_grf_survival_predict", (DL_FUNC) &_grf_survival_predict, 10},
     {"_grf_survival_predict_oob", (DL_FUNC) &_grf_survival_predict_oob, 9},
     {NULL, NULL, 0}


### PR DESCRIPTION
This pull request is a first attempt at addressing #292. For now, the progress percentage and time estimation are only implemented for training forests.

We create a `ProgressBar` class and it is initialized in the `ForestTrainer::train_trees` function. The progress bar is then passed to the `train_batch` function, and the progress estimate is updated once each of the trees has been grown.

`ProgressBar::write_time_estimate` uses the same logic as the ranger `showProgress` function of waiting a pre-specified amount of time (`STATUS_INTERVAL` in `globals.h`) before printing out the estimated time remaining.  Also, I added the `beautifyTime` function from ranger to `utility.cpp`. If there is a proper way to give attribution for using their function, please let me know.

At the moment, we show progress for any forests grown for orthogonalizing or other substeps of training a forest. But, should the time estimation only be shown for the final forest? In this first version, `ForestTrainer` has a different `verbose_operation_name` to clarify whether we are giving a time estimate for a substep like orthogonalization or training the final forest.

Remaining to-dos:
- [ ] Write tests?
- [ ] Decide whether to keep the estimation for substeps
- [ ] Improve formatting of printed output

EDIT:
~~I forgot that CRAN does not permit the use of `std::cout` in R packages so we either need a way to successfully put the `Rcout` print statement in a locking scope or print at some other point in the training loop.~~

~~I've tried just using a mutex around the [line](https://github.com/grf-labs/grf/pull/1025/files#diff-8d915af053729f388069502f3344f77c78c02438fbe92325cebacdfc8436cbdbR44) where we can replace std::cout with Rcout, but I still get a C stack usage error.  I've been looking into `RcppThread`'s `Rcout` function and it looks like it collects the print messages in a global buffer and only prints once it is called again from the main thread.~~

See comments below.