### PR TITLE
Update DefaultPredictionStrategy docstring

### DIFF
--- a/core/src/prediction/DefaultPredictionStrategy.h
+++ b/core/src/prediction/DefaultPredictionStrategy.h
@@ -50,7 +50,7 @@ public:
    * Computes a prediction for a single test sample.
    *
    * sample: the ID of the test sample.
-   * weights_by_sample: a map from neighboring sample ID, to a weight specifying
+   * weights_by_sample: a collection of neighboring sample IDs and weights specifying
    *     how often the sample appeared in the same leaf as the test sample. Note that
    *     these weights are normalized and will sum to 1.
    * train_data: the training data matrix.
@@ -68,7 +68,7 @@ public:
    * sample: the ID of the test sample.
    * samples_by_tree: vector of samples in the same leaf as the test point,
    *    for each tree
-   * weights_by_sampleID: a map from neighboring sample ID, to a weight specifying
+   * weights_by_sampleID: a collection of neighboring sample IDs and weights specifying
    *     how often the sample appeared in the same leaf as the test sample. Note that
    *     these weights are normalized and will sum to 1.
    * train_data: the training data matrix.


### PR DESCRIPTION
After #1531 this is not a map, but a simple pair. Just making the docstring clear for posterity. Note that no typical use cases requires random access of sample to weight, so a simple collection of vectors is perfectly fine.