### PR TITLE
Relax sample size requirement in boot_grf

### DIFF
--- a/r-package/grf/R/rank_average_treatment.R
+++ b/r-package/grf/R/rank_average_treatment.R
@@ -532,7 +532,7 @@ estimate_rate <- function(data, indices, q, wtd.mean) {
 boot_grf <- function(data, statistic, R, clusters, half.sample = TRUE, ...) {
   samples.by.cluster <- split(seq_along(clusters), clusters)
   n <- length(samples.by.cluster) # number of clusters
-  if (n <= 1 || (half.sample && floor(n / 2) <= 1)) {
+  if (n <= 1 || (half.sample && floor(n / 2) < 1)) {
     stop("Cannot bootstrap sample with only one effective unit.")
   }
   if (half.sample) {


### PR DESCRIPTION
Relaxing this effective sample size check to allow as few as n = 2 clusters, which is consistent with average_treatment_effect.