### PR TITLE
Add `seed` note on `num.threads` cross-platform dependency

### DIFF
--- a/r-package/grf/DESCRIPTION
+++ b/r-package/grf/DESCRIPTION
@@ -29,7 +29,7 @@ Imports:
     methods,
     Rcpp (>= 0.12.15),
     sandwich (>= 2.4-0)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 Suggests:
     DiagrammeR,
     MASS,

--- a/r-package/grf/R/causal_forest.R
+++ b/r-package/grf/R/causal_forest.R
@@ -74,7 +74,8 @@
 #' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed. Default is TRUE.
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency.
-#' @param seed The seed of the C++ random number generator.
+#' @param seed The seed of the C++ random number generator. \emph{Note}: For consistent results across
+#'  different platforms, ensure the `num.threads` argument is set to the same value.
 #'
 #' @return A trained causal forest object. If tune.parameters is enabled,
 #'  then tuning information will be included through the `tuning.output` attribute.

--- a/r-package/grf/R/causal_survival_forest.R
+++ b/r-package/grf/R/causal_survival_forest.R
@@ -89,7 +89,8 @@
 #' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed. Default is TRUE.
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency.
-#' @param seed The seed of the C++ random number generator.
+#' @param seed The seed of the C++ random number generator. \emph{Note}: For consistent results across
+#'  different platforms, ensure the `num.threads` argument is set to the same value.
 #'
 #' @return A trained causal_survival_forest forest object.
 #'

--- a/r-package/grf/R/instrumental_forest.R
+++ b/r-package/grf/R/instrumental_forest.R
@@ -75,7 +75,8 @@
 #' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed. Default is TRUE.
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency.
-#' @param seed The seed of the C++ random number generator.
+#' @param seed The seed of the C++ random number generator. \emph{Note}: For consistent results across
+#'  different platforms, ensure the `num.threads` argument is set to the same value.
 #'
 #' @return A trained instrumental forest object.
 #'

--- a/r-package/grf/R/ll_regression_forest.R
+++ b/r-package/grf/R/ll_regression_forest.R
@@ -60,7 +60,8 @@
 #'                          to select the optimal parameters. Default is 1000.
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency.
-#' @param seed The seed of the C++ random number generator.
+#' @param seed The seed of the C++ random number generator. \emph{Note}: For consistent results across
+#'  different platforms, ensure the `num.threads` argument is set to the same value.
 #'
 #' @return A trained local linear forest object.
 #'

--- a/r-package/grf/R/multi_arm_causal_forest.R
+++ b/r-package/grf/R/multi_arm_causal_forest.R
@@ -97,7 +97,8 @@
 #' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed. Default is TRUE.
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency.
-#' @param seed The seed of the C++ random number generator.
+#' @param seed The seed of the C++ random number generator. \emph{Note}: For consistent results across
+#'  different platforms, ensure the `num.threads` argument is set to the same value.
 #'
 #' @return A trained multi arm causal forest object.
 #'

--- a/r-package/grf/R/multi_regression_forest.R
+++ b/r-package/grf/R/multi_regression_forest.R
@@ -45,7 +45,8 @@
 #' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed. Default is TRUE.
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency.
-#' @param seed The seed of the C++ random number generator.
+#' @param seed The seed of the C++ random number generator. \emph{Note}: For consistent results across
+#'  different platforms, ensure the `num.threads` argument is set to the same value.
 #'
 #' @return A trained multi regression forest object.
 #'

--- a/r-package/grf/R/probability_forest.R
+++ b/r-package/grf/R/probability_forest.R
@@ -46,7 +46,8 @@
 #' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed. Default is TRUE.
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency.
-#' @param seed The seed of the C++ random number generator.
+#' @param seed The seed of the C++ random number generator. \emph{Note}: For consistent results across
+#'  different platforms, ensure the `num.threads` argument is set to the same value.
 #'
 #' @return A trained probability forest object.
 #'

--- a/r-package/grf/R/quantile_forest.R
+++ b/r-package/grf/R/quantile_forest.R
@@ -46,7 +46,8 @@
 #' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed. Default is FALSE.
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency.
-#' @param seed The seed of the C++ random number generator.
+#' @param seed The seed of the C++ random number generator. \emph{Note}: For consistent results across
+#'  different platforms, ensure the `num.threads` argument is set to the same value.
 #'
 #' @return A trained quantile forest object.
 #'

--- a/r-package/grf/R/regression_forest.R
+++ b/r-package/grf/R/regression_forest.R
@@ -57,7 +57,8 @@
 #' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed. Default is TRUE.
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency.
-#' @param seed The seed of the C++ random number generator.
+#' @param seed The seed of the C++ random number generator. \emph{Note}: For consistent results across
+#'  different platforms, ensure the `num.threads` argument is set to the same value.
 #'
 #' @return A trained regression forest object. If tune.parameters is enabled,
 #'  then tuning information will be included through the `tuning.output` attribute.

--- a/r-package/grf/R/survival_forest.R
+++ b/r-package/grf/R/survival_forest.R
@@ -52,7 +52,8 @@
 #' Only relevant if `compute.oob.predictions` is TRUE. Default is "Kaplan-Meier".
 #' @param num.threads Number of threads used in training. By default, the number of threads is set
 #'                    to the maximum hardware concurrency.
-#' @param seed The seed of the C++ random number generator.
+#' @param seed The seed of the C++ random number generator. \emph{Note}: For consistent results across
+#'  different platforms, ensure the `num.threads` argument is set to the same value.
 #'
 #' @return A trained survival_forest forest object.
 #'

--- a/r-package/grf/man/causal_forest.Rd
+++ b/r-package/grf/man/causal_forest.Rd
@@ -124,7 +124,8 @@ to select the optimal parameters. Default is 1000.}
 \item{num.threads}{Number of threads used in training. By default, the number of threads is set
 to the maximum hardware concurrency.}
 
-\item{seed}{The seed of the C++ random number generator.}
+\item{seed}{The seed of the C++ random number generator. \emph{Note}: For consistent results across
+different platforms, ensure the `num.threads` argument is set to the same value.}
 }
 \value{
 A trained causal forest object. If tune.parameters is enabled,

--- a/r-package/grf/man/causal_survival_forest.Rd
+++ b/r-package/grf/man/causal_survival_forest.Rd
@@ -135,7 +135,8 @@ Default is "none" (no parameters are tuned).}
 \item{num.threads}{Number of threads used in training. By default, the number of threads is set
 to the maximum hardware concurrency.}
 
-\item{seed}{The seed of the C++ random number generator.}
+\item{seed}{The seed of the C++ random number generator. \emph{Note}: For consistent results across
+different platforms, ensure the `num.threads` argument is set to the same value.}
 }
 \value{
 A trained causal_survival_forest forest object.

--- a/r-package/grf/man/instrumental_forest.Rd
+++ b/r-package/grf/man/instrumental_forest.Rd
@@ -133,7 +133,8 @@ to select the optimal parameters. Default is 1000.}
 \item{num.threads}{Number of threads used in training. By default, the number of threads is set
 to the maximum hardware concurrency.}
 
-\item{seed}{The seed of the C++ random number generator.}
+\item{seed}{The seed of the C++ random number generator. \emph{Note}: For consistent results across
+different platforms, ensure the `num.threads` argument is set to the same value.}
 }
 \value{
 A trained instrumental forest object.

--- a/r-package/grf/man/ll_regression_forest.Rd
+++ b/r-package/grf/man/ll_regression_forest.Rd
@@ -114,7 +114,8 @@ to select the optimal parameters. Default is 1000.}
 \item{num.threads}{Number of threads used in training. By default, the number of threads is set
 to the maximum hardware concurrency.}
 
-\item{seed}{The seed of the C++ random number generator.}
+\item{seed}{The seed of the C++ random number generator. \emph{Note}: For consistent results across
+different platforms, ensure the `num.threads` argument is set to the same value.}
 }
 \value{
 A trained local linear forest object.

--- a/r-package/grf/man/multi_arm_causal_forest.Rd
+++ b/r-package/grf/man/multi_arm_causal_forest.Rd
@@ -112,7 +112,8 @@ currently only supported for univariate outcomes Y).}
 \item{num.threads}{Number of threads used in training. By default, the number of threads is set
 to the maximum hardware concurrency.}
 
-\item{seed}{The seed of the C++ random number generator.}
+\item{seed}{The seed of the C++ random number generator. \emph{Note}: For consistent results across
+different platforms, ensure the `num.threads` argument is set to the same value.}
 }
 \value{
 A trained multi arm causal forest object.

--- a/r-package/grf/man/multi_regression_forest.Rd
+++ b/r-package/grf/man/multi_regression_forest.Rd
@@ -83,7 +83,8 @@ Only applies if honesty is enabled. Default is TRUE.}
 \item{num.threads}{Number of threads used in training. By default, the number of threads is set
 to the maximum hardware concurrency.}
 
-\item{seed}{The seed of the C++ random number generator.}
+\item{seed}{The seed of the C++ random number generator. \emph{Note}: For consistent results across
+different platforms, ensure the `num.threads` argument is set to the same value.}
 }
 \value{
 A trained multi regression forest object.

--- a/r-package/grf/man/probability_forest.Rd
+++ b/r-package/grf/man/probability_forest.Rd
@@ -86,7 +86,8 @@ be at least 2. Default is 2.}
 \item{num.threads}{Number of threads used in training. By default, the number of threads is set
 to the maximum hardware concurrency.}
 
-\item{seed}{The seed of the C++ random number generator.}
+\item{seed}{The seed of the C++ random number generator. \emph{Note}: For consistent results across
+different platforms, ensure the `num.threads` argument is set to the same value.}
 }
 \value{
 A trained probability forest object.

--- a/r-package/grf/man/quantile_forest.Rd
+++ b/r-package/grf/man/quantile_forest.Rd
@@ -86,7 +86,8 @@ Only applies if honesty is enabled. Default is TRUE.}
 \item{num.threads}{Number of threads used in training. By default, the number of threads is set
 to the maximum hardware concurrency.}
 
-\item{seed}{The seed of the C++ random number generator.}
+\item{seed}{The seed of the C++ random number generator. \emph{Note}: For consistent results across
+different platforms, ensure the `num.threads` argument is set to the same value.}
 }
 \value{
 A trained quantile forest object.

--- a/r-package/grf/man/regression_forest.Rd
+++ b/r-package/grf/man/regression_forest.Rd
@@ -105,7 +105,8 @@ to select the optimal parameters. Default is 1000.}
 \item{num.threads}{Number of threads used in training. By default, the number of threads is set
 to the maximum hardware concurrency.}
 
-\item{seed}{The seed of the C++ random number generator.}
+\item{seed}{The seed of the C++ random number generator. \emph{Note}: For consistent results across
+different platforms, ensure the `num.threads` argument is set to the same value.}
 }
 \value{
 A trained regression forest object. If tune.parameters is enabled,

--- a/r-package/grf/man/survival_forest.Rd
+++ b/r-package/grf/man/survival_forest.Rd
@@ -94,7 +94,8 @@ Only relevant if `compute.oob.predictions` is TRUE. Default is "Kaplan-Meier".}
 \item{num.threads}{Number of threads used in training. By default, the number of threads is set
 to the maximum hardware concurrency.}
 
-\item{seed}{The seed of the C++ random number generator.}
+\item{seed}{The seed of the C++ random number generator. \emph{Note}: For consistent results across
+different platforms, ensure the `num.threads` argument is set to the same value.}
 }
 \value{
 A trained survival_forest forest object.


### PR DESCRIPTION
See #1368. 