### PR TITLE
Allow continuous treatment in causal_survival_forest

### DIFF
--- a/r-package/grf/R/causal_survival_forest.R
+++ b/r-package/grf/R/causal_survival_forest.R
@@ -12,7 +12,7 @@
 #' The causal survival forest paper defines the survival function in the 2nd estimand with weak inequality.
 #' It is defined using strict inequality in the R package (note that P[T >= h] = P[T > h - epsilon]).
 #' When W is continuous, we effectively estimate an average partial effect corresponding to
-#' 1) Cov[min(T, horizon) | X = x] / Var[W | X = x] or 2) Cov[1(T > horizon) | X = x] / Var[W | X = x],
+#' 1) Cov[min(T, horizon), W | X = x] / Var[W | X = x] or 2) Cov[1(T > horizon), W | X = x] / Var[W | X = x],
 #' and interpret it as a treatment effect given unconfoundedness.
 #'
 #' @param X The covariates.

--- a/r-package/grf/R/causal_survival_forest.R
+++ b/r-package/grf/R/causal_survival_forest.R
@@ -14,7 +14,7 @@
 #'
 #' @param X The covariates.
 #' @param Y The event time (must be non-negative).
-#' @param W The treatment assignment (must be a binary vector with no NAs).
+#' @param W The treatment assignment (must be a binary or real numeric vector with no NAs).
 #' @param D The event type (0: censored, 1: failure).
 #' @param W.hat Estimates of the treatment propensities E[W | X = x]. If W.hat = NULL,
 #'              these are estimated using a separate regression forest. Default is NULL.

--- a/r-package/grf/R/causal_survival_forest.R
+++ b/r-package/grf/R/causal_survival_forest.R
@@ -12,7 +12,7 @@
 #' The causal survival forest paper defines the survival function in the 2nd estimand with weak inequality.
 #' It is defined using strict inequality in the R package (note that P(T >= h) = P(T > h - epsilon)).
 #' When W is continuous, we effectively estimate an average partial effect corresponding to
-#' 1) Cov[min(T, horizon) | X = x] / Var[W | X = x] or 2) Cov[1\{T > horizon\} | X = x] / Var[W | X = x].
+#' 1) Cov[min(T, horizon) | X = x] / Var[W | X = x] or 2) Cov[1(T > horizon) | X = x] / Var[W | X = x].
 #'
 #' @param X The covariates.
 #' @param Y The event time (must be non-negative).

--- a/r-package/grf/R/causal_survival_forest.R
+++ b/r-package/grf/R/causal_survival_forest.R
@@ -11,6 +11,8 @@
 #'
 #' The causal survival forest paper defines the survival function in the 2nd estimand with weak inequality.
 #' It is defined using strict inequality in the R package (note that P(T >= h) = P(T > h - epsilon)).
+#' When W is continuous, we effectively estimate an average partial effect corresponding to
+#' 1) Cov[min(T, horizon) | X = x] / Var[W | X = x] or 2) Cov[1\{T > horizon\} | X = x] / Var[W | X = x].
 #'
 #' @param X The covariates.
 #' @param Y The event time (must be non-negative).

--- a/r-package/grf/R/causal_survival_forest.R
+++ b/r-package/grf/R/causal_survival_forest.R
@@ -217,7 +217,6 @@ causal_survival_forest <- function(X, Y, W, D,
                    "censoring curves, consider discretizing the event values `Y` or ",
                    "supplying a coarser grid with the `failure.times` argument. "), immediate. = TRUE)
   }
-  binary.W <- all(W %in% c(0, 1))
 
   if (is.null(W.hat)) {
     forest.W <- regression_forest(X, W, num.trees = max(50, num.trees / 4),
@@ -263,6 +262,7 @@ causal_survival_forest <- function(X, Y, W, D,
   # (for this to work W has to be binary).
   sf.survival <- do.call(survival_forest, c(list(X = cbind(X, W), Y = Y, D = D), args.nuisance))
 
+  binary.W <- all(W %in% c(0, 1))
   if (binary.W) {
     # The survival function conditioning on being treated S(t, x, 1) estimated with an "S-learner".
     # Computing OOB estimates for modified training samples is not a workflow we have implemented,

--- a/r-package/grf/R/causal_survival_forest.R
+++ b/r-package/grf/R/causal_survival_forest.R
@@ -12,7 +12,8 @@
 #' The causal survival forest paper defines the survival function in the 2nd estimand with weak inequality.
 #' It is defined using strict inequality in the R package (note that P[T >= h] = P[T > h - epsilon]).
 #' When W is continuous, we effectively estimate an average partial effect corresponding to
-#' 1) Cov[min(T, horizon) | X = x] / Var[W | X = x] or 2) Cov[1(T > horizon) | X = x] / Var[W | X = x].
+#' 1) Cov[min(T, horizon) | X = x] / Var[W | X = x] or 2) Cov[1(T > horizon) | X = x] / Var[W | X = x],
+#' and interpret it as a treatment effect given unconfoundedness.
 #'
 #' @param X The covariates.
 #' @param Y The event time (must be non-negative).

--- a/r-package/grf/R/get_scores.R
+++ b/r-package/grf/R/get_scores.R
@@ -317,7 +317,6 @@ get_scores.causal_survival_forest <- function(forest,
   psi <- numerator - denominator * cate.hat
 
   binary.W <- all(forest$W.orig %in% c(0, 1))
-
   if (binary.W) {
     if (min(forest$W.hat[subset]) <= 0.05 || max(forest$W.hat[subset]) >= 0.95) {
       rng <- range(forest$W.hat[subset])
@@ -328,12 +327,10 @@ get_scores.causal_survival_forest <- function(forest,
         ", meaning some estimates may not be well identified."
       ))
     }
-  }
-
-  if (binary.W) {
     W.hat <- forest$W.hat[subset]
     V.hat <- W.hat * (1 - W.hat)
   } else {
+    # Estimate Var[W | X = x], as in get_scores.causal_forest.
     clusters <- if (length(forest$clusters) > 0) {
       forest$clusters
     } else {

--- a/r-package/grf/man/causal_survival_forest.Rd
+++ b/r-package/grf/man/causal_survival_forest.Rd
@@ -153,7 +153,8 @@ tau(X) = P[T(1) > horizon | X = x] - P[T(0) > horizon | X = x], for a chosen tim
 The causal survival forest paper defines the survival function in the 2nd estimand with weak inequality.
 It is defined using strict inequality in the R package (note that P[T >= h] = P[T > h - epsilon]).
 When W is continuous, we effectively estimate an average partial effect corresponding to
-1) Cov[min(T, horizon) | X = x] / Var[W | X = x] or 2) Cov[1(T > horizon) | X = x] / Var[W | X = x].
+1) Cov[min(T, horizon) | X = x] / Var[W | X = x] or 2) Cov[1(T > horizon) | X = x] / Var[W | X = x],
+and interpret it as a treatment effect given unconfoundedness.
 }
 \examples{
 \donttest{

--- a/r-package/grf/man/causal_survival_forest.Rd
+++ b/r-package/grf/man/causal_survival_forest.Rd
@@ -153,7 +153,7 @@ tau(X) = P[T(1) > horizon | X = x] - P[T(0) > horizon | X = x], for a chosen tim
 The causal survival forest paper defines the survival function in the 2nd estimand with weak inequality.
 It is defined using strict inequality in the R package (note that P[T >= h] = P[T > h - epsilon]).
 When W is continuous, we effectively estimate an average partial effect corresponding to
-1) Cov[min(T, horizon) | X = x] / Var[W | X = x] or 2) Cov[1(T > horizon) | X = x] / Var[W | X = x],
+1) Cov[min(T, horizon), W | X = x] / Var[W | X = x] or 2) Cov[1(T > horizon), W | X = x] / Var[W | X = x],
 and interpret it as a treatment effect given unconfoundedness.
 }
 \examples{

--- a/r-package/grf/man/causal_survival_forest.Rd
+++ b/r-package/grf/man/causal_survival_forest.Rd
@@ -38,7 +38,7 @@ causal_survival_forest(
 
 \item{Y}{The event time (must be non-negative).}
 
-\item{W}{The treatment assignment (must be a binary vector with no NAs).}
+\item{W}{The treatment assignment (must be a binary or real numeric vector with no NAs).}
 
 \item{D}{The event type (0: censored, 1: failure).}
 

--- a/r-package/grf/man/causal_survival_forest.Rd
+++ b/r-package/grf/man/causal_survival_forest.Rd
@@ -153,7 +153,7 @@ tau(X) = P(T(1) > horizon | X = x) - P(T(0) > horizon | X = x), for a chosen tim
 The causal survival forest paper defines the survival function in the 2nd estimand with weak inequality.
 It is defined using strict inequality in the R package (note that P(T >= h) = P(T > h - epsilon)).
 When W is continuous, we effectively estimate an average partial effect corresponding to
-1) Cov[min(T, horizon) | X = x] / Var[W | X = x] or 2) Cov[1\{T > horizon\} | X = x] / Var[W | X = x].
+1) Cov[min(T, horizon) | X = x] / Var[W | X = x] or 2) Cov[1(T > horizon) | X = x] / Var[W | X = x].
 }
 \examples{
 \donttest{

--- a/r-package/grf/man/causal_survival_forest.Rd
+++ b/r-package/grf/man/causal_survival_forest.Rd
@@ -152,6 +152,8 @@ tau(X) = P(T(1) > horizon | X = x) - P(T(0) > horizon | X = x), for a chosen tim
 \details{
 The causal survival forest paper defines the survival function in the 2nd estimand with weak inequality.
 It is defined using strict inequality in the R package (note that P(T >= h) = P(T > h - epsilon)).
+When W is continuous, we effectively estimate an average partial effect corresponding to
+1) Cov[min(T, horizon) | X = x] / Var[W | X = x] or 2) Cov[1\{T > horizon\} | X = x] / Var[W | X = x].
 }
 \examples{
 \donttest{

--- a/r-package/grf/man/get_scores.causal_survival_forest.Rd
+++ b/r-package/grf/man/get_scores.causal_survival_forest.Rd
@@ -4,7 +4,7 @@
 \alias{get_scores.causal_survival_forest}
 \title{Compute doubly robust scores for a causal survival forest.}
 \usage{
-\method{get_scores}{causal_survival_forest}(forest, subset = NULL, ...)
+\method{get_scores}{causal_survival_forest}(forest, subset = NULL, num.trees.for.weights = 500, ...)
 }
 \arguments{
 \item{forest}{A trained causal survival forest.}
@@ -13,6 +13,10 @@
 estimate the ATE. WARNING: For valid statistical performance,
 the subset should be defined only using features Xi, not using
 the treatment Wi or the outcome Yi.}
+
+\item{num.trees.for.weights}{Number of trees used to estimate Var[W | X = x]. Note: this
+argument is only used in the case of a continuous treatment
+(see \code{\link{get_scores.causal_forest}} for details).}
 
 \item{...}{Additional arguments (currently ignored).}
 }

--- a/r-package/grf/tests/testthat/test_causal_survival_forest.R
+++ b/r-package/grf/tests/testthat/test_causal_survival_forest.R
@@ -326,6 +326,21 @@ test_that("causal survival forest for partial effect estimation works as expecte
   csf <- suppressWarnings(causal_survival_forest(X, Y, W, D, horizon = max(Y)))
   ate <- average_treatment_effect(csf)
   expect_equal(ate[["estimate"]], mean(tau), tolerance = 3 * ate[["std.err"]])
+
+  # a complete-data CSF is ~same as CF
+  p <- 6
+  n <- 1000
+  X <- matrix(2 * runif(n * p) - 1, n, p)
+  W <- rbinom(n, 1, 0.5) + abs(rnorm(n))
+  TAU <- 4 * (X[, 1] > 0)
+  Y <- TAU * W + runif(n)
+
+  cf <- causal_forest(X, Y, W, num.trees = 500)
+  csf.complete <- causal_survival_forest(X, Y, W, rep(1, n), horizon = max(Y), num.trees = 500)
+  ate.cf <- average_treatment_effect(cf)
+  ate.csf.complete <- average_treatment_effect(csf.complete)
+  expect_equal(ate.cf[[1]], ate.csf.complete[[1]], tolerance = 0.02)
+  expect_equal(ate.cf[[2]], ate.csf.complete[[2]], tolerance = 0.005)
 })
 
 test_that("causal survival forest utility functions are internally consistent", {

--- a/r-package/grf/tests/testthat/test_causal_survival_forest.R
+++ b/r-package/grf/tests/testthat/test_causal_survival_forest.R
@@ -291,17 +291,17 @@ test_that("causal survival forest for partial effect estimation works as expecte
   cs.forest.ape <- causal_survival_forest(X, Y, W, D, horizon = data$Y.max, num.trees = 500)
   cs.forest.prob.ape <- causal_survival_forest(X, Y, W, D, target = "survival.probability",
                                                horizon = data$y0, num.trees = 500)
-  expect_equal(cs.forest$predictions, cs.forest.ape$predictions, tolerance = 0.025)
-  expect_equal(cs.forest.prob$predictions, cs.forest.prob.ape$predictions, tolerance = 0.025)
+  expect_equal(cs.forest$predictions, cs.forest.ape$predictions, tolerance = 0.035)
+  expect_equal(cs.forest.prob$predictions, cs.forest.prob.ape$predictions, tolerance = 0.035)
 
   ate <- average_treatment_effect(cs.forest)
   ate.ape <- average_treatment_effect(cs.forest.ape)
   ate.prob <- average_treatment_effect(cs.forest.prob)
   ate.prob.ape <- average_treatment_effect(cs.forest.prob.ape)
-  expect_equal(ate[1], ate.ape[1], tolerance = 0.01)
-  expect_equal(ate[2], ate.ape[2], tolerance = 0.001)
-  expect_equal(ate.prob[1], ate.prob.ape[1], tolerance = 0.01)
-  expect_equal(ate.prob[2], ate.prob.ape[2], tolerance = 0.001)
+  expect_equal(ate[1], ate.ape[1], tolerance = 0.015)
+  expect_equal(ate[2], ate.ape[2], tolerance = 0.0015)
+  expect_equal(ate.prob[1], ate.prob.ape[1], tolerance = 0.015)
+  expect_equal(ate.prob[2], ate.prob.ape[2], tolerance = 0.0015)
 
   blp <- best_linear_projection(cs.forest)
   blp.ape <- best_linear_projection(cs.forest.ape)

--- a/r-package/grf/tests/testthat/test_causal_survival_forest.R
+++ b/r-package/grf/tests/testthat/test_causal_survival_forest.R
@@ -1,5 +1,3 @@
-library(grf)
-
 test_that("causal survival forest is well-calibrated", {
   n <- 1000
   p <- 5


### PR DESCRIPTION
The reason CSF was restricted to a binary W was for simplicity, it simplifies nuisance estimation. In principle there is nothing preventing the CSF construction from being applied in the continuous exposure setting, the estimand and interpretation follows from causal forest.

This PR makes no changes to the case when W is binary. When W is continuous an additional survival forest is used to estimate m(x) = E[f(T) | X].