### PR TITLE
Add note on low event rate to docstring

### DIFF
--- a/r-package/grf/R/causal_survival_forest.R
+++ b/r-package/grf/R/causal_survival_forest.R
@@ -63,7 +63,11 @@
 #'  tree is skipped and does not contribute to the estimate). Setting this to FALSE may improve performance on
 #'  small/marginally powered data, but requires more trees (note: tuning does not adjust the number of trees).
 #'  Only applies if honesty is enabled. Default is TRUE.
-#' @param alpha A tuning parameter that controls the maximum imbalance of a split. Default is 0.05.
+#' @param alpha A tuning parameter that controls the maximum imbalance of a split. This parameter plays the same
+#'  role as in causal forest and surival forest, where for the latter the number of failures in
+#'  each child has to be at least one or `alpha` times the number of samples in the parent node. Default is 0.05.
+#'  (On data with very low event rate the default value may be too high for the forest to split
+#'  and lowering it may be beneficial).
 #' @param imbalance.penalty A tuning parameter that controls how harshly imbalanced splits are penalized. Default is 0.
 #' @param stabilize.splits Whether or not the treatment and censoring status should be taken into account when
 #'  determining the imbalance of a split. The requirement for valid split candidates is the same as in causal_forest

--- a/r-package/grf/R/survival_forest.R
+++ b/r-package/grf/R/survival_forest.R
@@ -45,6 +45,8 @@
 #'  Only applies if honesty is enabled. Default is TRUE.
 #' @param alpha A tuning parameter that controls the maximum imbalance of a split. The number of failures in
 #'  each child has to be at least one or `alpha` times the number of samples in the parent node. Default is 0.05.
+#'  (On data with very low event rate the default value may be too high for the forest to split
+#'  and lowering it may be beneficial).
 #' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed. Default is TRUE.
 #' @param prediction.type The type of estimate of the survival function, choices are "Kaplan-Meier" or "Nelson-Aalen".
 #' Only relevant if `compute.oob.predictions` is TRUE. Default is "Kaplan-Meier".

--- a/r-package/grf/man/causal_survival_forest.Rd
+++ b/r-package/grf/man/causal_survival_forest.Rd
@@ -107,7 +107,11 @@ tree is skipped and does not contribute to the estimate). Setting this to FALSE 
 small/marginally powered data, but requires more trees (note: tuning does not adjust the number of trees).
 Only applies if honesty is enabled. Default is TRUE.}
 
-\item{alpha}{A tuning parameter that controls the maximum imbalance of a split. Default is 0.05.}
+\item{alpha}{A tuning parameter that controls the maximum imbalance of a split. This parameter plays the same
+role as in causal forest and surival forest, where for the latter the number of failures in
+each child has to be at least one or `alpha` times the number of samples in the parent node. Default is 0.05.
+(On data with very low event rate the default value may be too high for the forest to split
+and lowering it may be beneficial).}
 
 \item{imbalance.penalty}{A tuning parameter that controls how harshly imbalanced splits are penalized. Default is 0.}
 

--- a/r-package/grf/man/survival_forest.Rd
+++ b/r-package/grf/man/survival_forest.Rd
@@ -82,7 +82,9 @@ small/marginally powered data, but requires more trees (note: tuning does not ad
 Only applies if honesty is enabled. Default is TRUE.}
 
 \item{alpha}{A tuning parameter that controls the maximum imbalance of a split. The number of failures in
-each child has to be at least one or `alpha` times the number of samples in the parent node. Default is 0.05.}
+each child has to be at least one or `alpha` times the number of samples in the parent node. Default is 0.05.
+(On data with very low event rate the default value may be too high for the forest to split
+and lowering it may be beneficial).}
 
 \item{prediction.type}{The type of estimate of the survival function, choices are "Kaplan-Meier" or "Nelson-Aalen".
 Only relevant if `compute.oob.predictions` is TRUE. Default is "Kaplan-Meier".}


### PR DESCRIPTION
Add a docstring note that on survival data with very low event rate the `alpha` parameter may need to be lowered to get the forest to split.

Does this look good to you @CrystalXuR?

As point of reference a causal forest with very low treatment propensity will also not split due to the split stabilizing criteria, which is kind of expected behavior.

For survival/causal survival we can keep this documentation note for now and instead elaborate on empirical examples in a future survival Vignette (omit having some automated message for now, as very low event rate data is a special use case it is reasonable to expect a user to think about)
