### PR TITLE
Refer to RATE in test_calibration

### DIFF
--- a/r-package/grf/R/forest_summary.R
+++ b/r-package/grf/R/forest_summary.R
@@ -9,7 +9,7 @@
 #' The p-value of the `differential.forest.prediction` coefficient
 #' also acts as an omnibus test for the presence of heterogeneity: If the coefficient
 #' is significantly greater than 0, then we can reject the null of
-#' no heterogeneity.
+#' no heterogeneity. For another class of omnnibus tests see \code{\link{rank_average_treatment_effect}}.
 #'
 #' @param forest The trained forest.
 #' @param vcov.type Optional covariance type for standard errors. The possible

--- a/r-package/grf/man/test_calibration.Rd
+++ b/r-package/grf/man/test_calibration.Rd
@@ -28,7 +28,7 @@ that the heterogeneity estimates from the forest are well calibrated.
 The p-value of the `differential.forest.prediction` coefficient
 also acts as an omnibus test for the presence of heterogeneity: If the coefficient
 is significantly greater than 0, then we can reject the null of
-no heterogeneity.
+no heterogeneity. For another class of omnnibus tests see \code{\link{rank_average_treatment_effect}}.
 }
 \examples{
 \donttest{


### PR DESCRIPTION
Just adding a quick reference to `rank_average_treatment_effect` as discussed with @swager 