### PR TITLE
Update effective n for AIPW SEs

### DIFF
--- a/r-package/grf/R/average_treatment_effect.R
+++ b/r-package/grf/R/average_treatment_effect.R
@@ -205,7 +205,7 @@ average_treatment_effect <- function(forest,
         (sweep(as.matrix(DR.scores), 2, tau.hat, "-") * subset.weights)
 
       Matrix::colSums(correction.clust^2) / sum(subset.weights)^2 *
-        nrow(correction.clust) / (nrow(correction.clust) - 1)
+        Matrix::nnzero(correction.clust) / (Matrix::nnzero(correction.clust) - 1)
     }
 
     if (any(c("causal_forest", "instrumental_forest", "multi_arm_causal_forest", "causal_survival_forest")

--- a/r-package/grf/tests/testthat/test_average_effect.R
+++ b/r-package/grf/tests/testthat/test_average_effect.R
@@ -462,6 +462,8 @@ test_that("average effect estimation handles SE's with sample weights=0 consiste
   wts <- sample(c(0, 1, 2), n, replace = TRUE)
   cf <- causal_forest(X, Y, W, W.hat = 0.5, sample.weights = wts)
 
+  expect_equal(average_treatment_effect(cf),
+               average_treatment_effect(cf, subset = wts > 0))
   expect_equal(average_treatment_effect(cf, target.sample = "control"),
                average_treatment_effect(cf, target.sample = "control", subset = wts > 0))
   expect_equal(average_treatment_effect(cf, target.sample = "treated"),
@@ -470,6 +472,8 @@ test_that("average effect estimation handles SE's with sample weights=0 consiste
   cl <- sample(c(5:20), n, replace = TRUE)
   cf.clust <- causal_forest(X, Y, W, W.hat = 0.5, sample.weights = wts, clusters = cl)
 
+  expect_equal(average_treatment_effect(cf.clust),
+               average_treatment_effect(cf.clust, subset = wts > 0))
   expect_equal(average_treatment_effect(cf.clust, target.sample = "control"),
                average_treatment_effect(cf.clust, target.sample = "control", subset = wts > 0))
   expect_equal(average_treatment_effect(cf.clust, target.sample = "treated"),


### PR DESCRIPTION
See #1103, hand constructed SE's in the ATE functions relies on a sample correction that looks like n/(n-1). When some observations have weight zero this is not right. 