### PR TITLE
Fix sample weighted ATT/ATC standard errors

### DIFF
--- a/r-package/grf/R/average_treatment_effect.R
+++ b/r-package/grf/R/average_treatment_effect.R
@@ -356,7 +356,7 @@ average_treatment_effect <- function(forest,
         length(correction.clust) / (length(correction.clust) - 1)
     } else {
       sigma2.hat <- sum(subset.weights^2 * dr.correction.all^2 / sum(subset.weights)^2) *
-        length(subset.weights) / (length(subset.weights) - 1)
+        length(subset.weights[subset.weights != 0]) / (length(subset.weights[subset.weights != 0]) - 1)
     }
   } else if (method == "TMLE") {
     if (target.sample == "all") {

--- a/r-package/grf/R/average_treatment_effect.R
+++ b/r-package/grf/R/average_treatment_effect.R
@@ -353,7 +353,7 @@ average_treatment_effect <- function(forest,
         transpose = TRUE
       ) %*% (dr.correction.all * subset.weights)
       sigma2.hat <- sum(correction.clust^2) / sum(subset.weights)^2 *
-        length(correction.clust) / (length(correction.clust) - 1)
+        Matrix::nnzero(correction.clust) / (Matrix::nnzero(correction.clust) - 1)
     } else {
       sigma2.hat <- sum(subset.weights^2 * dr.correction.all^2 / sum(subset.weights)^2) *
         length(subset.weights[subset.weights != 0]) / (length(subset.weights[subset.weights != 0]) - 1)

--- a/r-package/grf/R/average_treatment_effect.R
+++ b/r-package/grf/R/average_treatment_effect.R
@@ -355,7 +355,8 @@ average_treatment_effect <- function(forest,
       sigma2.hat <- sum(correction.clust^2) / sum(subset.weights)^2 *
         length(correction.clust) / (length(correction.clust) - 1)
     } else {
-      sigma2.hat <- mean(dr.correction.all^2) / (length(dr.correction.all) - 1)
+      sigma2.hat <- sum(subset.weights^2 * dr.correction.all^2 / sum(subset.weights)^2) *
+        length(subset.weights) / (length(subset.weights) - 1)
     }
   } else if (method == "TMLE") {
     if (target.sample == "all") {


### PR DESCRIPTION
As pointed out by @davidahirshberg, an old typo caused optional sample weights not to be taken into account during SE calculation for ATT/ATC when clusters not supplied.

This only affects `average_treatment_effect` uses cases where method="AIPW", and target.sample = "treated" or "control" and the forest is trained with sample.weights and no clusters.

This PR also updates the finite sample correction n/(n-1) when some some weights are zero. A follow-up PR address the same thing for AIPW and target.sample="all" where we rely on similarly hand computed SEs