### PR TITLE
Add "overlap" option to best_linear_projection

### DIFF
--- a/r-package/grf/R/forest_summary.R
+++ b/r-package/grf/R/forest_summary.R
@@ -132,7 +132,7 @@ test_calibration <- function(forest, vcov.type = "HC3") {
 #'  (see MacKinnon & White for more discussion, and Cameron & Miller for a review).
 #'  For large data sets with clusters, "HC0" or "HC1" are significantly faster to compute.
 #' @param target.sample Which sample to compute the BLP over. The default is "all".
-#'  Option "overlap" uses weights equal to e(X)(1 - e(X)), where e(x) are estimates of.
+#'  Option "overlap" uses weights equal to e(X)(1 - e(X)), where e(x) are estimates of
 #'  the propensity score.
 #'
 #' @references Cameron, A. Colin, and Douglas L. Miller. "A practitioner's guide to

--- a/r-package/grf/R/forest_summary.R
+++ b/r-package/grf/R/forest_summary.R
@@ -132,7 +132,8 @@ test_calibration <- function(forest, vcov.type = "HC3") {
 #'  (see MacKinnon & White for more discussion, and Cameron & Miller for a review).
 #'  For large data sets with clusters, "HC0" or "HC1" are significantly faster to compute.
 #' @param target.sample Which sample to compute the BLP over. The default is "all".
-#'  Option "overlap" uses weights equal to e(X)(1 - e(X)), where e(x) = P[Wi = 1 | Xi = x].
+#'  Option "overlap" uses weights equal to e(X)(1 - e(X)), where e(x) are estimates of.
+#'  the propensity score.
 #'
 #' @references Cameron, A. Colin, and Douglas L. Miller. "A practitioner's guide to
 #'  cluster-robust inference." Journal of Human Resources 50, no. 2 (2015): 317-372.
@@ -182,7 +183,7 @@ best_linear_projection <- function(forest,
       overlap.weights <- forest$W.hat * (1 - forest$W.hat)
       # some overlap weights might be exactly zero, these are currently not handled correctly in
       # `sandwhich`'s SE calculation and we drop these units here.
-      subset <- intersect(subset, which(overlap.weights != 0))
+      subset <- intersect(subset, which(overlap.weights > .Machine$double.eps))
       subset.weights <- observation.weight[subset] * overlap.weights[subset]
     } else {
       stop("option `target.sample=overlap` is not supported for this forest type.")

--- a/r-package/grf/R/forest_summary.R
+++ b/r-package/grf/R/forest_summary.R
@@ -220,8 +220,12 @@ best_linear_projection <- function(forest,
   }
 
   if (any(c("causal_forest", "causal_survival_forest", "instrumental_forest") %in% class(forest))) {
-    DR.scores <- get_scores(forest, subset = subset, debiasing.weights = debiasing.weights,
-                            compliance.score = compliance.score, num.trees.for.weights = num.trees.for.weights)
+    .no.warnings <- function(func) func
+    if (any(c("causal_survival_forest") %in% class(forest))) {
+      .no.warnings <- function(func) suppressWarnings(func)
+    }
+    DR.scores <- .no.warnings(get_scores(forest, subset = subset, debiasing.weights = debiasing.weights,
+      compliance.score = compliance.score, num.trees.for.weights = num.trees.for.weights))
   } else {
     stop(paste0("`best_linear_projection` is only implemented for ",
       "`causal_forest`, `causal_survival_forest`, and `instrumental_forest`"))

--- a/r-package/grf/R/forest_summary.R
+++ b/r-package/grf/R/forest_summary.R
@@ -214,8 +214,8 @@ best_linear_projection <- function(forest,
         round(rng[1], 3), " and ", round(rng[2], 3),
         " and in particular get very close to 0 or 1.",
         " (using `target.sample=overlap`, or `subset` to filter data as in",
-        " Crump, Hotz, Imbens, and Mitnik (Biometrika, 2009) may be helpful.)"
-      ))
+        " Crump, Hotz, Imbens, and Mitnik (Biometrika, 2009) may be helpful)"
+      ), immediate. = TRUE)
     }
   }
 

--- a/r-package/grf/R/forest_summary.R
+++ b/r-package/grf/R/forest_summary.R
@@ -212,9 +212,9 @@ best_linear_projection <- function(forest,
       warning(paste0(
         "Estimated treatment propensities take values between ",
         round(rng[1], 3), " and ", round(rng[2], 3),
-        " and in particular get very close to 0 or 1.",
-        " (using `target.sample=overlap`, or `subset` to filter data as in",
-        " Crump, Hotz, Imbens, and Mitnik (Biometrika, 2009) may be helpful)"
+        " and in particular get very close to 0 or 1. ",
+        "In this case, using `target.sample=overlap`, or `subset` to filter data as in ",
+        "Crump, Hotz, Imbens, and Mitnik (Biometrika, 2009) may be helpful."
       ), immediate. = TRUE)
     }
   }

--- a/r-package/grf/R/forest_summary.R
+++ b/r-package/grf/R/forest_summary.R
@@ -183,7 +183,7 @@ best_linear_projection <- function(forest,
       # some overlap weights might be exactly zero, these are currently not handled correctly in
       # `sandwhich`'s SE calculation and we drop these units here.
       subset <- intersect(subset, which(overlap.weights != 0))
-      subset.weights <- overlap.weights[subset]
+      subset.weights <- observation.weight[subset] * overlap.weights[subset]
     } else {
       stop("option `target.sample=overlap` is not supported for this forest type.")
     }

--- a/r-package/grf/man/best_linear_projection.Rd
+++ b/r-package/grf/man/best_linear_projection.Rd
@@ -47,7 +47,8 @@ samples and corresponds to the "shortcut formula" for the jackknife
 For large data sets with clusters, "HC0" or "HC1" are significantly faster to compute.}
 
 \item{target.sample}{Which sample to compute the BLP over. The default is "all".
-Option "overlap" uses weights equal to e(X)(1 - e(X)), where e(x) = P[Wi = 1 | Xi = x].}
+Option "overlap" uses weights equal to e(X)(1 - e(X)), where e(x) are estimates of.
+the propensity score.}
 }
 \value{
 An estimate of the best linear projection, along with coefficient standard errors.

--- a/r-package/grf/man/best_linear_projection.Rd
+++ b/r-package/grf/man/best_linear_projection.Rd
@@ -11,7 +11,8 @@ best_linear_projection(
   debiasing.weights = NULL,
   compliance.score = NULL,
   num.trees.for.weights = 500,
-  vcov.type = "HC3"
+  vcov.type = "HC3",
+  target.sample = c("all", "overlap")
 )
 }
 \arguments{
@@ -44,6 +45,9 @@ options are HC0, ..., HC3. The default is "HC3", which is recommended in small
 samples and corresponds to the "shortcut formula" for the jackknife
 (see MacKinnon & White for more discussion, and Cameron & Miller for a review).
 For large data sets with clusters, "HC0" or "HC1" are significantly faster to compute.}
+
+\item{target.sample}{Which sample to compute the BLP over. The default is "all".
+Option "overlap" uses weights equal to e(X)(1 - e(X)), where e(x) = P[Wi = 1 | Xi = x].}
 }
 \value{
 An estimate of the best linear projection, along with coefficient standard errors.

--- a/r-package/grf/man/best_linear_projection.Rd
+++ b/r-package/grf/man/best_linear_projection.Rd
@@ -47,7 +47,7 @@ samples and corresponds to the "shortcut formula" for the jackknife
 For large data sets with clusters, "HC0" or "HC1" are significantly faster to compute.}
 
 \item{target.sample}{Which sample to compute the BLP over. The default is "all".
-Option "overlap" uses weights equal to e(X)(1 - e(X)), where e(x) are estimates of.
+Option "overlap" uses weights equal to e(X)(1 - e(X)), where e(x) are estimates of
 the propensity score.}
 }
 \value{

--- a/r-package/grf/tests/testthat/test_average_effect.R
+++ b/r-package/grf/tests/testthat/test_average_effect.R
@@ -229,8 +229,9 @@ test_that("average treatment effect with overlap: larger example works", {
   expect_equal(wate[[1]], tau.overlap, tolerance = 3 * wate[2])
 
   # Should be very similar to a best linear projection on a constant with target.sample = "overlap"
-  blp.wate <- best_linear_projection(forest, target.sample = "overlap")
-  expect_equal(blp.wate[1, 1], wate[[1]], tolerance = 0.1)
+  blp.wate <- best_linear_projection(forest.causal, target.sample = "overlap")
+  expect_equal(blp.wate[1, 1], wate[[1]], tolerance = 0.05)
+  expect_equal(blp.wate[1, 2], wate[[2]], tolerance = 0.05)
 })
 
 test_that("cluster robust average effects are consistent", {

--- a/r-package/grf/tests/testthat/test_average_effect.R
+++ b/r-package/grf/tests/testthat/test_average_effect.R
@@ -227,6 +227,10 @@ test_that("average treatment effect with overlap: larger example works", {
   tau.overlap <- sum(eX * (1 - eX) * TAU) / sum(eX * (1 - eX))
   expect_equal(wate[[1]], tau.overlap, tolerance = 0.2)
   expect_equal(wate[[1]], tau.overlap, tolerance = 3 * wate[2])
+
+  # Should be very similar to a best linear projection on a constant with target.sample = "overlap"
+  blp.wate <- best_linear_projection(forest, target.sample = "overlap")
+  expect_equal(blp.wate[1, 1], wate[[1]], tolerance = 0.1)
 })
 
 test_that("cluster robust average effects are consistent", {

--- a/r-package/grf/tests/testthat/test_forest_summaries.R
+++ b/r-package/grf/tests/testthat/test_forest_summaries.R
@@ -267,3 +267,64 @@ test_that("best linear projection works as expected with instrumental forest", {
   expect_equal(blp[, "Estimate"], ate[["estimate"]], tolerance = 1e-10)
   expect_equal(blp[, "Std. Error"], ate[["std.err"]], tolerance = 1e-4)
 })
+
+test_that("ground truth does better than forest-estimates of overlap weights", {
+  # A hard setup
+  n <- 1000
+  p <- 5
+  X <- matrix(rnorm(n * (p)), n, p)
+  eX <- 1 / (1 + exp(-10 * X[, 2]))
+  W <- rbinom(n, 1, eX)
+  M <- X[, 2]
+  TAU <- (1 + X[, 2])^2
+  Y <- M + (W - 0.5) * TAU + rnorm(n)
+
+  W.forest <- regression_forest(X, W)
+  W.hat.forest <- predict(W.forest)$predictions
+  suppressWarnings(W.lm <- glm(W ~ X, family = "binomial"))
+  W.hat.lm <- predict(W.lm, type = "response")
+
+  blp.true <- lm(TAU ~ X, weights = eX * (1 - eX))
+  blp.lm.wts <- lm(TAU ~ X, weights = W.hat.lm * (1 - W.hat.lm))
+  blp.forest.wts <- lm(TAU ~ X, weights = W.hat.forest * (1 - W.hat.forest))
+
+  expect_equal(coef(blp.lm.wts), coef(blp.true), tolerance = 0.1)
+  expect_equal(coef(blp.forest.wts), coef(blp.true), tolerance = 0.5)
+})
+
+test_that("overlap weighted best linear projection works as expected in a simple setup", {
+  n <- 1000
+  p <- 5
+  X <- matrix(rnorm(n * (p)), n, p)
+  eX <- 1 / (1 + exp(-3 * X[, 1]))
+  W <- rbinom(n, 1, eX)
+  TAU <- X[, 2]
+  Y <- X[, 1] + (W - 0.5) * TAU + rnorm(n)
+  true.blp <- lm(TAU ~ X, weights = eX * (1 - eX))
+
+  cf <- causal_forest(X, Y, W)
+  blp.wate <- best_linear_projection(cf, X, target.sample = "overlap")
+  expect_equal(blp.wate[3, 1], coef(true.blp)[[3]], tolerance = 3 * blp.wate[3, 2])
+
+  # TODO these SEs are not smaller than with overlap:
+  #suppressWarnings(blp <- best_linear_projection(cf, X))
+})
+
+test_that("causal forest overlap weighted BLP ~same as complete data causal survival BLP", {
+  n <- 1000
+  p <- 5
+  X <- matrix(runif(n * (p)), n, p)
+  eX <- 1 / (1 + exp(-3 * X[, 1]))
+  W <- rbinom(n, 1, eX)
+  TAU <- X[, 2]
+  Y <- X[, 1] + W * TAU + runif(n)
+
+  cf <- causal_forest(X, Y, W)
+  csf <- causal_survival_forest(X, Y, W, rep(1, n), W.hat = cf$W.hat, horizon = max(Y))
+
+  blp.cf <- best_linear_projection(cf, X, target.sample = "overlap")
+  suppressWarnings(blp.csf <- best_linear_projection(csf, X, target.sample = "overlap"))
+
+  expect_equal(blp.cf[, "Estimate"], blp.csf[, "Estimate"], tolerance = 0.05)
+  expect_equal(blp.cf[, "Std. Error"], blp.csf[, "Std. Error"], tolerance = 0.05)
+})

--- a/r-package/grf/tests/testthat/test_forest_summaries.R
+++ b/r-package/grf/tests/testthat/test_forest_summaries.R
@@ -306,8 +306,12 @@ test_that("overlap weighted best linear projection works as expected in a simple
   blp.wate <- best_linear_projection(cf, X, target.sample = "overlap")
   expect_equal(blp.wate[3, 1], coef(true.blp)[[3]], tolerance = 3 * blp.wate[3, 2])
 
-  # TODO these SEs are not smaller than with overlap:
-  #suppressWarnings(blp <- best_linear_projection(cf, X))
+  # The overlap-weighted SEs are on average smaller:
+  # https://github.com/grf-labs/grf/pull/1258#discussion_r1137992471
+
+  # suppressWarnings(blp <- best_linear_projection(cf, X))
+  # se.ratio <- blp.wate[, "Std. Error"] / blp[, "Std. Error"]
+  # expect_true(all(se.ratio < 0.95))
 })
 
 test_that("causal forest overlap weighted BLP ~same as complete data causal survival BLP", {

--- a/r-package/grf/tests/testthat/test_forest_summaries.R
+++ b/r-package/grf/tests/testthat/test_forest_summaries.R
@@ -327,7 +327,7 @@ test_that("causal forest overlap weighted BLP ~same as complete data causal surv
   csf <- causal_survival_forest(X, Y, W, rep(1, n), W.hat = cf$W.hat, horizon = max(Y))
 
   blp.cf <- best_linear_projection(cf, X, target.sample = "overlap")
-  suppressWarnings(blp.csf <- best_linear_projection(csf, X, target.sample = "overlap"))
+  blp.csf <- best_linear_projection(csf, X, target.sample = "overlap")
 
   expect_equal(blp.cf[, "Estimate"], blp.csf[, "Estimate"], tolerance = 0.05)
   expect_equal(blp.cf[, "Std. Error"], blp.csf[, "Std. Error"], tolerance = 0.05)


### PR DESCRIPTION
Add option `target.sample = c("all", "overlap")` to `best_linear_projection` which uses estimates of propensity scores to compute a BLP with weights = e(x)(1 - e(x)).

Until the next cran release: to use this option without recompiling grf from scratch, `source`-able [best_linear_projection.R](https://gist.github.com/erikcs/424b7ac84e7360d755760ca597d82d6e)