### PR TITLE
Use ubuntu-20.04 in clang/cpp checks

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ trigger:
 jobs:
 - job: coreCPP
   pool:
-    vmImage: "ubuntu-latest"
+    vmImage: "ubuntu-20.04" # bundled valgrind in ubuntu-latest breaks with clang (update to latest when available).
   strategy:
     matrix:
       clang:


### PR DESCRIPTION
The valgrind in ubuntu-latest breaks with clang (#1248). Use ubuntu-20 for now.