### PR TITLE
Enhance input validation for sample weights

### DIFF
--- a/r-package/grf/R/input_utilities.R
+++ b/r-package/grf/R/input_utilities.R
@@ -174,8 +174,8 @@ validate_sample_weights <- function(sample.weights, X) {
     if (length(sample.weights) != nrow(X)) {
       stop("sample.weights has incorrect length")
     }
-    if (any(sample.weights < 0)) {
-      stop("sample.weights must be nonnegative")
+    if (anyNA(sample.weights) || any(sample.weights < 0) || any(is.infinite(sample.weights))) {
+      stop("sample.weights must be nonnegative and without missing values")
     }
   }
 }


### PR DESCRIPTION
Accidentally passing sample weights with missing entries or for example 1 / 0 (as could happen if estimating inverse weights with kaplan-meier, which may yield estimates exactly = 0) went through previously. Adding a more stringent input check to prevent this - as this could be a rare occurrence when passing estimated weights to grf.