### PR TITLE
Remove as.matrix in best_linear_projection

### DIFF
--- a/r-package/grf/R/forest_summary.R
+++ b/r-package/grf/R/forest_summary.R
@@ -100,7 +100,7 @@ test_calibration <- function(forest, vcov.type = "HC3") {
 #'
 #' Procedurally, we do so by regressing doubly robust scores derived from the
 #' forest against the Ai. Note the covariates Ai may consist of a subset of the Xi,
-#' or they may be distinct The case of the null model tau(Xi) ~ beta_0 is equivalent
+#' or they may be distinct. The case of the null model tau(Xi) ~ beta_0 is equivalent
 #' to fitting an average treatment effect via AIPW.
 #'
 #' In the event the treatment is continuous the inverse-propensity weight component of the

--- a/r-package/grf/R/forest_summary.R
+++ b/r-package/grf/R/forest_summary.R
@@ -211,7 +211,7 @@ best_linear_projection <- function(forest,
   }
 
   if (!is.null(A)) {
-    if (is.null(dim(A))) {
+    if (is.vector(A)) {
       dim(A) <- c(length(A), 1L)
     }
     if (nrow(A) == NROW(forest$Y.orig)) {

--- a/r-package/grf/R/forest_summary.R
+++ b/r-package/grf/R/forest_summary.R
@@ -211,7 +211,9 @@ best_linear_projection <- function(forest,
   }
 
   if (!is.null(A)) {
-    A <- as.matrix(A)
+    if (is.null(dim(A))) {
+      dim(A) <- c(length(A), 1L)
+    }
     if (nrow(A) == NROW(forest$Y.orig)) {
       A.subset <- A[subset, , drop = FALSE]
     } else if (nrow(A) == length(subset)) {

--- a/r-package/grf/man/best_linear_projection.Rd
+++ b/r-package/grf/man/best_linear_projection.Rd
@@ -55,7 +55,7 @@ covariates. This function provides a (doubly robust) fit to the linear model tau
 \details{
 Procedurally, we do so by regressing doubly robust scores derived from the
 forest against the Ai. Note the covariates Ai may consist of a subset of the Xi,
-or they may be distinct The case of the null model tau(Xi) ~ beta_0 is equivalent
+or they may be distinct. The case of the null model tau(Xi) ~ beta_0 is equivalent
 to fitting an average treatment effect via AIPW.
 
 In the event the treatment is continuous the inverse-propensity weight component of the


### PR DESCRIPTION
Minor fix which allows a user to pass an arbitrary data.frame `A` and have it behave as calling `lm` directly (that is, it will expand factor variables if present).