### PR TITLE
Assign random number seed independent of num_threads

### DIFF
--- a/core/src/forest/ForestTrainer.cpp
+++ b/core/src/forest/ForestTrainer.cpp
@@ -99,12 +99,13 @@ std::vector<std::unique_ptr<Tree>> ForestTrainer::train_batch(
     const ForestOptions& options) const {
   size_t ci_group_size = options.get_ci_group_size();
 
-  std::mt19937_64 random_number_generator(options.get_random_seed() + start);
+  std::mt19937_64 random_number_generator;
   nonstd::uniform_int_distribution<uint> udist;
   std::vector<std::unique_ptr<Tree>> trees;
   trees.reserve(num_trees * ci_group_size);
 
   for (size_t i = 0; i < num_trees; i++) {
+    random_number_generator.seed(options.get_random_seed() + start + i);
     uint tree_seed = udist(random_number_generator);
     RandomSampler sampler(tree_seed, options.get_sampling_options());
 


### PR DESCRIPTION
Addresses my comment in https://github.com/grf-labs/grf/issues/1262#issuecomment-1440227209

`ForestTrainer::train_trees` calls `split_sequence` to split the number of trees to grow into batches depending on the specified number of threads. However, when assigning a seed to grow an individual tree, only the batch index is considered, but not the tree index. Therefore, different values for the number of threads will yield different results, despite the user having specified the same (global) random number seed.

The patch initializes the random number generator based on the user provided seed and the index of the tree (`start + i`). Thus, each tree will be assigned the same seed, independent of the specified number of threads.