### PR TITLE
Update CMake minimum to 3.5

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(grf)
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 ## ======================================================================================##
 ## Compiler flags


### PR DESCRIPTION
From the [azure build](https://dev.azure.com/grf-labs/grf/_build/results?buildId=2457&view=logs&j=4ca8cba6-7183-564e-ab5e-f9751ebd5d9f&t=89a15387-052c-5742-0e51-6ee512ec3a14)

>CMake Deprecation Warning at CMakeLists.txt:2 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.
>
>Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.