### PR TITLE
Require non-negative events in survival

### DIFF
--- a/r-package/grf/R/survival_forest.R
+++ b/r-package/grf/R/survival_forest.R
@@ -4,7 +4,7 @@
 #' conditional survival function S(t, x) = P[T > t | X = x]
 #'
 #' @param X The covariates.
-#' @param Y The event time (may be negative).
+#' @param Y The event time (non-negative).
 #' @param D The event type (0: censored, 1: failure).
 #' @param failure.times A vector of event times to fit the survival curve at. If NULL, then all the observed
 #'  failure times are used. This speeds up forest estimation by constraining the event grid. Observed event
@@ -132,6 +132,9 @@ survival_forest <- function(X, Y, D,
   has.missing.values <- validate_X(X, allow.na = TRUE)
   validate_sample_weights(sample.weights, X)
   Y <- validate_observations(Y, X)
+  if (any(Y < 0)) {
+    stop("The event times must be non-negative.")
+  }
   D <- validate_observations(D, X)
   if (!all(D %in% c(0, 1))) {
     stop("The censor values can only be 0 or 1.")

--- a/r-package/grf/R/survival_forest.R
+++ b/r-package/grf/R/survival_forest.R
@@ -4,7 +4,7 @@
 #' conditional survival function S(t, x) = P[T > t | X = x]
 #'
 #' @param X The covariates.
-#' @param Y The event time (non-negative).
+#' @param Y The event time (must be non-negative).
 #' @param D The event type (0: censored, 1: failure).
 #' @param failure.times A vector of event times to fit the survival curve at. If NULL, then all the observed
 #'  failure times are used. This speeds up forest estimation by constraining the event grid. Observed event

--- a/r-package/grf/man/survival_forest.Rd
+++ b/r-package/grf/man/survival_forest.Rd
@@ -29,7 +29,7 @@ survival_forest(
 \arguments{
 \item{X}{The covariates.}
 
-\item{Y}{The event time (non-negative).}
+\item{Y}{The event time (must be non-negative).}
 
 \item{D}{The event type (0: censored, 1: failure).}
 

--- a/r-package/grf/man/survival_forest.Rd
+++ b/r-package/grf/man/survival_forest.Rd
@@ -29,7 +29,7 @@ survival_forest(
 \arguments{
 \item{X}{The covariates.}
 
-\item{Y}{The event time (may be negative).}
+\item{Y}{The event time (non-negative).}
 
 \item{D}{The event type (0: censored, 1: failure).}
 

--- a/r-package/grf/tests/valgrind/test_grf_valgrind.R
+++ b/r-package/grf/tests/valgrind/test_grf_valgrind.R
@@ -10,7 +10,7 @@ W <- rbinom(n, 1, 0.5)
 W.factor <- as.factor(W)
 D <- rep(1, n)
 Y <- (X[, 1] > 0) * (2 * W - 1) + 2 * rnorm(n)
-Y.surv <- round(Y, 1)
+Y.surv <- abs(round(Y, 1))
 
 # Also checks regression_forest
 forest.causal <- causal_forest(X, Y, W, W.hat = 0.5, num.trees = 250, compute.oob.predictions = FALSE)


### PR DESCRIPTION
Place more restrictions on input Y (allowing this to be negative may lead to bugs in `causal_survival_forest` and is not that intuitive).