### PR TITLE
Request: make `causal_forest` keep the RF's used to make Y.hat and W.hat

### DIFF
--- a/r-package/grf/R/causal_forest.R
+++ b/r-package/grf/R/causal_forest.R
@@ -203,6 +203,7 @@ causal_forest <- function(X, Y, W,
                       num.threads = num.threads,
                       seed = seed)
 
+  forest.Y <- NULL
   if (is.null(Y.hat)) {
     forest.Y <- do.call(regression_forest, c(Y = list(Y), args.orthog))
     Y.hat <- predict(forest.Y)$predictions
@@ -212,6 +213,7 @@ causal_forest <- function(X, Y, W,
     stop("Y.hat has incorrect length.")
   }
 
+  forest.W <- NULL
   if (is.null(W.hat)) {
     forest.W <- do.call(regression_forest, c(Y = list(W), args.orthog))
     W.hat <- predict(forest.W)$predictions
@@ -275,7 +277,9 @@ causal_forest <- function(X, Y, W,
   forest[["X.orig"]] <- X
   forest[["Y.orig"]] <- Y
   forest[["W.orig"]] <- W
+  forest[["forest.Y"]] <- forest.Y
   forest[["Y.hat"]] <- Y.hat
+  forest[["forest.W"]] <- forest.W
   forest[["W.hat"]] <- W.hat
   forest[["clusters"]] <- clusters
   forest[["equalize.cluster.weights"]] <- equalize.cluster.weights


### PR DESCRIPTION
Hi all, 

Thanks for such a great package! I imagine you all have considered this already, but would you consider making the `causal_forest` function also return the regression forests used to predict Y.hat and W.hat?  

I've written a pull request to implement this. The forests now have the fields 'forest.Y' and 'forest.W', which are the regression forests used to fit the nuisance parameters. If the forests are not trained, these fields are set to NULL. 

As I see it, the change would have the following effects: 

## Pros:
* Allows users to investigate / evaluate the fit of the forests fit to predict y.hat and w.hat
* Would allow the `conditional_means.causal_forest` and `double_robust_scores.causal_forest` to be extended to predict new conditional means / scores for unseen data. 

## Cons: 
* Would increase the size / memory usage of the causal forests. 