### PR TITLE
Disable sample weights for TMLE ATE

### DIFF
--- a/r-package/grf/R/average_treatment_effect.R
+++ b/r-package/grf/R/average_treatment_effect.R
@@ -136,6 +136,9 @@ average_treatment_effect <- function(forest,
     if (cluster.se) {
       stop("TMLE has not yet been implemented with clustered observations.")
     }
+    if (!is.null(forest$sample.weights)) {
+      stop("TMLE has not yet been implemented with sample weighted observations.")
+    }
   }
 
   clusters <- if (cluster.se) {


### PR DESCRIPTION
ATE estimates does not take sample weights into account when using TMLE: explicitly disable this code path instead of silently ignoring them.