### PR TITLE
Add sufficient statistics note to DEVELOPING

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -200,6 +200,7 @@ The algorithm proceeds in the same manner as outlined above for RegressionSplitt
 ***Algorithm*** (`ProbabilitySplittingRule`): This splitting rule uses the Gini impurity measure from CART for categorical data. Sample weights are incorporated by counting the sample weight of an observation when forming class counts. The missing values adjustment is the same as for the other splitting rules.
 
 ### Computing point predictions
+
 GRF point estimates, $\theta(x)$, for a target sample $X=x$, are given by a forest-specific estimating equation $\psi_{\theta(x)}(\cdot)$ solved using GRF forest weights $\alpha(x)$ (see equation (2) and (3) in the [GRF paper](https://arxiv.org/abs/1610.01271)). In the GRF software package we additionally incorporate sample weights $w_i$. For training samples $i = 1...n$, predictions at a target sample $X=x$ are given by:
 
 $$

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -75,7 +75,7 @@ The following table shows the current collection of forests implemented and the 
 | causal_forest with ll_causal_predict 	| InstrumentalRelabelingStrategy   	| InstrumentalSplittingRule    	| LLCausalPredictionStrategy        	|
 | causal_survival_forest               	| CausalSurvivalRelabelingStrategy 	| CausalSurvivalSplittingRule  	| CausalSurvivalPredictionStrategy  	|
 | instrumental_forest                  	| InstrumentalRelabelingStrategy   	| InstrumentalSplittingRule    	| InstrumentalPredictionStrategy    	|
-| ll_regression_forest                 	| LLRegressionRelabelingStrategy   	| RegressionSplittingRule      	| LocalLinearPredictionStrategy       |
+| ll_regression_forest                 	| LLRegressionRelabelingStrategy   	| RegressionSplittingRule      	| LocalLinearPredictionStrategy      	|
 | lm_forest                            	| MultiCausalRelabelingStrategy    	| MultiRegressionSplittingRule  | MultiCausalPredictionStrategy     	|
 | multi_arm_causal_forest              	| MultiCausalRelabelingStrategy    	| MultiCausalSplittingRule      | MultiCausalPredictionStrategy     	|
 | multi_regression_forest              	| MultiNoopRelabelingStrategy      	| MultiRegressionSplittingRule 	| MultiRegressionPredictionStrategy 	|


### PR DESCRIPTION
Now that GitHub markdown is supposed to support LaTeX: adding an explanation of how the OptimizedPredictionStrategy works to the developing docs. Last time we touched sample weights we wrote up a pdf https://github.com/grf-labs/grf/pull/774, it would be convenient to record this in DEVELOPING for easier future reference.