### PR TITLE
Revert to default if tuning selects params outside valid range

### DIFF
--- a/r-package/grf/R/tune_forest.R
+++ b/r-package/grf/R/tune_forest.R
@@ -114,7 +114,7 @@ tune_forest <- function(data,
   default.forest <- do.call.rcpp(train, c(data, fit.parameters, tune.parameters.defaults))
   default.forest.error <- mean(default.forest$debiased.error, na.rm = TRUE)
 
-  if (!is.na(retrained.forest.error) || default.forest.error < retrained.forest.error) {
+  if (is.na(retrained.forest.error) || default.forest.error < retrained.forest.error) {
     out <- get_tuning_output(
       error = default.forest.error,
       params = tune.parameters.defaults,

--- a/r-package/grf/R/tune_forest.R
+++ b/r-package/grf/R/tune_forest.R
@@ -114,7 +114,7 @@ tune_forest <- function(data,
   default.forest <- do.call.rcpp(train, c(data, fit.parameters, tune.parameters.defaults))
   default.forest.error <- mean(default.forest$debiased.error, na.rm = TRUE)
 
-  if (default.forest.error < retrained.forest.error) {
+  if (!is.na(retrained.forest.error) || default.forest.error < retrained.forest.error) {
     out <- get_tuning_output(
       error = default.forest.error,
       params = tune.parameters.defaults,


### PR DESCRIPTION
Revert to default parameters if DiceKringing extrapolates optimal parameters outside range of admissible draws, as can be the case when it selects a too small sample.fraction when clusters are specified, leading zero samples to be drawn. Follow up to #1067... 