### PR TITLE
Add grf logo/swag info to GitHub

### DIFF
--- a/images/logo/README.md
+++ b/images/logo/README.md
@@ -1,12 +1,12 @@
 # GRF Logos
 
-The GRF logo, leaf, and vertical leaf in Scalable Vector Graphics (SVG) format:
+The GRF logo, leaf, and vertical leaf in Scalable Vector Graphics (**SVG**) format:
 
 <p><img src='https://raw.githubusercontent.com/grf-labs/grf/master/images/logo/grf_logo.svg' height="120" /></p>
 <p><img src='https://raw.githubusercontent.com/grf-labs/grf/master/images/logo/grf_leaf.svg' height="120" /></p>
 <p><img src='https://raw.githubusercontent.com/grf-labs/grf/master/images/logo/grf_leaf_vertical.svg' height="120" /></p>
 
-The GRF logo with a white background, and in forest green (HEX code #195E54), in PNG:
+The GRF logo with a white background, and in forest green (HEX code _#195E54_), in **PNG**:
 
 <p><img src='https://raw.githubusercontent.com/grf-labs/grf/master/images/logo/grf_logo_wbg_cropped.png' height="120" /></p>
 <p><img src='https://raw.githubusercontent.com/grf-labs/grf/master/images/logo/grf_logo_green.png' height="120" /></p>

--- a/images/logo/README.md
+++ b/images/logo/README.md
@@ -1,0 +1,29 @@
+# GRF Logos
+
+The GRF logo, leaf, and vertical leaf in Scalable Vector Graphics (SVG) format:
+
+<p><img src='https://raw.githubusercontent.com/grf-labs/grf/master/images/logo/grf_logo.svg' height="120" /></p>
+<p><img src='https://raw.githubusercontent.com/grf-labs/grf/master/images/logo/grf_leaf.svg' height="120" /></p>
+<p><img src='https://raw.githubusercontent.com/grf-labs/grf/master/images/logo/grf_leaf_vertical.svg' height="120" /></p>
+
+The GRF logo with a white background, and in forest green (HEX code #195E54), in PNG:
+
+<p><img src='https://raw.githubusercontent.com/grf-labs/grf/master/images/logo/grf_logo_wbg_cropped.png' height="120" /></p>
+<p><img src='https://raw.githubusercontent.com/grf-labs/grf/master/images/logo/grf_logo_green.png' height="120" /></p>
+<p><img src='https://raw.githubusercontent.com/grf-labs/grf/master/images/logo/grf_leaf_green.png' height="120" /></p>
+
+## GRF Swag
+
+**Stickers**:
+
+* [Main logo](https://www.zazzle.com/z/atwmynaw)
+* [Main logo (green)](https://www.zazzle.com/z/53j7d2y1)
+* [Leaf](https://www.zazzle.com/z/exa5ynyz)
+* [Leaf (green)](https://www.zazzle.com/z/f5eagrgn)
+
+**Mug/coffee cup** ☕
+* [GRF mug](https://www.zazzle.com/z/a3cmanu3)
+
+**T-shirt** 👕
+* [Men's](https://www.zazzle.com/z/pisi5kym)
+* [Women's](https://www.zazzle.com/z/axt98ip9)


### PR DESCRIPTION
Consolidating some information that we previously kept on Quip.