### PR TITLE
Remove appendix from maq vignette

### DIFF
--- a/r-package/grf/vignettes/maq.Rmd
+++ b/r-package/grf/vignettes/maq.Rmd
@@ -274,14 +274,3 @@ Yadlowsky, Steve, Scott Fleming, Nigam Shah, Emma Brunskill, and Stefan Wager. E
 [^f]: Note that at most one unit will have a non-integer entry in this row matrix. If the particular budget is not enough to give the final $i$-th unit a treatment, then this unit will either have a single fractional entry, or two fractional entries, depending on whether the unit is being assigned an initial arm or upgraded to a costlier arm. These fractions can be interpreted as a probability of arm assignment.
 
 [^h]: With many treatment arms, this “baseline” arm allocation is going to trace out the upper left convex hull on the average cost and ATE plane, where the y-axis is the arm ATEs and the x-axis is the average arm costs.
-
-## Appendix: Note on AUC terminology
-We call the area under the TOC curve a RATE metric, as it can be represented as a *rank-weighted* ATE. The area under the TOC curve ("AUTOC") can be expressed as an ATE with weights equal to the term in $\color{red}{()}$:
-$$
-\text{AUTOC} = E\big[\color{red}{\big(-\log[1 - F(\hat \tau(X_i))] - 1\big)} (Y_i(1) - Y_i(0))\big],
-$$
-where $F(\cdot)$ is the distribution function. That is, the AUTOC strongly upweights treatment effects for the first units prioritized by the estimates $\hat \tau(X_i)$. Another appealing weighting method is to weight each unit's estimated treatment effect symmetrically. This looks like the following:
-$$
-E\big[\color{red}{\big(F(\hat \tau(X_i)) - 1 \big)} (Y_i(1) - Y_i(0))\big].
-$$
-For historical reasons, we refer to this RATE metric as the "QINI". These two weighting methods have different statistical properties. The AUTOC can yield better power in tests for treatment effect heterogeneity when a small subset of the population exhibits HTEs, while the QINI can yield better power when the HTEs are more diffuse across the population. For more details see Yadlowsky et al. (2021).


### PR DESCRIPTION
It's easier to just drop this note, makes it easier to read.