### PR TITLE
Update and standardize URLs across documentation for enhanced reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Development of GRF is supported by the National Institutes of Health, the Nation
 Susan Athey and Stefan Wager.
 <b>Estimating Treatment Effects with Causal Forests: An Application.</b>
 <i>Observational Studies</i>, 5, 2019.
-[<a href="https://obsstudies.org/wp-content/uploads/2019/09/all-papers-compiled.pdf">paper</a>,
+[<a href="https://doi.org/10.1353/obs.2019.0001">paper</a>,
 <a href="https://arxiv.org/abs/1902.07409">arxiv</a>]
 
 Susan Athey, Julie Tibshirani and Stefan Wager.
@@ -165,7 +165,7 @@ Stefan Wager and Susan Athey.
 <b>Estimation and Inference of Heterogeneous Treatment Effects using Random Forests.</b>
 <i>Journal of the American Statistical Association</i>, 113(523), 2018.
 [<a href="https://www.tandfonline.com/eprint/v7p66PsDhHCYiPafTJwC/full">paper</a>,
-<a href="http://arxiv.org/abs/1510.04342">arxiv</a>]
+<a href="https://arxiv.org/abs/1510.04342">arxiv</a>]
 
 Steve Yadlowsky, Scott Fleming, Nigam Shah, Emma Brunskill, and Stefan Wager.
 <b>Evaluating Treatment Prioritization Rules via Rank-Weighted Average Treatment Effects.</b> 2021.

--- a/core/third_party/random/README.md
+++ b/core/third_party/random/README.md
@@ -2,7 +2,7 @@
 
 ## What are these files?
 
-They are copies of `random` and `algorithm` headers from the [llvm](https://github.com/llvm-mirror/libcxx/blob/master/include/) standard library.
+They are copies of `random` and `algorithm` headers from the [llvm](https://github.com/llvm-mirror/libcxx/tree/master/include) standard library.
 
 
 ## Motivation

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -21,7 +21,7 @@ This directory contains replication code for
 Susan Athey and Stefan Wager.
 <b>Estimating Treatment Effects with Causal Forests: An Application.</b>
 <i>Observational Studies</i>, 5, 2019.
-[<a href="https://obsstudies.org/wp-content/uploads/2019/09/all-papers-compiled.pdf">paper</a>,
+[<a href="https://doi.org/10.1353/obs.2019.0001">paper</a>,
 <a href="https://arxiv.org/abs/1902.07409">arxiv</a>]
 
 Susan Athey, Julie Tibshirani and Stefan Wager.
@@ -50,7 +50,7 @@ Stefan Wager and Susan Athey.
 <b>Estimation and Inference of Heterogeneous Treatment Effects using Random Forests.</b>
 <i>Journal of the American Statistical Association</i>, 113(523), 2018.
 [<a href="https://www.tandfonline.com/eprint/v7p66PsDhHCYiPafTJwC/full">paper</a>,
-<a href="http://arxiv.org/abs/1510.04342">arxiv</a>]
+<a href="https://arxiv.org/abs/1510.04342">arxiv</a>]
 
 Steve Yadlowsky, Scott Fleming, Nigam Shah, Emma Brunskill, and Stefan Wager.
 <b>Evaluating Treatment Prioritization Rules via Rank-Weighted Average Treatment Effects.</b> 2021.

--- a/r-package/grf/vignettes/grf_guide.Rmd
+++ b/r-package/grf/vignettes/grf_guide.Rmd
@@ -403,7 +403,7 @@ qini.age
 
 *Some educational resources*
 
-* [Stanford video lectures on machine learning & causal inference](https://youtube.com/playlist?list=PLxq_lXOUlvQAoWZEqhRqHNezS30lI49G-)
+* [Stanford video lectures on machine learning & causal inference](https://www.youtube.com/playlist?list=PLxq_lXOUlvQAoWZEqhRqHNezS30lI49G-)
 
 * [Online seminar on estimating heterogeneous treatment effects in R](https://youtu.be/YBbnCDRCcAI)
 

--- a/r-package/grf/vignettes/rate.Rmd
+++ b/r-package/grf/vignettes/rate.Rmd
@@ -140,7 +140,7 @@ This hypothesis has a testable implication implied by the previous section: if t
 
 3) If both populations exhibit similar HTEs, then a powerful CATE estimator should yield a positive and significant RATE estimate.
 
-For the purpose of this vignette example we'll not analyse the original SPRINT/ACCORD data, but rather a *smaller simulated* example, stored in the [GRF repository](https://github.com/grf-labs/grf/blob/master/r-package/grf/vignettes/data/). For details on the simulator see the [paper repository](https://github.com/som-shahlab/RATE-experiments/).
+For the purpose of this vignette example we'll not analyse the original SPRINT/ACCORD data, but rather a *smaller simulated* example, stored in the [GRF repository](https://github.com/grf-labs/grf/tree/master/r-package/grf/vignettes/data). For details on the simulator see the [paper repository](https://github.com/som-shahlab/RATE-experiments/).
 
 The outcome data in this trial is *right-censored*, so we cannot use any ordinary "out-of-the-box" CATE estimator to estimate treatment effects, rather, we need one that takes censoring into account. For this reason we use GRF's `causal_survival_forest` (and refer to the [documentation](https://grf-labs.github.io/grf/reference/causal_survival_forest.html) for details). Below is an illustration of the simulated trial data.
 

--- a/releases/CHANGELOG.md
+++ b/releases/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 All notable changes to `grf` will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.3.0] - 2023-05-10
 


### PR DESCRIPTION
This PR provides necessary updates to URL references across the repository's documentation (`.md`, `.Rmd` files) for enhanced reliability and standardization. It primarily targets broken links and links that have been moved, replacing them with accurate, secure, and more stable URL references.

Details of the changes are as follows:

- ATW19 paper link update: The old link to this paper, which used an obsolete domain name, has been replaced with its permanent DOI link. The previous URL now redirects to an irrelevant site, thus this update ensures that users are directed to the correct resource.
- HTTP to HTTPS Updates: Several links that were previously using the HTTP protocol have been updated to HTTPS. While these links were being auto-redirected, this change ensures better security and performance by reducing the redirection.
- GitHub directory link updates: Links directing to GitHub directories have been updated from `blob` to `tree`. The previous `blob` links were auto-redirected to `tree` links. This change reduces the unnecessary redirection and ensures a more direct access.
- YouTube video list link Updates: A YouTube video list link was missing the `www` prefix. While the old link was auto-redirected to the `www` version, this update makes the URL reference more standard and eliminates unnecessary redirection.

These changes aim to improve the overall user experience and reliability of the documentation by ensuring all links direct to their intended destinations without unnecessary redirects, thereby preventing possible confusion or misinformation.

The URLs updated were [identified by urlchecker](https://nanx.me/blog/post/rmarkdown-quarto-link-checker/), which is a tool primarily used for checking link issues within R packages using the stringent CRAN standard.