### PR TITLE
Add `sandwich` check for sample.weights=0

### DIFF
--- a/r-package/grf/R/average_treatment_effect.R
+++ b/r-package/grf/R/average_treatment_effect.R
@@ -262,6 +262,7 @@ average_treatment_effect <- function(forest,
   subset.Y.hat.1 <- subset.Y.hat + (1 - subset.W.hat) * tau.hat.pointwise
 
   if (target.sample == "overlap") {
+    validate_sandwich(subset.weights)
 
     # Address the overlap case separately, as this is a very different estimation problem.
     # The method argument (AIPW vs TMLE) is ignored in this case, as both methods are effectively

--- a/r-package/grf/R/forest_summary.R
+++ b/r-package/grf/R/forest_summary.R
@@ -170,6 +170,7 @@ best_linear_projection <- function(forest,
   subset <- validate_subset(forest, subset)
   subset.clusters <- clusters[subset]
   subset.weights <- observation.weight[subset]
+  validate_sandwich(subset.weights)
 
   if (length(unique(subset.clusters)) <= 1) {
     stop("The specified subset must contain units from more than one cluster.")

--- a/r-package/grf/R/input_utilities.R
+++ b/r-package/grf/R/input_utilities.R
@@ -294,3 +294,18 @@ validate_subset <- function(forest, subset) {
   }
   subset
 }
+
+# Up until version 3.0.1, the sandwich package did not handle SE's when
+# some sample weights were 0. For code that relies on this package and
+# that might encounter 0 weights, we provide guidance below.
+validate_sandwich <- function(subset.weights) {
+  if (any(subset.weights == 0)) {
+    if (utils::packageVersion("sandwich") <= numeric_version("3.0.1")) {
+      stop(paste(
+        "Some sample weights are zero. This requires package `sandwich` version 3.0.2 or greater.",
+        "An alternative work-around is to use the optional `subset` argument to specify non-zero samples",
+        "(`subset = sample.weights > 0`)."
+      ))
+    }
+  }
+}


### PR DESCRIPTION
Some code paths in `average_treatment_effect`, and `best_linear_projection` calls into the `sandwich` package to compute standard errors. In some rare cases optional sample.weights that might be zero are passed onto this function, and they are currently not handled correctly. This workaround raises an appropriate error message.

The other code paths that relies on manually calculated SEs are updated to be correct for 0 weights in #1104. 

Kindly pinging @zeileis just to make sure he agrees with our version check `(utils::packageVersion("sandwich") <= numeric_version("3.0.1")` where we assume a future 3.0.2 release will be fine with zero weights?

