### PR TITLE
Add optional argument prediction.times to survival_forest.predict

### DIFF
--- a/r-package/grf/R/survival_forest.R
+++ b/r-package/grf/R/survival_forest.R
@@ -303,7 +303,7 @@ predict.survival_forest <- function(object,
     failure.times <- failure.times.orig
   }
   if (prediction.times == "curve") {
-    if (!is.null(failure.times) && is.unsorted(failure.times, strictly = TRUE)) {
+    if (is.unsorted(failure.times, strictly = TRUE)) {
       stop("Argument `failure.times` should be a vector with elements in increasing order.")
     }
   } else {

--- a/r-package/grf/R/survival_forest.R
+++ b/r-package/grf/R/survival_forest.R
@@ -210,8 +210,8 @@ survival_forest <- function(X, Y, D,
 #' @param failure.times A vector of survival times to make predictions at. If NULL, then the
 #'  failure times used for training the forest is used. If prediction.times = "curve" then the
 #'  time points should be in increasing order. Default is NULL.
-#' @param prediction.times "curve" predicts the entire survival curve on grid failure.times for each sample Xi.
-#'  "time" predicts at an event time failure.times[i] for each sample Xi.
+#' @param prediction.times "curve" predicts the survival curve S(t, x) on grid t = failure.times for each sample Xi.
+#'  "time" predicts S(t, x) at an event time t = failure.times[i] for each sample Xi.
 #'  Default is "curve".
 #' @param prediction.type The type of estimate of the survival function, choices are "Kaplan-Meier" or "Nelson-Aalen".
 #'  The default is the prediction.type used to train the forest.

--- a/r-package/grf/man/predict.survival_forest.Rd
+++ b/r-package/grf/man/predict.survival_forest.Rd
@@ -27,8 +27,8 @@ matrix, and that the columns must appear in the same order.}
 failure times used for training the forest is used. If prediction.times = "curve" then the
 time points should be in increasing order. Default is NULL.}
 
-\item{prediction.times}{"curve" predicts the entire survival curve on grid failure.times for each sample Xi.
-"time" predicts at an event time failure.times[i] for each sample Xi.
+\item{prediction.times}{"curve" predicts the survival curve S(t, x) on grid t = failure.times for each sample Xi.
+"time" predicts S(t, x) at an event time t = failure.times[i] for each sample Xi.
 Default is "curve".}
 
 \item{prediction.type}{The type of estimate of the survival function, choices are "Kaplan-Meier" or "Nelson-Aalen".

--- a/r-package/grf/man/predict.survival_forest.Rd
+++ b/r-package/grf/man/predict.survival_forest.Rd
@@ -8,6 +8,7 @@
   object,
   newdata = NULL,
   failure.times = NULL,
+  prediction.times = c("curve", "time"),
   prediction.type = c("Kaplan-Meier", "Nelson-Aalen"),
   num.threads = NULL,
   ...
@@ -23,7 +24,12 @@ that this matrix should have the number of columns as the training
 matrix, and that the columns must appear in the same order.}
 
 \item{failure.times}{A vector of survival times to make predictions at. If NULL, then the
-failure times used for training the forest is used. The time points should be in increasing order. Default is NULL.}
+failure times used for training the forest is used. If prediction.times = "curve" then the
+time points should be in increasing order. Default is NULL.}
+
+\item{prediction.times}{"curve" predicts the entire survival curve on grid failure.times for each sample Xi.
+"time" predicts at an event time failure.times[i] for each sample Xi.
+Default is "curve".}
 
 \item{prediction.type}{The type of estimate of the survival function, choices are "Kaplan-Meier" or "Nelson-Aalen".
 The default is the prediction.type used to train the forest.}
@@ -35,8 +41,10 @@ automatically selects an appropriate amount.}
 }
 \value{
 A list with elements \itemize{
- \item predictions: a matrix of survival curves. Each row is the survival curve for
- sample Xi: predictions[i, j] = S(failure.times[j], Xi).
+ \item predictions: a matrix of survival curves. If prediction.times = "curve" then each row
+ is the survival curve for sample Xi: predictions[i, j] = S(failure.times[j], Xi).
+ If prediction.times = "time" then each row is the survival curve at time point failure.times[i]
+ for sample Xi: predictions[i, ] = S(failure.times[i], Xi).
  \item failure.times: a vector of event times t for the survival curve.
 }
 }


### PR DESCRIPTION
By default (prediction.times = "curve") survival forest predicts the survival curve specified by grid failure.times for each sample Xi.

If prediction.times = "times" then it will predict the event time on the survival curve specified by failure.times[i] for each sample Xi. For example, prediction.times = pmin(Y, t0) will predict P(T > pmin(Yi, t0) | Xi)