### PR TITLE
Add performance note to SurvivalPredictionStrategy.h

### DIFF
--- a/core/src/prediction/SurvivalPredictionStrategy.h
+++ b/core/src/prediction/SurvivalPredictionStrategy.h
@@ -42,6 +42,13 @@ public:
    * The event times retrieved from data.get_outcome(sample) will always be
    * integers in the range 0, ..., num_failures.
    *
+   * Note: The reason we don't use OptimizedPredictionStrategy for survival
+   * curves is that it may require a large memory footprint in the form of
+   * storing sufficient statistics with a size equal to the length of the
+   * survival curve. DefaultPredictionStrategy requires less memory. A 
+   * drawback is, particularly in the case of shallow trees (as will be
+   * the case with very few events), more CPU time spent in hash table
+   * lookups, as a target sample x will match many training samples.
    */
   SurvivalPredictionStrategy(size_t num_failures,
                              int prediction_type);


### PR DESCRIPTION
Adding a note for future consideration: one reason Causal Survival Forest can be time consuming on large data is fitting (predicting) survival and censoring curves.

A big time chunk is spent in predicting the survival curves via the DefaultPredictionStrategy. We were aware of this when making it, just documenting it here in case we wish to revisit it in the future, it would be possible to speed up CSF by

- having survival forest use OptimizedPredictionStrategy at a higher memory cost
- have survival forest use some hash table other than the std library that is optimized for dense data