### PR TITLE
Check for non-zero dims in feature matrix

### DIFF
--- a/r-package/grf/R/input_utilities.R
+++ b/r-package/grf/R/input_utilities.R
@@ -7,6 +7,9 @@ validate_X <- function(X, allow.na = FALSE) {
       "`matrix`, `data.frame`"
     ))
   }
+  if (any(0 %in% dim(X))) {
+    stop("Feature matrix X must have non-zero dimensions.")
+  }
 
   if (!is.numeric(as.matrix(X))) {
     stop(paste(


### PR DESCRIPTION
This is just to provide more informative feedback in case of accidentally indexing with an empty set in the feature matrix.

```R
n <- 500
p <- 5
X <- matrix(rnorm(n * p), n, p)
W <- rbinom(n, 1, 0.5)
Y <- pmax(X[, 1], 0) * W + X[, 2] + pmin(X[, 3], 0) + rnorm(n)

cf <- causal_forest(X[, 0], Y, W)

print(cf)
Error in raw[, feature.indices, drop = FALSE] : subscript out of bounds

predict(cf, X[, 0)
segfault
```