### PR TITLE
Update vector arg calls to expect_equal

### DIFF
--- a/r-package/grf/tests/testthat/test_forest_summaries.R
+++ b/r-package/grf/tests/testthat/test_forest_summaries.R
@@ -217,7 +217,8 @@ test_that("best linear projection works as expected with causal survival forest"
   A1 <- data.test$X[, 1]
   blp.X1.true <- lm(data.test$cate ~ A1)$coefficients
   blp.X1 <- best_linear_projection(cs.forest, data$X[, 1])
-  expect_equal(blp.X1.true, blp.X1[, "Estimate"], tolerance = 2.1 * sqrt(blp.X1[, "Std. Error"]))
+  expect_equal(blp.X1.true[[1]], blp.X1[1, "Estimate"], tolerance = 2.1 * sqrt(blp.X1[1, "Std. Error"]))
+  expect_equal(blp.X1.true[[2]], blp.X1[2, "Estimate"], tolerance = 2.1 * sqrt(blp.X1[2, "Std. Error"]))
 
   weights <- rep(1, n)
   dup <- sample(1:n, 50)

--- a/r-package/grf/tests/testthat/test_rank_average_treatment.R
+++ b/r-package/grf/tests/testthat/test_rank_average_treatment.R
@@ -96,7 +96,9 @@ test_that("TOC grid works as expected", {
   rate <- rank_average_treatment_effect(cf, rand.prio)
   TOC <- rate$TOC$estimate
   TOC.se <- rate$TOC$std.err
-  expect_equal(TOC, rep(0, length(TOC)), tolerance = 3 * TOC.se)
+  for (i in seq_along(TOC)) {
+    expect_equal(TOC[i], 0, tolerance = 3.1 * TOC.se[i])
+  }
 
   q5 <- seq(0.05, 1, by = 0.05)
   rate.q5 <- rank_average_treatment_effect(cf, rand.prio, q = q5)
@@ -129,7 +131,9 @@ test_that("sample weighted TOC grid works as expected", {
   rate <- rank_average_treatment_effect(cf, rand.prio)
   TOC <- rate$TOC$estimate
   TOC.se <- rate$TOC$std.err
-  expect_equal(TOC, rep(0, length(TOC)), tolerance = 3 * TOC.se)
+  for (i in seq_along(TOC)) {
+    expect_equal(TOC[i], 0, tolerance = 3.1 * TOC.se[i])
+  }
 
   q5 <- seq(0.05, 1, by = 0.05)
   rate.q5 <- rank_average_treatment_effect(cf, rand.prio, q = q5)

--- a/r-package/grf/tests/testthat/test_rank_average_treatment.R
+++ b/r-package/grf/tests/testthat/test_rank_average_treatment.R
@@ -104,7 +104,9 @@ test_that("TOC grid works as expected", {
   rate.q5 <- rank_average_treatment_effect(cf, rand.prio, q = q5)
   TOC.q5 <- rate.q5$TOC$estimate
   TOC.q5.se <- rate.q5$TOC$std.err
-  expect_equal(TOC.q5, rep(0, length(TOC.q5)), tolerance = 3 * TOC.q5.se)
+  for (i in seq_along(TOC.q5)) {
+    expect_equal(TOC.q5[i], 0, tolerance = 3.1 * TOC.q5.se[i])
+  }
 })
 
 test_that("sample weighted TOC grid works as expected", {
@@ -139,7 +141,9 @@ test_that("sample weighted TOC grid works as expected", {
   rate.q5 <- rank_average_treatment_effect(cf, rand.prio, q = q5)
   TOC.q5 <- rate.q5$TOC$estimate
   TOC.q5.se <- rate.q5$TOC$std.err
-  expect_equal(TOC.q5, rep(0, length(TOC.q5)), tolerance = 3 * TOC.q5.se)
+  for (i in seq_along(TOC.q5)) {
+    expect_equal(TOC.q5[i], 0, tolerance = 3.1 * TOC.q5.se[i])
+  }
 })
 
 test_that("rank_average_treatment_effect agrees with plain brute-force calculation", {


### PR DESCRIPTION
Small fix affecting a few tests.

> all.equal.numeric() gains a sanity check on its tolerance
      argument - calling all.equal(a, b, c) for three numeric vectors
      is a surprisingly common error.

https://stat.ethz.ch/pipermail/r-announce/2022/000683.html