### PR TITLE
Require optional event grid to be strictly increasing

### DIFF
--- a/r-package/grf/R/survival_forest.R
+++ b/r-package/grf/R/survival_forest.R
@@ -152,6 +152,8 @@ survival_forest <- function(X, Y, D,
   # etc. Will range from 0 to num.failures.
   if (is.null(failure.times)) {
     failure.times <- sort(unique(Y[D == 1]))
+  } else if (is.unsorted(failure.times, strictly = TRUE)) {
+    stop("Argument `failure.times` should be a vector with elements in increasing order.")
   }
   Y.relabeled <- findInterval(Y, failure.times)
 
@@ -274,6 +276,9 @@ predict.survival_forest <- function(object,
     failure.times <- object[["failure.times"]]
     Y.relabeled <- object[["Y.relabeled"]]
   } else {
+    if (is.unsorted(failure.times, strictly = TRUE)) {
+      stop("Argument `failure.times` should be a vector with elements in increasing order.")
+    }
     Y.relabeled <- findInterval(object[["Y.orig"]], failure.times)
   }
 


### PR DESCRIPTION
This is a "bug fix" for an unfortunate design choice in `survival_forest`: the optional event grid `failure.times` could in practice contain duplicate grid values, but it is hard to justify why a user would want that. If one is using `survival_forest` to estimate for example IPCW weights, one could unintentionally select pick out the wrong weights from the grid.

Prevent this (unlikely) scenario by enforcing that the optional event grid is strictly increasing.