### PR TITLE
Fix documentation notation in survival_forest

### DIFF
--- a/r-package/grf/R/survival_forest.R
+++ b/r-package/grf/R/survival_forest.R
@@ -1,7 +1,7 @@
 #' Survival forest
 #'
 #' Trains a forest for right-censored surival data that can be used to estimate the
-#' conditional survival function S(t, x) = P[Y > t | X = x]
+#' conditional survival function S(t, x) = P[T > t | X = x]
 #'
 #' @param X The covariates.
 #' @param Y The event time (may be negative).

--- a/r-package/grf/man/survival_forest.Rd
+++ b/r-package/grf/man/survival_forest.Rd
@@ -99,7 +99,7 @@ A trained survival_forest forest object.
 }
 \description{
 Trains a forest for right-censored surival data that can be used to estimate the
-conditional survival function S(t, x) = P[Y > t | X = x]
+conditional survival function S(t, x) = P[T > t | X = x]
 }
 \examples{
 \donttest{


### PR DESCRIPTION
Fix minor notation inconsistency with the notation used in the CSF paper.