### PR TITLE
Simplify CSF DR score

### DIFF
--- a/r-package/grf/R/causal_survival_forest.R
+++ b/r-package/grf/R/causal_survival_forest.R
@@ -508,7 +508,5 @@ compute_eta <- function(S.hat,
   numerator <- numerator.one - numerator.two
   denominator <- W.centered^2 # denominator simplifies to this.
 
-  list(numerator = numerator, denominator = denominator,
-       numerator.one = numerator.one, numerator.two = numerator.two,
-       C.Y.hat = C.Y.hat)
+  list(numerator = numerator, denominator = denominator, C.Y.hat = C.Y.hat)
 }

--- a/r-package/grf/R/get_scores.R
+++ b/r-package/grf/R/get_scores.R
@@ -315,12 +315,11 @@ get_scores.causal_survival_forest <- function(forest,
   }
 
   eta <- forest[["_eta"]]
-  numerator.one <- eta$numerator.one[subset]
-  numerator.two <- eta$numerator.two[subset]
+  numerator <- eta$numerator[subset]
+  denominator <- eta$denominator[subset]
   W.hat <- forest$W.hat[subset]
-  W.orig <- forest$W.orig[subset]
   cate.hat <- predict(forest)$predictions[subset]
-  correction <- numerator.one - numerator.two - cate.hat * (W.orig - W.hat)^2
+  psi <- numerator - denominator * cate.hat
 
-  cate.hat + correction * 1 / W.hat / (1 - W.hat)
+  cate.hat + psi * 1 / W.hat / (1 - W.hat)
 }


### PR DESCRIPTION
This is only an aesthetic change. The way CSF R updated the score was overly involved and more verbose than in the relabeling strategy. Simplify it and make it consistent.