### PR TITLE
Update failure.times argument in predict.survival_forest

### DIFF
--- a/r-package/grf/R/survival_forest.R
+++ b/r-package/grf/R/survival_forest.R
@@ -302,8 +302,7 @@ predict.survival_forest <- function(object,
       return(list(predictions = object$predictions, failure.times = failure.times.orig))
     }
     idx <- findInterval(failure.times, failure.times.orig)
-    n.samples <- nrow(object$predictions)
-    out <- matrix(1, nrow = n.samples, ncol = length(failure.times))
+    out <- matrix(1, nrow = nrow(object$predictions), ncol = length(failure.times))
     out[, idx > 0] <- object$predictions[, idx]
     return(list(predictions = out, failure.times = failure.times))
   }
@@ -333,8 +332,7 @@ predict.survival_forest <- function(object,
   }
 
   idx <- findInterval(failure.times, failure.times.orig)
-  n.samples <- nrow(ret$predictions)
-  out <- matrix(1, nrow = n.samples, ncol = length(failure.times))
+  out <- matrix(1, nrow = nrow(ret$predictions), ncol = length(failure.times))
   out[, idx > 0] <- ret$predictions[, idx]
 
   list(predictions = out, failure.times = failure.times)

--- a/r-package/grf/man/predict.survival_forest.Rd
+++ b/r-package/grf/man/predict.survival_forest.Rd
@@ -22,7 +22,7 @@ Xi using only trees that did not use the i-th training example). Note
 that this matrix should have the number of columns as the training
 matrix, and that the columns must appear in the same order.}
 
-\item{failure.times}{A vector of failure times to make predictions at. If NULL, then the
+\item{failure.times}{A vector of survival times to make predictions at. If NULL, then the
 failure times used for training the forest is used. The time points should be in increasing order. Default is NULL.}
 
 \item{prediction.type}{The type of estimate of the survival function, choices are "Kaplan-Meier" or "Nelson-Aalen".
@@ -34,13 +34,15 @@ automatically selects an appropriate amount.}
 \item{...}{Additional arguments (currently ignored).}
 }
 \value{
-A list with elements `failure.times`: a vector of event times t for the survival curve,
- and `predictions`: a matrix of survival curves. Each row is the survival curve for
- sample X_i: predictions[i, j] = S(failure.times[j], X_i).
+A list with elements \itemize{
+ \item predictions: a matrix of survival curves. Each row is the survival curve for
+ sample Xi: predictions[i, j] = S(failure.times[j], Xi).
+ \item failure.times: a vector of event times t for the survival curve.
+}
 }
 \description{
-Gets estimates of the conditional survival function S(t, x) using a trained survival forest. The curve can be
-estimated by Kaplan-Meier, or Nelson-Aalen.
+Gets estimates of the conditional survival function S(t, x) = P[T > t | X = x] using a trained survival forest.
+The curve can be estimated by Kaplan-Meier, or Nelson-Aalen.
 }
 \examples{
 \donttest{

--- a/r-package/grf/tests/testthat/test_survival_forest.R
+++ b/r-package/grf/tests/testthat/test_survival_forest.R
@@ -162,6 +162,6 @@ test_that("survival forest with complete data is ~equal to regression forest", {
   rf <- regression_forest(X, Y, num.trees = 500)
   Y.hat.rf <- predict(rf)$predictions
 
-  expect_equal(Y.hat.sf, Y.hat.rf, tolerance = 0.075)
-  expect_equal(Y.hat.sf.grid, Y.hat.rf, tolerance = 0.075)
+  expect_equal(Y.hat.sf, Y.hat.rf, tolerance = 0.1)
+  expect_equal(Y.hat.sf.grid, Y.hat.rf, tolerance = 0.1)
 })

--- a/r-package/grf/tests/testthat/test_survival_forest.R
+++ b/r-package/grf/tests/testthat/test_survival_forest.R
@@ -79,6 +79,10 @@ test_that("survival forest grid indexing works as expected", {
                matrix(1, nrow = n))
   expect_equal(predict(sf, X[1:10, ], failure.times = -100)$predictions,
                matrix(1, nrow = 10))
+ pp <- predict(sf)
+ idx <- findInterval(mean(Y), pp$failure.times)
+ pp.t <- predict(sf, failure.times = mean(Y))
+ expect_equal(pp.t$predictions[,], pp$predictions[, idx])
 })
 
 test_that("sample weighted survival prediction is invariant to weight rescaling", {

--- a/r-package/grf/tests/testthat/test_survival_forest.R
+++ b/r-package/grf/tests/testthat/test_survival_forest.R
@@ -79,10 +79,10 @@ test_that("survival forest grid indexing works as expected", {
                matrix(1, nrow = n))
   expect_equal(predict(sf, X[1:10, ], failure.times = -100)$predictions,
                matrix(1, nrow = 10))
- pp <- predict(sf)
- idx <- findInterval(mean(Y), pp$failure.times)
- pp.t <- predict(sf, failure.times = mean(Y))
- expect_equal(pp.t$predictions[,], pp$predictions[, idx])
+  pp <- predict(sf)
+  idx <- findInterval(mean(Y), pp$failure.times)
+  pp.t <- predict(sf, failure.times = mean(Y))
+  expect_equal(pp.t$predictions[,], pp$predictions[, idx])
 })
 
 test_that("sample weighted survival prediction is invariant to weight rescaling", {

--- a/r-package/grf/tests/testthat/test_survival_forest.R
+++ b/r-package/grf/tests/testthat/test_survival_forest.R
@@ -75,9 +75,9 @@ test_that("survival forest grid indexing works as expected", {
                predict(sfOOB, failure.times = sf$failure.times)$predictions)
   expect_equal(predict(sf, X)$predictions,
                predict(sf, X, failure.times = sf$failure.times)$predictions)
-  expect_equal(predict(sf, failure.times = -100, prediction.times = "point")$predictions,
+  expect_equal(predict(sf, failure.times = -100)$predictions,
                matrix(1, nrow = n))
-  expect_equal(predict(sf, X[1:10, ], failure.times = -100, prediction.times = "point")$predictions,
+  expect_equal(predict(sf, X[1:10, ], failure.times = -100)$predictions,
                matrix(1, nrow = 10))
 })
 


### PR DESCRIPTION
Closes #1131: fix argument failure.times s.t. it it predicts new time points on the existing curve, w/o snapping a new curve onto the grid. This does not affect `causal_survival_forest`
