### PR TITLE
Drop CXX_STD in R Makevars

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The current development version can be installed from source using devtools.
 devtools::install_github("grf-labs/grf", subdir = "r-package/grf")
 ```
 
-Note that to install from source, a compiler that implements C++11 is required (clang 3.3 or higher, or g++ 4.8 or higher). If installing on Windows, the RTools toolchain is also required.
+Note that to install from source, a compiler that implements C++11 or later is required (clang 3.3 or higher, or g++ 4.8 or higher). If installing on Windows, the RTools toolchain is also required.
 
 ### Usage Examples
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,8 +54,19 @@ jobs:
     matrix:
       ubuntu:
         imageName: "ubuntu-latest"
-      macos:
+        cppVer: "CXX11"
+      macos_cpp11:
         imageName: "macOS-latest"
+        cppVer: "CXX11"
+      macos_cpp14:
+        imageName: "macOS-latest"
+        cppVer: "CXX14"
+      macos_cpp17:
+        imageName: "macOS-latest"
+        cppVer: "CXX17"
+      macos_cpp20:
+        imageName: "macOS-latest"
+        cppVer: "CXX20"
   pool:
     vmImage: $(imageName)
   variables:
@@ -77,6 +88,10 @@ jobs:
       sudo apt-get install -qq valgrind
     displayName: Setup valgrind
     condition: eq(variables['Agent.OS'], 'Linux')
+  - script: |
+      echo CXX_STD = $(cppVer) >> Makevars
+    workingDirectory: r-package/grf/bindings
+    displayName: Specify CXX_STD in R Makevars
   - script: |
       curl -OLs https://eddelbuettel.github.io/r-ci/run.sh && chmod 0755 run.sh
       ./run.sh bootstrap

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,6 @@ jobs:
     matrix:
       ubuntu:
         imageName: "ubuntu-latest"
-        cppVer: "CXX11"
       macos_cpp11:
         imageName: "macOS-latest"
         cppVer: "CXX11"
@@ -92,6 +91,7 @@ jobs:
       echo CXX_STD = $(cppVer) >> Makevars
     workingDirectory: r-package/grf/bindings
     displayName: Specify CXX_STD in R Makevars
+    condition: ne(variables['Agent.OS'], 'Linux')
   - script: |
       curl -OLs https://eddelbuettel.github.io/r-ci/run.sh && chmod 0755 run.sh
       ./run.sh bootstrap

--- a/r-package/grf/bindings/Makevars
+++ b/r-package/grf/bindings/Makevars
@@ -1,6 +1,3 @@
-## Use c++11
-CXX_STD = CXX11
-
 PKG_CXXFLAGS = -I. -Isrc -DR_BUILD
 
 SOURCES = $(wildcard *.cpp */*.cpp */*/*.cpp */*/*/*.cpp)


### PR DESCRIPTION
Update for latest CRAN
>Result: NOTE
     Specified C++11: please drop specification unless essential

We drop this requirement in src/Makevars, but add extra tests in Azure that make sure grf R runs with all C++ versions up to C++20.

The core/ tests are kept the same as before using CXX_STANDARD 11 in CMakeLists. Can revisit that later, note that the bundled Eigen may need to be updated to make the compiler emit less warnings.