### PR TITLE
Fix subset typo in RATE docstring

### DIFF
--- a/r-package/grf/R/rank_average_treatment.R
+++ b/r-package/grf/R/rank_average_treatment.R
@@ -74,7 +74,7 @@
 #' plot(rate)
 #'
 #' # Compute a prioritization based on baseline risk.
-#' rf.risk <- regression_forest(X[W[train] == 0, ], Y[W[train] == 0])
+#' rf.risk <- regression_forest(X[train[W[train] == 0], ], Y[train[W[train] == 0]])
 #' priority.risk <- predict(rf.risk, X[-train, ])$predictions
 #'
 #' # Test if two RATEs are equal.

--- a/r-package/grf/man/rank_average_treatment_effect.Rd
+++ b/r-package/grf/man/rank_average_treatment_effect.Rd
@@ -105,7 +105,7 @@ rate
 plot(rate)
 
 # Compute a prioritization based on baseline risk.
-rf.risk <- regression_forest(X[W[train] == 0, ], Y[W[train] == 0])
+rf.risk <- regression_forest(X[train[W[train] == 0], ], Y[train[W[train] == 0]])
 priority.risk <- predict(rf.risk, X[-train, ])$predictions
 
 # Test if two RATEs are equal.


### PR DESCRIPTION
Just fixing a tiny docstring example subset operation that was incorrect.