### PR TITLE
Add optional drop argument to predict.mgrf

### DIFF
--- a/r-package/grf/R/get_scores.R
+++ b/r-package/grf/R/get_scores.R
@@ -226,6 +226,7 @@ get_scores.instrumental_forest <- function(forest,
 #'               estimate the ATE. WARNING: For valid statistical performance,
 #'               the subset should be defined only using features Xi, not using
 #'               the treatment Wi or the outcome Yi.
+#' @param drop If TRUE, coerce the result to the lowest possible dimension. Default is FALSE.
 #' @param ... Additional arguments (currently ignored).
 #'
 #' @return An array of scores for each contrast and outcome.
@@ -234,6 +235,7 @@ get_scores.instrumental_forest <- function(forest,
 #' @export
 get_scores.multi_arm_causal_forest <- function(forest,
                                                subset = NULL,
+                                               drop = FALSE,
                                                ...) {
   subset <- validate_subset(forest, subset)
   W.orig <- forest$W.orig[subset]
@@ -281,7 +283,9 @@ get_scores.multi_arm_causal_forest <- function(forest,
 
   scores <- lapply(1:NCOL(forest$Y.orig), function(col) .get.scores(col))
 
-  array(unlist(scores), dim = c(length(subset), dim(forest.pp$predictions)[-1]), dimnames = dimnames(forest.pp$predictions))
+  array(unlist(scores),
+        dim = c(length(subset), dim(forest.pp$predictions)[-1]),
+        dimnames = dimnames(forest.pp$predictions))[, , , drop = drop]
 }
 
 #' Compute doubly robust scores for a causal survival forest.

--- a/r-package/grf/R/multi_regression_forest.R
+++ b/r-package/grf/R/multi_regression_forest.R
@@ -132,6 +132,7 @@ multi_regression_forest <- function(X, Y,
 #'                matrix, and that the columns must appear in the same order.
 #' @param num.threads Number of threads used in training. If set to NULL, the software
 #'                    automatically selects an appropriate amount.
+#' @param drop If TRUE, coerce the prediction result to the lowest possible dimension. Default is FALSE.
 #' @param ... Additional arguments (currently ignored).
 #'
 #' @return A list containing `predictions`: a matrix of predictions for each outcome.
@@ -159,6 +160,7 @@ multi_regression_forest <- function(X, Y,
 predict.multi_regression_forest <- function(object,
                                             newdata = NULL,
                                             num.threads = NULL,
+                                            drop = FALSE,
                                             ...) {
   outcome.names <- if (is.null(colnames(object[["Y.orig"]]))) {
     paste0("Y", 1:NCOL(object[["Y.orig"]]))
@@ -168,7 +170,7 @@ predict.multi_regression_forest <- function(object,
   # If possible, use pre-computed predictions.
   if (is.null(newdata) && !is.null(object$predictions)) {
     colnames(object$predictions) <- outcome.names
-    return(list(predictions = object$predictions))
+    return(list(predictions = object$predictions[, , drop = drop]))
   }
 
   num.threads <- validate_num_threads(num.threads)
@@ -189,5 +191,5 @@ predict.multi_regression_forest <- function(object,
   }
   colnames(ret$predictions) <- outcome.names
 
-  list(predictions = ret$predictions)
+  list(predictions = ret$predictions[, , drop = drop])
 }

--- a/r-package/grf/man/get_scores.multi_arm_causal_forest.Rd
+++ b/r-package/grf/man/get_scores.multi_arm_causal_forest.Rd
@@ -4,7 +4,7 @@
 \alias{get_scores.multi_arm_causal_forest}
 \title{Compute doubly robust scores for a multi arm causal forest.}
 \usage{
-\method{get_scores}{multi_arm_causal_forest}(forest, subset = NULL, ...)
+\method{get_scores}{multi_arm_causal_forest}(forest, subset = NULL, drop = FALSE, ...)
 }
 \arguments{
 \item{forest}{A trained multi arm causal forest.}
@@ -13,6 +13,8 @@
 estimate the ATE. WARNING: For valid statistical performance,
 the subset should be defined only using features Xi, not using
 the treatment Wi or the outcome Yi.}
+
+\item{drop}{If TRUE, coerce the result to the lowest possible dimension. Default is FALSE.}
 
 \item{...}{Additional arguments (currently ignored).}
 }

--- a/r-package/grf/man/multi_arm_causal_forest.Rd
+++ b/r-package/grf/man/multi_arm_causal_forest.Rd
@@ -165,13 +165,14 @@ Y <- X[, 1] + X[, 2] * (W == "B") - 1.5 * X[, 2] * (W == "C") + rnorm(n)
 mc.forest <- multi_arm_causal_forest(X, Y, W)
 
 # Predict contrasts (out-of-bag) using the forest.
-# By default, the first ordinal treatment is used as baseline ("A" in this example),
-# giving two contrasts tau_B = Y(B) - Y(A), tau_C = Y(C) - Y(A)
-mc.pred <- predict(mc.forest)
 # Fitting several outcomes jointly is supported, and the returned prediction array has
 # dimension [num.samples, num.contrasts, num.outcomes]. Since num.outcomes is one in
-# this example, we can `drop()` this singleton dimension using the `[,,]` shorthand.
-tau.hat <- mc.pred$predictions[,,]
+# this example, we use drop = TRUE to ignore this singleton dimension.
+mc.pred <- predict(mc.forest, drop = TRUE)
+
+# By default, the first ordinal treatment is used as baseline ("A" in this example),
+# giving two contrasts tau_B = Y(B) - Y(A), tau_C = Y(C) - Y(A)
+tau.hat <- mc.pred$predictions
 
 plot(X[, 2], tau.hat[, "B - A"], ylab = "tau.contrast")
 abline(0, 1, col = "red")

--- a/r-package/grf/man/predict.multi_arm_causal_forest.Rd
+++ b/r-package/grf/man/predict.multi_arm_causal_forest.Rd
@@ -9,6 +9,7 @@
   newdata = NULL,
   num.threads = NULL,
   estimate.variance = FALSE,
+  drop = FALSE,
   ...
 )
 }
@@ -27,6 +28,8 @@ automatically selects an appropriate amount.}
 \item{estimate.variance}{Whether variance estimates for hat{tau}(x) are desired
 (for confidence intervals). This option is currently
 only supported for univariate outcomes Y.}
+
+\item{drop}{If TRUE, coerce the prediction result to the lowest possible dimension. Default is FALSE.}
 
 \item{...}{Additional arguments (currently ignored).}
 }
@@ -51,13 +54,14 @@ Y <- X[, 1] + X[, 2] * (W == "B") - 1.5 * X[, 2] * (W == "C") + rnorm(n)
 mc.forest <- multi_arm_causal_forest(X, Y, W)
 
 # Predict contrasts (out-of-bag) using the forest.
-# By default, the first ordinal treatment is used as baseline ("A" in this example),
-# giving two contrasts tau_B = Y(B) - Y(A), tau_C = Y(C) - Y(A)
-mc.pred <- predict(mc.forest)
 # Fitting several outcomes jointly is supported, and the returned prediction array has
 # dimension [num.samples, num.contrasts, num.outcomes]. Since num.outcomes is one in
-# this example, we can `drop()` this singleton dimension using the `[,,]` shorthand.
-tau.hat <- mc.pred$predictions[,,]
+# this example, we use drop = TRUE to ignore this singleton dimension.
+mc.pred <- predict(mc.forest, drop = TRUE)
+
+# By default, the first ordinal treatment is used as baseline ("A" in this example),
+# giving two contrasts tau_B = Y(B) - Y(A), tau_C = Y(C) - Y(A)
+tau.hat <- mc.pred$predictions
 
 plot(X[, 2], tau.hat[, "B - A"], ylab = "tau.contrast")
 abline(0, 1, col = "red")

--- a/r-package/grf/man/predict.multi_regression_forest.Rd
+++ b/r-package/grf/man/predict.multi_regression_forest.Rd
@@ -4,7 +4,7 @@
 \alias{predict.multi_regression_forest}
 \title{Predict with a multi regression forest}
 \usage{
-\method{predict}{multi_regression_forest}(object, newdata = NULL, num.threads = NULL, ...)
+\method{predict}{multi_regression_forest}(object, newdata = NULL, num.threads = NULL, drop = FALSE, ...)
 }
 \arguments{
 \item{object}{The trained forest.}
@@ -17,6 +17,8 @@ matrix, and that the columns must appear in the same order.}
 
 \item{num.threads}{Number of threads used in training. If set to NULL, the software
 automatically selects an appropriate amount.}
+
+\item{drop}{If TRUE, coerce the prediction result to the lowest possible dimension. Default is FALSE.}
 
 \item{...}{Additional arguments (currently ignored).}
 }


### PR DESCRIPTION
`predict.multi_arm_causal_forest` by default returns an array with dimensions num.samples * num.arms - 1 * num.outcomes. Add an optional argument (FALSE by default) that drops this singleton dimension for cases when the forest is fit with one outcome.
