### PR TITLE
Fix overall.beta calculation when X is not matrix

### DIFF
--- a/r-package/grf/R/ll_regression_forest.R
+++ b/r-package/grf/R/ll_regression_forest.R
@@ -142,7 +142,7 @@ ll_regression_forest <- function(X, Y,
     # find overall beta
     J <- diag(ncol(X) + 1)
     J[1,1] <- 0
-    D <- cbind(1, X)
+    D <- cbind(1, as.matrix(X))
     overall.beta <- solve(t(D) %*% D + ll.split.lambda * J) %*% t(D) %*% Y
 
     # update arguments with LLF parameters


### PR DESCRIPTION
Allow ll_regression_forest input to work regardless of X type when enable.ll.split = TRUE.

Fixes #1197 (thanks to @tmieno2 for pointing this out)