### PR TITLE
Use consistent internal CSF variable names

### DIFF
--- a/core/src/prediction/CausalSurvivalPredictionStrategy.cpp
+++ b/core/src/prediction/CausalSurvivalPredictionStrategy.cpp
@@ -42,7 +42,7 @@ std::vector<double> CausalSurvivalPredictionStrategy::compute_variance(
     size_t ci_group_size) const {
 
   double v_est = average.at(DENOMINATOR);
-  double average_eta = average.at(NUMERATOR) / average.at(DENOMINATOR);
+  double average_tau = average.at(NUMERATOR) / average.at(DENOMINATOR);
 
 
   double num_good_groups = 0;
@@ -67,7 +67,7 @@ std::vector<double> CausalSurvivalPredictionStrategy::compute_variance(
       size_t i = group * ci_group_size + j;
       const std::vector<double>& leaf_value = leaf_values.get_values(i);
 
-      double psi_1 = leaf_value.at(NUMERATOR) - leaf_value.at(DENOMINATOR) * average_eta;
+      double psi_1 = leaf_value.at(NUMERATOR) - leaf_value.at(DENOMINATOR) * average_tau;
 
       psi_squared += psi_1 * psi_1;
       group_psi += psi_1;

--- a/core/src/relabeling/CausalSurvivalRelabelingStrategy.cpp
+++ b/core/src/relabeling/CausalSurvivalRelabelingStrategy.cpp
@@ -41,12 +41,12 @@ bool CausalSurvivalRelabelingStrategy::relabel(
     return true;
   }
 
-  double eta = numerator_sum / denominator_sum;
+  double tau = numerator_sum / denominator_sum;
 
   // Create the new outcomes.
   for (size_t sample : samples) {
     double response = (data.get_causal_survival_numerator(sample) -
-      data.get_causal_survival_denominator(sample) * eta) / denominator_sum;
+      data.get_causal_survival_denominator(sample) * tau) / denominator_sum;
     responses_by_sample(sample, 0) = response;
   }
   return false;

--- a/r-package/grf/R/causal_survival_forest.R
+++ b/r-package/grf/R/causal_survival_forest.R
@@ -304,15 +304,15 @@ causal_survival_forest <- function(X, Y, W, D,
                   "may help."))
   }
 
-  eta <- compute_eta(S.hat, C.hat, C.Y.hat, Y.hat, W.centered,
+  psi <- compute_psi(S.hat, C.hat, C.Y.hat, Y.hat, W.centered,
                      D, fY, Y.index, Y.grid, target, horizon)
-  validate_observations(eta[["numerator"]], X)
-  validate_observations(eta[["denominator"]], X)
+  validate_observations(psi[["numerator"]], X)
+  validate_observations(psi[["denominator"]], X)
 
   data <- create_train_matrices(X,
                                 treatment = W.centered,
-                                survival.numerator = eta[["numerator"]],
-                                survival.denominator = eta[["denominator"]],
+                                survival.numerator = psi[["numerator"]],
+                                survival.denominator = psi[["denominator"]],
                                 censor = D,
                                 sample.weights = sample.weights)
 
@@ -336,7 +336,7 @@ causal_survival_forest <- function(X, Y, W, D,
   forest <- do.call.rcpp(causal_survival_train, c(data, args))
   class(forest) <- c("causal_survival_forest", "grf")
   forest[["seed"]] <- seed
-  forest[["_eta"]] <- eta
+  forest[["_psi"]] <- psi
   forest[["X.orig"]] <- X
   forest[["Y.orig"]] <- Y
   forest[["W.orig"]] <- W
@@ -454,7 +454,7 @@ expected_survival <- function(S.hat, Y.grid) {
   c(cbind(1, S.hat) %*% grid.diff)
 }
 
-compute_eta <- function(S.hat,
+compute_psi <- function(S.hat,
                         C.hat,
                         C.Y.hat,
                         Y.hat,

--- a/r-package/grf/R/get_scores.R
+++ b/r-package/grf/R/get_scores.R
@@ -314,9 +314,8 @@ get_scores.causal_survival_forest <- function(forest,
     ))
   }
 
-  eta <- forest[["_eta"]]
-  numerator <- eta$numerator[subset]
-  denominator <- eta$denominator[subset]
+  numerator <- forest[["_psi"]]$numerator[subset]
+  denominator <- forest[["_psi"]]$denominator[subset]
   W.hat <- forest$W.hat[subset]
   cate.hat <- predict(forest)$predictions[subset]
   psi <- numerator - denominator * cate.hat

--- a/r-package/grf/tests/testthat/test_causal_survival_forest.R
+++ b/r-package/grf/tests/testthat/test_causal_survival_forest.R
@@ -132,10 +132,10 @@ test_that("causal survival forest predictions are kernel weighted correctly", {
   forest.weights <- get_forest_weights(cs.forest, x1)[1, ]
   forest.weights.weighted <- get_forest_weights(cs.forest.weighted, x1)[1, ]
 
-  theta1 <- sum(forest.weights * cs.forest[["_eta"]]$numerator) /
-    sum(forest.weights * cs.forest[["_eta"]]$denominator)
-  theta1.weighted <- sum(forest.weights.weighted * sample.weights * cs.forest.weighted[["_eta"]]$numerator) /
-    sum(forest.weights.weighted * sample.weights * cs.forest.weighted[["_eta"]]$denominator)
+  theta1 <- sum(forest.weights * cs.forest[["_psi"]]$numerator) /
+    sum(forest.weights * cs.forest[["_psi"]]$denominator)
+  theta1.weighted <- sum(forest.weights.weighted * sample.weights * cs.forest.weighted[["_psi"]]$numerator) /
+    sum(forest.weights.weighted * sample.weights * cs.forest.weighted[["_psi"]]$denominator)
 
   expect_equal(cs.pred, theta1)
   expect_equal(cs.pred.weighted, theta1.weighted)


### PR DESCRIPTION
Purely aesthetic: use consistent naming convention from CSF paper to make it easier to connect the CSF paper to its implementation (#1175).