### PR TITLE
Clarify event grids in survival docstrings

### DIFF
--- a/r-package/grf/R/causal_survival_forest.R
+++ b/r-package/grf/R/causal_survival_forest.R
@@ -123,6 +123,9 @@
 #' # Predict on out-of-bag training samples.
 #' cs.pred <- predict(cs.forest)
 #'
+#' # Predict with confidence intervals; growing more trees is now recommended.
+#' c.pred <- predict(c.forest, X.test, estimate.variance = TRUE)
+#'
 #' # Compute a doubly robust estimate of the average treatment effect.
 #' average_treatment_effect(cs.forest)
 #'
@@ -407,6 +410,9 @@ causal_survival_forest <- function(X, Y, W, D,
 #'
 #' # Predict on out-of-bag training samples.
 #' cs.pred <- predict(cs.forest)
+#'
+#' # Predict with confidence intervals; growing more trees is now recommended.
+#' c.pred <- predict(c.forest, X.test, estimate.variance = TRUE)
 #'
 #' # Compute a doubly robust estimate of the average treatment effect.
 #' average_treatment_effect(cs.forest)

--- a/r-package/grf/R/causal_survival_forest.R
+++ b/r-package/grf/R/causal_survival_forest.R
@@ -124,7 +124,7 @@
 #' cs.pred <- predict(cs.forest)
 #'
 #' # Predict with confidence intervals; growing more trees is now recommended.
-#' c.pred <- predict(c.forest, X.test, estimate.variance = TRUE)
+#' c.pred <- predict(cs.forest, X.test, estimate.variance = TRUE)
 #'
 #' # Compute a doubly robust estimate of the average treatment effect.
 #' average_treatment_effect(cs.forest)
@@ -412,7 +412,7 @@ causal_survival_forest <- function(X, Y, W, D,
 #' cs.pred <- predict(cs.forest)
 #'
 #' # Predict with confidence intervals; growing more trees is now recommended.
-#' c.pred <- predict(c.forest, X.test, estimate.variance = TRUE)
+#' c.pred <- predict(cs.forest, X.test, estimate.variance = TRUE)
 #'
 #' # Compute a doubly robust estimate of the average treatment effect.
 #' average_treatment_effect(cs.forest)

--- a/r-package/grf/R/causal_survival_forest.R
+++ b/r-package/grf/R/causal_survival_forest.R
@@ -109,11 +109,11 @@
 #' censor.time <- 2 * runif(n)
 #' Y <- pmin(failure.time, censor.time)
 #' D <- as.integer(failure.time <= censor.time)
-#' # Constrain the event grid by discretizing continuous events.
-#' Y <- round(Y, 2)
-#' # Or by passing, for example:
-#' # failure.times <- seq(min(Y), max(Y), length.out = 150)
-#' cs.forest <- causal_survival_forest(X, Y, W, D, horizon = horizon)
+#' # Save computation time by constraining the event grid by discretizing (rounding) continuous events.
+#' cs.forest <- causal_survival_forest(X, round(Y, 2), W, D, horizon = horizon)
+#' # Or do so more flexibly by defining your own time grid using the failure.times argument.
+#' # grid <- seq(min(Y), max(Y), length.out = 150)
+#' # cs.forest <- causal_survival_forest(X, Y, W, D, horizon = horizon, failure.times = grid)
 #'
 #' # Predict using the forest.
 #' X.test <- matrix(0.5, 10, p)
@@ -398,11 +398,11 @@ causal_survival_forest <- function(X, Y, W, D,
 #' censor.time <- 2 * runif(n)
 #' Y <- pmin(failure.time, censor.time)
 #' D <- as.integer(failure.time <= censor.time)
-#' # Constrain the event grid by discretizing continuous events.
-#' Y <- round(Y, 2)
-#' # Or by passing, for example:
-#' # failure.times <- seq(min(Y), max(Y), length.out = 150)
-#' cs.forest <- causal_survival_forest(X, Y, W, D, horizon = horizon)
+#' # Save computation time by constraining the event grid by discretizing (rounding) continuous events.
+#' cs.forest <- causal_survival_forest(X, round(Y, 2), W, D, horizon = horizon)
+#' # Or do so more flexibly by defining your own time grid using the failure.times argument.
+#' # grid <- seq(min(Y), max(Y), length.out = 150)
+#' # cs.forest <- causal_survival_forest(X, Y, W, D, horizon = horizon, failure.times = grid)
 #'
 #' # Predict using the forest.
 #' X.test <- matrix(0.5, 10, p)

--- a/r-package/grf/R/causal_survival_forest.R
+++ b/r-package/grf/R/causal_survival_forest.R
@@ -107,9 +107,12 @@
 #' horizon <- 1
 #' failure.time <- pmin(rexp(n) * X[, 1] + W, horizon)
 #' censor.time <- 2 * runif(n)
-#' # Discretizing continuous events decreases runtime.
-#' Y <- round(pmin(failure.time, censor.time), 2)
+#' Y <- pmin(failure.time, censor.time)
 #' D <- as.integer(failure.time <= censor.time)
+#' # Constrain the event grid by discretizing continuous events.
+#' Y <- round(Y, 2)
+#' # Or by passing, for example:
+#' # failure.times <- seq(min(Y), max(Y), length.out = 150)
 #' cs.forest <- causal_survival_forest(X, Y, W, D, horizon = horizon)
 #'
 #' # Predict using the forest.
@@ -393,9 +396,12 @@ causal_survival_forest <- function(X, Y, W, D,
 #' horizon <- 1
 #' failure.time <- pmin(rexp(n) * X[, 1] + W, horizon)
 #' censor.time <- 2 * runif(n)
-#' # Discretizing continuous events decreases runtime.
-#' Y <- round(pmin(failure.time, censor.time), 2)
+#' Y <- pmin(failure.time, censor.time)
 #' D <- as.integer(failure.time <= censor.time)
+#' # Constrain the event grid by discretizing continuous events.
+#' Y <- round(Y, 2)
+#' # Or by passing, for example:
+#' # failure.times <- seq(min(Y), max(Y), length.out = 150)
 #' cs.forest <- causal_survival_forest(X, Y, W, D, horizon = horizon)
 #'
 #' # Predict using the forest.

--- a/r-package/grf/R/causal_survival_forest.R
+++ b/r-package/grf/R/causal_survival_forest.R
@@ -139,10 +139,6 @@
 #'                                       predict(train.forest, X[eval, ])$predictions)
 #' plot(rate)
 #' paste("AUTOC:", round(rate$estimate, 2), "+/", round(1.96 * rate$std.err, 2))
-#'
-#' # Train a causal survival forest targeting an absolute risk difference
-#' # at the median timepoint `horizon`.
-#' cs.forest.prob <- causal_survival_forest(X, Y, W, D, target = "survival.probability", horizon = 0.5)
 #' }
 #'
 #' @export
@@ -428,10 +424,6 @@ causal_survival_forest <- function(X, Y, W, D,
 #'                                       predict(train.forest, X[eval, ])$predictions)
 #' plot(rate)
 #' paste("AUTOC:", round(rate$estimate, 2), "+/", round(1.96 * rate$std.err, 2))
-#'
-#' # Train a causal survival forest targeting an absolute risk difference
-#' # at the median timepoint `horizon`.
-#' cs.forest.prob <- causal_survival_forest(X, Y, W, D, target = "survival.probability", horizon = 0.5)
 #' }
 #'
 #' @method predict causal_survival_forest

--- a/r-package/grf/R/survival_forest.R
+++ b/r-package/grf/R/survival_forest.R
@@ -72,11 +72,11 @@
 #' censor.time <- 2 * rexp(n)
 #' Y <- pmin(failure.time, censor.time)
 #' D <- as.integer(failure.time <= censor.time)
-#' # Constrain the event grid by discretizing continuous events.
-#' Y <- round(Y, 2)
-#' # Or by passing, for example:
-#' # failure.times <- seq(min(Y[D==1]), max(Y[D==1]), length.out = 150)
-#' s.forest <- survival_forest(X, Y, D)
+#' # Save computation time by constraining the event grid by discretizing (rounding) continuous events.
+#' s.forest <- survival_forest(X, round(Y, 2), D)
+#' # Or do so more flexibly by defining your own time grid using the failure.times argument.
+#' # grid <- seq(min(Y[D==1]), max(Y[D==1]), length.out = 150)
+#' # s.forest <- survival_forest(X, Y, D, failure.times = grid)
 #'
 #' # Predict using the forest.
 #' X.test <- matrix(0, 3, p)
@@ -228,11 +228,11 @@ survival_forest <- function(X, Y, D,
 #' censor.time <- 2 * rexp(n)
 #' Y <- pmin(failure.time, censor.time)
 #' D <- as.integer(failure.time <= censor.time)
-#' # Constrain the event grid by discretizing continuous events.
-#' Y <- round(Y, 2)
-#' # Or by passing, for example:
-#' # failure.times <- seq(min(Y[D==1]), max(Y[D==1]), length.out = 150)
-#' s.forest <- survival_forest(X, Y, D)
+#' # Save computation time by constraining the event grid by discretizing (rounding) continuous events.
+#' s.forest <- survival_forest(X, round(Y, 2), D)
+#' # Or do so more flexibly by defining your own time grid using the failure.times argument.
+#' # grid <- seq(min(Y[D==1]), max(Y[D==1]), length.out = 150)
+#' # s.forest <- survival_forest(X, Y, D, failure.times = grid)
 #'
 #' # Predict using the forest.
 #' X.test <- matrix(0, 3, p)

--- a/r-package/grf/R/survival_forest.R
+++ b/r-package/grf/R/survival_forest.R
@@ -72,6 +72,10 @@
 #' censor.time <- 2 * rexp(n)
 #' Y <- pmin(failure.time, censor.time)
 #' D <- as.integer(failure.time <= censor.time)
+#' # Constrain the event grid by discretizing continuous events.
+#' Y <- round(Y, 2)
+#' # Or by passing, for example:
+#' # failure.times <- seq(min(Y[D==1]), max(Y[D==1]), length.out = 150)
 #' s.forest <- survival_forest(X, Y, D)
 #'
 #' # Predict using the forest.
@@ -91,19 +95,6 @@
 #'
 #' # Predict on out-of-bag training samples.
 #' s.pred <- predict(s.forest)
-#'
-#' # Plot the survival curve for the first five individuals.
-#' matplot(s.pred$failure.times, t(s.pred$predictions[1:5, ]),
-#'         xlab = "failure time", ylab = "survival function (OOB)",
-#'         type = "l", lty = 1)
-#'
-#' # Train the forest on a less granular grid.
-#' failure.summary <- summary(Y[D == 1])
-#' events <- seq(failure.summary["Min."], failure.summary["Max."], by = 0.1)
-#' s.forest.grid <- survival_forest(X, Y, D, failure.times = events)
-#' s.pred.grid <- predict(s.forest.grid)
-#' matpoints(s.pred.grid$failure.times, t(s.pred.grid$predictions[1:5, ]),
-#'           type = "l", lty = 2)
 #'
 #' # Compute OOB concordance based on the mortality score in Ishwaran et al. (2008).
 #' s.pred.nelson.aalen <- predict(s.forest, prediction.type = "Nelson-Aalen")
@@ -237,6 +228,10 @@ survival_forest <- function(X, Y, D,
 #' censor.time <- 2 * rexp(n)
 #' Y <- pmin(failure.time, censor.time)
 #' D <- as.integer(failure.time <= censor.time)
+#' # Constrain the event grid by discretizing continuous events.
+#' Y <- round(Y, 2)
+#' # Or by passing, for example:
+#' # failure.times <- seq(min(Y[D==1]), max(Y[D==1]), length.out = 150)
 #' s.forest <- survival_forest(X, Y, D)
 #'
 #' # Predict using the forest.
@@ -256,19 +251,6 @@ survival_forest <- function(X, Y, D,
 #'
 #' # Predict on out-of-bag training samples.
 #' s.pred <- predict(s.forest)
-#'
-#' # Plot the survival curve for the first five individuals.
-#' matplot(s.pred$failure.times, t(s.pred$predictions[1:5, ]),
-#'         xlab = "failure time", ylab = "survival function (OOB)",
-#'         type = "l", lty = 1)
-#'
-#' # Train the forest on a less granular grid.
-#' failure.summary <- summary(Y[D == 1])
-#' events <- seq(failure.summary["Min."], failure.summary["Max."], by = 0.1)
-#' s.forest.grid <- survival_forest(X, Y, D, failure.times = events)
-#' s.pred.grid <- predict(s.forest.grid)
-#' matpoints(s.pred.grid$failure.times, t(s.pred.grid$predictions[1:5, ]),
-#'           type = "l", lty = 2)
 #'
 #' # Compute OOB concordance based on the mortality score in Ishwaran et al. (2008).
 #' s.pred.nelson.aalen <- predict(s.forest, prediction.type = "Nelson-Aalen")

--- a/r-package/grf/man/causal_survival_forest.Rd
+++ b/r-package/grf/man/causal_survival_forest.Rd
@@ -181,7 +181,7 @@ cs.pred <- predict(cs.forest, X.test)
 cs.pred <- predict(cs.forest)
 
 # Predict with confidence intervals; growing more trees is now recommended.
-c.pred <- predict(c.forest, X.test, estimate.variance = TRUE)
+c.pred <- predict(cs.forest, X.test, estimate.variance = TRUE)
 
 # Compute a doubly robust estimate of the average treatment effect.
 average_treatment_effect(cs.forest)

--- a/r-package/grf/man/causal_survival_forest.Rd
+++ b/r-package/grf/man/causal_survival_forest.Rd
@@ -180,6 +180,9 @@ cs.pred <- predict(cs.forest, X.test)
 # Predict on out-of-bag training samples.
 cs.pred <- predict(cs.forest)
 
+# Predict with confidence intervals; growing more trees is now recommended.
+c.pred <- predict(c.forest, X.test, estimate.variance = TRUE)
+
 # Compute a doubly robust estimate of the average treatment effect.
 average_treatment_effect(cs.forest)
 

--- a/r-package/grf/man/causal_survival_forest.Rd
+++ b/r-package/grf/man/causal_survival_forest.Rd
@@ -164,9 +164,12 @@ W <- rbinom(n, 1, 0.5)
 horizon <- 1
 failure.time <- pmin(rexp(n) * X[, 1] + W, horizon)
 censor.time <- 2 * runif(n)
-# Discretizing continuous events decreases runtime.
-Y <- round(pmin(failure.time, censor.time), 2)
+Y <- pmin(failure.time, censor.time)
 D <- as.integer(failure.time <= censor.time)
+# Constrain the event grid by discretizing continuous events.
+Y <- round(Y, 2)
+# Or by passing, for example:
+# failure.times <- seq(min(Y), max(Y), length.out = 150)
 cs.forest <- causal_survival_forest(X, Y, W, D, horizon = horizon)
 
 # Predict using the forest.

--- a/r-package/grf/man/causal_survival_forest.Rd
+++ b/r-package/grf/man/causal_survival_forest.Rd
@@ -166,11 +166,11 @@ failure.time <- pmin(rexp(n) * X[, 1] + W, horizon)
 censor.time <- 2 * runif(n)
 Y <- pmin(failure.time, censor.time)
 D <- as.integer(failure.time <= censor.time)
-# Constrain the event grid by discretizing continuous events.
-Y <- round(Y, 2)
-# Or by passing, for example:
-# failure.times <- seq(min(Y), max(Y), length.out = 150)
-cs.forest <- causal_survival_forest(X, Y, W, D, horizon = horizon)
+# Save computation time by constraining the event grid by discretizing (rounding) continuous events.
+cs.forest <- causal_survival_forest(X, round(Y, 2), W, D, horizon = horizon)
+# Or do so more flexibly by defining your own time grid using the failure.times argument.
+# grid <- seq(min(Y), max(Y), length.out = 150)
+# cs.forest <- causal_survival_forest(X, Y, W, D, horizon = horizon, failure.times = grid)
 
 # Predict using the forest.
 X.test <- matrix(0.5, 10, p)

--- a/r-package/grf/man/causal_survival_forest.Rd
+++ b/r-package/grf/man/causal_survival_forest.Rd
@@ -196,10 +196,6 @@ rate <- rank_average_treatment_effect(eval.forest,
                                       predict(train.forest, X[eval, ])$predictions)
 plot(rate)
 paste("AUTOC:", round(rate$estimate, 2), "+/", round(1.96 * rate$std.err, 2))
-
-# Train a causal survival forest targeting an absolute risk difference
-# at the median timepoint `horizon`.
-cs.forest.prob <- causal_survival_forest(X, Y, W, D, target = "survival.probability", horizon = 0.5)
 }
 
 }

--- a/r-package/grf/man/predict.causal_survival_forest.Rd
+++ b/r-package/grf/man/predict.causal_survival_forest.Rd
@@ -46,9 +46,12 @@ W <- rbinom(n, 1, 0.5)
 horizon <- 1
 failure.time <- pmin(rexp(n) * X[, 1] + W, horizon)
 censor.time <- 2 * runif(n)
-# Discretizing continuous events decreases runtime.
-Y <- round(pmin(failure.time, censor.time), 2)
+Y <- pmin(failure.time, censor.time)
 D <- as.integer(failure.time <= censor.time)
+# Constrain the event grid by discretizing continuous events.
+Y <- round(Y, 2)
+# Or by passing, for example:
+# failure.times <- seq(min(Y), max(Y), length.out = 150)
 cs.forest <- causal_survival_forest(X, Y, W, D, horizon = horizon)
 
 # Predict using the forest.

--- a/r-package/grf/man/predict.causal_survival_forest.Rd
+++ b/r-package/grf/man/predict.causal_survival_forest.Rd
@@ -78,10 +78,6 @@ rate <- rank_average_treatment_effect(eval.forest,
                                       predict(train.forest, X[eval, ])$predictions)
 plot(rate)
 paste("AUTOC:", round(rate$estimate, 2), "+/", round(1.96 * rate$std.err, 2))
-
-# Train a causal survival forest targeting an absolute risk difference
-# at the median timepoint `horizon`.
-cs.forest.prob <- causal_survival_forest(X, Y, W, D, target = "survival.probability", horizon = 0.5)
 }
 
 }

--- a/r-package/grf/man/predict.causal_survival_forest.Rd
+++ b/r-package/grf/man/predict.causal_survival_forest.Rd
@@ -48,11 +48,11 @@ failure.time <- pmin(rexp(n) * X[, 1] + W, horizon)
 censor.time <- 2 * runif(n)
 Y <- pmin(failure.time, censor.time)
 D <- as.integer(failure.time <= censor.time)
-# Constrain the event grid by discretizing continuous events.
-Y <- round(Y, 2)
-# Or by passing, for example:
-# failure.times <- seq(min(Y), max(Y), length.out = 150)
-cs.forest <- causal_survival_forest(X, Y, W, D, horizon = horizon)
+# Save computation time by constraining the event grid by discretizing (rounding) continuous events.
+cs.forest <- causal_survival_forest(X, round(Y, 2), W, D, horizon = horizon)
+# Or do so more flexibly by defining your own time grid using the failure.times argument.
+# grid <- seq(min(Y), max(Y), length.out = 150)
+# cs.forest <- causal_survival_forest(X, Y, W, D, horizon = horizon, failure.times = grid)
 
 # Predict using the forest.
 X.test <- matrix(0.5, 10, p)

--- a/r-package/grf/man/predict.causal_survival_forest.Rd
+++ b/r-package/grf/man/predict.causal_survival_forest.Rd
@@ -63,7 +63,7 @@ cs.pred <- predict(cs.forest, X.test)
 cs.pred <- predict(cs.forest)
 
 # Predict with confidence intervals; growing more trees is now recommended.
-c.pred <- predict(c.forest, X.test, estimate.variance = TRUE)
+c.pred <- predict(cs.forest, X.test, estimate.variance = TRUE)
 
 # Compute a doubly robust estimate of the average treatment effect.
 average_treatment_effect(cs.forest)

--- a/r-package/grf/man/predict.causal_survival_forest.Rd
+++ b/r-package/grf/man/predict.causal_survival_forest.Rd
@@ -62,6 +62,9 @@ cs.pred <- predict(cs.forest, X.test)
 # Predict on out-of-bag training samples.
 cs.pred <- predict(cs.forest)
 
+# Predict with confidence intervals; growing more trees is now recommended.
+c.pred <- predict(c.forest, X.test, estimate.variance = TRUE)
+
 # Compute a doubly robust estimate of the average treatment effect.
 average_treatment_effect(cs.forest)
 

--- a/r-package/grf/man/predict.survival_forest.Rd
+++ b/r-package/grf/man/predict.survival_forest.Rd
@@ -62,11 +62,11 @@ failure.time <- exp(0.5 * X[, 1]) * rexp(n)
 censor.time <- 2 * rexp(n)
 Y <- pmin(failure.time, censor.time)
 D <- as.integer(failure.time <= censor.time)
-# Constrain the event grid by discretizing continuous events.
-Y <- round(Y, 2)
-# Or by passing, for example:
-# failure.times <- seq(min(Y[D==1]), max(Y[D==1]), length.out = 150)
-s.forest <- survival_forest(X, Y, D)
+# Save computation time by constraining the event grid by discretizing (rounding) continuous events.
+s.forest <- survival_forest(X, round(Y, 2), D)
+# Or do so more flexibly by defining your own time grid using the failure.times argument.
+# grid <- seq(min(Y[D==1]), max(Y[D==1]), length.out = 150)
+# s.forest <- survival_forest(X, Y, D, failure.times = grid)
 
 # Predict using the forest.
 X.test <- matrix(0, 3, p)

--- a/r-package/grf/man/predict.survival_forest.Rd
+++ b/r-package/grf/man/predict.survival_forest.Rd
@@ -62,6 +62,10 @@ failure.time <- exp(0.5 * X[, 1]) * rexp(n)
 censor.time <- 2 * rexp(n)
 Y <- pmin(failure.time, censor.time)
 D <- as.integer(failure.time <= censor.time)
+# Constrain the event grid by discretizing continuous events.
+Y <- round(Y, 2)
+# Or by passing, for example:
+# failure.times <- seq(min(Y[D==1]), max(Y[D==1]), length.out = 150)
 s.forest <- survival_forest(X, Y, D)
 
 # Predict using the forest.
@@ -81,19 +85,6 @@ for(i in 1:3) {
 
 # Predict on out-of-bag training samples.
 s.pred <- predict(s.forest)
-
-# Plot the survival curve for the first five individuals.
-matplot(s.pred$failure.times, t(s.pred$predictions[1:5, ]),
-        xlab = "failure time", ylab = "survival function (OOB)",
-        type = "l", lty = 1)
-
-# Train the forest on a less granular grid.
-failure.summary <- summary(Y[D == 1])
-events <- seq(failure.summary["Min."], failure.summary["Max."], by = 0.1)
-s.forest.grid <- survival_forest(X, Y, D, failure.times = events)
-s.pred.grid <- predict(s.forest.grid)
-matpoints(s.pred.grid$failure.times, t(s.pred.grid$predictions[1:5, ]),
-          type = "l", lty = 2)
 
 # Compute OOB concordance based on the mortality score in Ishwaran et al. (2008).
 s.pred.nelson.aalen <- predict(s.forest, prediction.type = "Nelson-Aalen")

--- a/r-package/grf/man/survival_forest.Rd
+++ b/r-package/grf/man/survival_forest.Rd
@@ -113,6 +113,10 @@ failure.time <- exp(0.5 * X[, 1]) * rexp(n)
 censor.time <- 2 * rexp(n)
 Y <- pmin(failure.time, censor.time)
 D <- as.integer(failure.time <= censor.time)
+# Constrain the event grid by discretizing continuous events.
+Y <- round(Y, 2)
+# Or by passing, for example:
+# failure.times <- seq(min(Y[D==1]), max(Y[D==1]), length.out = 150)
 s.forest <- survival_forest(X, Y, D)
 
 # Predict using the forest.
@@ -132,19 +136,6 @@ for(i in 1:3) {
 
 # Predict on out-of-bag training samples.
 s.pred <- predict(s.forest)
-
-# Plot the survival curve for the first five individuals.
-matplot(s.pred$failure.times, t(s.pred$predictions[1:5, ]),
-        xlab = "failure time", ylab = "survival function (OOB)",
-        type = "l", lty = 1)
-
-# Train the forest on a less granular grid.
-failure.summary <- summary(Y[D == 1])
-events <- seq(failure.summary["Min."], failure.summary["Max."], by = 0.1)
-s.forest.grid <- survival_forest(X, Y, D, failure.times = events)
-s.pred.grid <- predict(s.forest.grid)
-matpoints(s.pred.grid$failure.times, t(s.pred.grid$predictions[1:5, ]),
-          type = "l", lty = 2)
 
 # Compute OOB concordance based on the mortality score in Ishwaran et al. (2008).
 s.pred.nelson.aalen <- predict(s.forest, prediction.type = "Nelson-Aalen")

--- a/r-package/grf/man/survival_forest.Rd
+++ b/r-package/grf/man/survival_forest.Rd
@@ -113,11 +113,11 @@ failure.time <- exp(0.5 * X[, 1]) * rexp(n)
 censor.time <- 2 * rexp(n)
 Y <- pmin(failure.time, censor.time)
 D <- as.integer(failure.time <= censor.time)
-# Constrain the event grid by discretizing continuous events.
-Y <- round(Y, 2)
-# Or by passing, for example:
-# failure.times <- seq(min(Y[D==1]), max(Y[D==1]), length.out = 150)
-s.forest <- survival_forest(X, Y, D)
+# Save computation time by constraining the event grid by discretizing (rounding) continuous events.
+s.forest <- survival_forest(X, round(Y, 2), D)
+# Or do so more flexibly by defining your own time grid using the failure.times argument.
+# grid <- seq(min(Y[D==1]), max(Y[D==1]), length.out = 150)
+# s.forest <- survival_forest(X, Y, D, failure.times = grid)
 
 # Predict using the forest.
 X.test <- matrix(0, 3, p)


### PR DESCRIPTION
Do some minor enhancements to survival docstrings by highlighting the role of the event grid, removing some unnecessary examples, + add CI example in CSF.